### PR TITLE
Add echo cancellation interface for full-duplex barge-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ML inference is **not** in this library. Consumers implement the abstract interf
                     │   LLMInterface            │  Abstract language model
                     │   VADInterface            │  Abstract voice activity detection
                     │   EnhancerInterface       │  Abstract speech enhancement
+                    │   EchoCancellerInterface  │  Abstract echo cancellation (AEC)
                     │                           │
                     └───────────────────────────┘
 ```

--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -195,6 +195,23 @@ Event types: `SC_EVENT_SESSION_CREATED`, `SC_EVENT_SPEECH_STARTED`, `SC_EVENT_SP
 
 All pointers in `sc_event_t` are valid only during the callback. Copy if needed.
 
+### Echo cancellation
+
+`sc_pipeline_set_echo_canceller()` sets an optional echo canceller that runs before enhancement and VAD on every `push_audio()`. TTS output is automatically fed as far-end reference during synthesis.
+
+```c
+sc_echo_canceller_vtable_t aec = {
+    .context = my_aec_state,
+    .feed_reference = my_feed_reference_fn,   // called with TTS chunks
+    .cancel_echo = my_cancel_echo_fn,         // called on mic input
+    .input_sample_rate = my_aec_sample_rate_fn,
+    .reset = my_aec_reset_fn
+};
+sc_pipeline_set_echo_canceller(pipeline, aec);
+```
+
+Processing chain: `mic → AEC → enhance → VAD → STT`. Implementations can use SpeexDSP, WebRTC AEC, or platform-native echo cancellation.
+
 ## Null safety
 
 All API functions handle `NULL` pipeline gracefully — they are no-ops. `sc_pipeline_state(NULL)` returns `SC_STATE_IDLE`, `sc_pipeline_is_running(NULL)` returns `false`. `sc_pipeline_clear_tools(NULL)` and `sc_pipeline_load_tools_json(NULL, ...)` are safe no-ops.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -9,10 +9,14 @@ The `VoicePipeline` is the central orchestrator. It connects STT, TTS, LLM, and 
 Full voice agent loop:
 
 ```
-audio → VAD → STT → [tools?] → LLM → TTS → audio
+audio → [AEC] → [enhance] → VAD → STT → [tools?] → LLM → TTS → audio
+                                                              │
+                                                              └──► AEC reference
 ```
 
-1. VAD detects user speech via `TurnDetector`
+1. Optional echo cancellation removes TTS playback from mic signal
+2. Optional speech enhancement (denoising) runs on the clean signal
+3. VAD detects user speech via `TurnDetector`
 2. On speech end, the buffered audio is sent to `STTInterface.transcribe()`
 3. Transcript + conversation history are sent to `LLMInterface.chat()`
 4. If the LLM returns tool calls, the pipeline executes them, injects results, and calls the LLM again

--- a/include/speech_core/interfaces.h
+++ b/include/speech_core/interfaces.h
@@ -195,4 +195,44 @@ public:
     virtual int input_sample_rate() const = 0;
 };
 
+// ---------------------------------------------------------------------------
+// Echo Cancellation
+// ---------------------------------------------------------------------------
+
+/// Acoustic echo cancellation interface.
+///
+/// The pipeline feeds TTS output as far-end reference via feed_reference(),
+/// then runs cancel_echo() on mic input before VAD:
+///
+///   TTS output ──► feed_reference()
+///   Mic input  ──► cancel_echo() ──► clean signal ──► enhance ──► VAD ──► STT
+///
+/// Implementations may use SpeexDSP, WebRTC AEC, or platform-native AEC.
+/// The interface is intentionally simple — frame alignment, sample rate
+/// conversion, and internal buffering are the implementation's responsibility.
+class EchoCancellerInterface {
+public:
+    virtual ~EchoCancellerInterface() = default;
+
+    /// Feed far-end (TTS playback) reference samples.
+    /// Called from the TTS synthesis callback on the worker thread.
+    /// Thread-safe: may be called concurrently with cancel_echo().
+    /// @param samples  PCM Float32 at input_sample_rate()
+    /// @param length   Number of samples
+    virtual void feed_reference(const float* samples, size_t length) = 0;
+
+    /// Remove echo from near-end (mic) audio.
+    /// Called from push_audio() on the audio thread.
+    /// @param input   Mic input PCM Float32
+    /// @param length  Number of samples
+    /// @param output  Pre-allocated output buffer (same length)
+    virtual void cancel_echo(const float* input, size_t length, float* output) = 0;
+
+    /// Expected sample rate in Hz (must match both mic and reference).
+    virtual int input_sample_rate() const = 0;
+
+    /// Reset internal state (e.g. on pipeline start/stop).
+    virtual void reset() = 0;
+};
+
 }  // namespace speech_core

--- a/include/speech_core/pipeline/voice_pipeline.h
+++ b/include/speech_core/pipeline/voice_pipeline.h
@@ -95,6 +95,11 @@ public:
     /// Must be called before start(). Pass nullptr to disable.
     void set_enhancer(EnhancerInterface* enhancer) { enhancer_ = enhancer; }
 
+    /// Set an optional echo canceller (runs before enhancer/VAD in push_audio).
+    /// TTS output is automatically fed as reference during synthesis.
+    /// Must be called before start(). Pass nullptr to disable.
+    void set_echo_canceller(EchoCancellerInterface* aec) { echo_canceller_ = aec; }
+
     /// Access the tool registry for adding tools.
     ToolRegistry& tool_registry() { return tool_registry_; }
 
@@ -106,6 +111,7 @@ private:
     TTSInterface& tts_;
     LLMInterface* llm_;
     EnhancerInterface* enhancer_;
+    EchoCancellerInterface* echo_canceller_ = nullptr;
     AgentConfig config_;
     EventCallback on_event_;
 
@@ -120,6 +126,7 @@ private:
     std::atomic<bool> running_{false};
     mutable std::mutex mutex_;  // protects turn_detector_ and push_audio
     std::vector<float> enhance_buf_;  // reusable buffer for enhancement output
+    std::vector<float> aec_buf_;      // reusable buffer for echo cancellation output
 
     // Worker thread for STT/LLM/TTS — keeps push_audio non-blocking
     struct PendingUtterance {

--- a/include/speech_core/speech_core_c.h
+++ b/include/speech_core/speech_core_c.h
@@ -122,6 +122,15 @@ typedef struct {
     int (*input_sample_rate)(void* ctx);
 } sc_enhancer_vtable_t;
 
+typedef struct {
+    void* context;
+    void (*feed_reference)(void* ctx, const float* samples, size_t length);
+    void (*cancel_echo)(void* ctx, const float* input, size_t length,
+                        float* output);
+    int (*input_sample_rate)(void* ctx);
+    void (*reset)(void* ctx);
+} sc_echo_canceller_vtable_t;
+
 // ---------------------------------------------------------------------------
 // Tool definition (callback-based, no popen)
 // ---------------------------------------------------------------------------
@@ -249,6 +258,12 @@ bool sc_pipeline_is_running(sc_pipeline_t pipeline);
 /// Must be called before sc_pipeline_start(). Pass NULL to disable.
 void sc_pipeline_set_enhancer(sc_pipeline_t pipeline,
                                sc_enhancer_vtable_t enhancer);
+
+/// Set an optional echo canceller (runs before enhancer/VAD on every push_audio).
+/// TTS output is automatically fed as far-end reference during synthesis.
+/// Must be called before sc_pipeline_start().
+void sc_pipeline_set_echo_canceller(sc_pipeline_t pipeline,
+                                     sc_echo_canceller_vtable_t aec);
 
 /// Register a tool with platform callback handler.
 /// Must be called before sc_pipeline_start().

--- a/src/pipeline/voice_pipeline.cpp
+++ b/src/pipeline/voice_pipeline.cpp
@@ -36,6 +36,7 @@ void VoicePipeline::start() {
         std::lock_guard<std::mutex> lock(mutex_);
         running_.store(true);
         state_.store(State::Idle);
+        if (echo_canceller_) echo_canceller_->reset();
     }
     worker_thread_ = std::thread(&VoicePipeline::worker_loop, this);
 }
@@ -77,14 +78,24 @@ void VoicePipeline::push_audio(const float* samples, size_t count) {
     if (!running_.load()) return;
     std::lock_guard<std::mutex> lock(mutex_);
 
+    const float* audio = samples;
+
+    // Echo cancellation (if set) — removes TTS playback from mic signal
+    if (echo_canceller_ && count > 0) {
+        aec_buf_.resize(count);
+        echo_canceller_->cancel_echo(audio, count, aec_buf_.data());
+        audio = aec_buf_.data();
+    }
+
+    // Speech enhancement (if set) — denoising after AEC
     if (enhancer_ && count > 0) {
         enhance_buf_.resize(count);
-        enhancer_->enhance(samples, count, enhancer_->input_sample_rate(),
+        enhancer_->enhance(audio, count, enhancer_->input_sample_rate(),
                            enhance_buf_.data());
-        turn_detector_.push_audio(enhance_buf_.data(), count);
-    } else {
-        turn_detector_.push_audio(samples, count);
+        audio = enhance_buf_.data();
     }
+
+    turn_detector_.push_audio(audio, count);
 }
 
 void VoicePipeline::worker_loop() {
@@ -487,6 +498,11 @@ void VoicePipeline::speak(const std::string& text, const std::string& language,
                 total_samples += emit_length;
 
                 if (emit_length > 0) {
+                    // Feed TTS audio as far-end reference for echo cancellation
+                    if (echo_canceller_) {
+                        echo_canceller_->feed_reference(samples, emit_length);
+                    }
+
                     auto pcm = PCMCodec::float_to_pcm16(samples, emit_length);
                     PipelineEvent audio_event;
                     audio_event.type = EventType::ResponseAudioDelta;

--- a/src/speech_core_c.cpp
+++ b/src/speech_core_c.cpp
@@ -165,6 +165,28 @@ public:
     }
 };
 
+class CEchoCancellerAdapter : public EchoCancellerInterface {
+    sc_echo_canceller_vtable_t vt_;
+public:
+    explicit CEchoCancellerAdapter(sc_echo_canceller_vtable_t vt) : vt_(vt) {}
+
+    void feed_reference(const float* samples, size_t length) override {
+        vt_.feed_reference(vt_.context, samples, length);
+    }
+
+    void cancel_echo(const float* input, size_t length, float* output) override {
+        vt_.cancel_echo(vt_.context, input, length, output);
+    }
+
+    int input_sample_rate() const override {
+        return vt_.input_sample_rate(vt_.context);
+    }
+
+    void reset() override {
+        if (vt_.reset) vt_.reset(vt_.context);
+    }
+};
+
 // ---------------------------------------------------------------------------
 // Pipeline handle
 // ---------------------------------------------------------------------------
@@ -175,6 +197,7 @@ struct sc_pipeline_s {
     std::unique_ptr<CLLMAdapter> llm;
     std::unique_ptr<CVADAdapter> vad;
     std::unique_ptr<CEnhancerAdapter> enhancer;
+    std::unique_ptr<CEchoCancellerAdapter> echo_canceller;
     std::unique_ptr<VoicePipeline> pipeline;
     sc_event_fn event_fn;
     void* event_context;
@@ -352,6 +375,13 @@ void sc_pipeline_set_enhancer(sc_pipeline_t pipeline,
     if (!pipeline) return;
     pipeline->enhancer = std::make_unique<CEnhancerAdapter>(enhancer);
     pipeline->pipeline->set_enhancer(pipeline->enhancer.get());
+}
+
+void sc_pipeline_set_echo_canceller(sc_pipeline_t pipeline,
+                                     sc_echo_canceller_vtable_t aec) {
+    if (!pipeline) return;
+    pipeline->echo_canceller = std::make_unique<CEchoCancellerAdapter>(aec);
+    pipeline->pipeline->set_echo_canceller(pipeline->echo_canceller.get());
 }
 
 void sc_pipeline_add_tool(sc_pipeline_t pipeline, sc_tool_definition_t tool) {

--- a/tests/test_pipeline_e2e.cpp
+++ b/tests/test_pipeline_e2e.cpp
@@ -2572,6 +2572,166 @@ void test_echo_cancellation() {
     printf("  PASS: echo_cancellation\n");
 }
 
+void test_echo_cancellation_with_enhancer() {
+    // Both AEC and enhancer set — verify processing order: AEC → enhance → VAD
+    MockSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    vad.probs = {
+        0.0f,
+        0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f,
+        0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f
+    };
+
+    // AEC that scales by 0.5
+    class OrderAEC : public EchoCancellerInterface {
+    public:
+        std::atomic<int> call_order{0};
+        int* counter;
+        OrderAEC(int* c) : counter(c) {}
+        void feed_reference(const float*, size_t) override {}
+        void cancel_echo(const float* input, size_t length, float* output) override {
+            call_order = ++(*counter);
+            for (size_t i = 0; i < length; i++) output[i] = input[i] * 0.5f;
+        }
+        int input_sample_rate() const override { return 16000; }
+        void reset() override {}
+    };
+
+    // Enhancer that scales by 0.5
+    class OrderEnhancer : public EnhancerInterface {
+    public:
+        std::atomic<int> call_order{0};
+        int* counter;
+        OrderEnhancer(int* c) : counter(c) {}
+        void enhance(const float* audio, size_t length, int, float* output) override {
+            call_order = ++(*counter);
+            for (size_t i = 0; i < length; i++) output[i] = audio[i] * 0.5f;
+        }
+        int input_sample_rate() const override { return 16000; }
+    };
+
+    int call_counter = 0;
+    OrderAEC aec(&call_counter);
+    OrderEnhancer enhancer(&call_counter);
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::Echo;
+    config.vad.min_speech_duration = 0.064f;
+    config.post_playback_guard = 0;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); },
+        &enhancer);
+
+    pipeline.set_echo_canceller(&aec);
+    pipeline.start();
+
+    auto audio = make_audio(vad.probs.size());
+    pipeline.push_audio(audio.data(), audio.size());
+    pipeline.wait_idle();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Both should have been called
+    assert(aec.call_order.load() > 0);
+    assert(enhancer.call_order.load() > 0);
+    // AEC must run before enhancer
+    assert(aec.call_order.load() < enhancer.call_order.load());
+
+    pipeline.stop();
+    printf("  PASS: echo_cancellation_with_enhancer\n");
+}
+
+void test_echo_cancellation_no_reference_transcribe_only() {
+    // TranscribeOnly mode — no TTS, so no reference fed
+    MockSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    vad.probs = {
+        0.0f,
+        0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f,
+        0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f
+    };
+
+    class TestAEC : public EchoCancellerInterface {
+    public:
+        std::atomic<int> cancel_count{0};
+        std::atomic<int> reference_count{0};
+        void feed_reference(const float*, size_t) override { reference_count++; }
+        void cancel_echo(const float* input, size_t length, float* output) override {
+            cancel_count++;
+            for (size_t i = 0; i < length; i++) output[i] = input[i];
+        }
+        int input_sample_rate() const override { return 16000; }
+        void reset() override {}
+    };
+
+    TestAEC aec;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.064f;
+    config.post_playback_guard = 0;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.set_echo_canceller(&aec);
+    pipeline.start();
+
+    auto audio = make_audio(vad.probs.size());
+    pipeline.push_audio(audio.data(), audio.size());
+    pipeline.wait_idle();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // cancel_echo runs on push_audio
+    assert(aec.cancel_count.load() > 0);
+    // No TTS in TranscribeOnly → no reference fed
+    assert(aec.reference_count.load() == 0);
+
+    pipeline.stop();
+    printf("  PASS: echo_cancellation_no_reference_transcribe_only\n");
+}
+
+void test_echo_cancellation_reset_on_start() {
+    MockSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+    vad.probs = {0.0f};
+
+    class TestAEC : public EchoCancellerInterface {
+    public:
+        std::atomic<int> reset_count{0};
+        void feed_reference(const float*, size_t) override {}
+        void cancel_echo(const float* input, size_t length, float* output) override {
+            for (size_t i = 0; i < length; i++) output[i] = input[i];
+        }
+        int input_sample_rate() const override { return 16000; }
+        void reset() override { reset_count++; }
+    };
+
+    TestAEC aec;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::Echo;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.set_echo_canceller(&aec);
+
+    pipeline.start();
+    assert(aec.reset_count.load() == 1);
+
+    pipeline.stop();
+    printf("  PASS: echo_cancellation_reset_on_start\n");
+}
+
 // ---------------------------------------------------------------------------
 // Partial transcription test
 // ---------------------------------------------------------------------------
@@ -3160,6 +3320,9 @@ int main() {
     test_history_mask_tool_results();
     test_speech_enhancement();
     test_echo_cancellation();
+    test_echo_cancellation_with_enhancer();
+    test_echo_cancellation_no_reference_transcribe_only();
+    test_echo_cancellation_reset_on_start();
     test_partial_transcription();
     test_partial_transcription_batch_fallback();
     test_partial_transcription_disabled();

--- a/tests/test_pipeline_e2e.cpp
+++ b/tests/test_pipeline_e2e.cpp
@@ -2504,6 +2504,75 @@ void test_speech_enhancement() {
 }
 
 // ---------------------------------------------------------------------------
+// Echo cancellation test
+// ---------------------------------------------------------------------------
+
+void test_echo_cancellation() {
+    MockSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    vad.probs = {
+        0.0f,
+        0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f,
+        0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f
+    };
+
+    class TestAEC : public EchoCancellerInterface {
+    public:
+        std::atomic<int> cancel_count{0};
+        std::atomic<int> reference_count{0};
+
+        void feed_reference(const float* /*samples*/, size_t /*length*/) override {
+            reference_count++;
+        }
+
+        void cancel_echo(const float* input, size_t length, float* output) override {
+            cancel_count++;
+            // Pass through with 0.5x scale (simulates echo removal)
+            for (size_t i = 0; i < length; i++) {
+                output[i] = input[i] * 0.5f;
+            }
+        }
+
+        int input_sample_rate() const override { return 16000; }
+        void reset() override {}
+    };
+
+    TestAEC aec;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::Echo;
+    config.vad.min_speech_duration = 0.064f;
+    config.post_playback_guard = 0;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.set_echo_canceller(&aec);
+    pipeline.start();
+
+    auto audio = make_audio(vad.probs.size());
+    pipeline.push_audio(audio.data(), audio.size());
+    pipeline.wait_idle();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // AEC cancel_echo should have been called for each push_audio chunk
+    assert(aec.cancel_count.load() > 0);
+
+    // TTS produced audio → reference should have been fed
+    assert(aec.reference_count.load() > 0);
+
+    // Pipeline still works normally
+    assert(log.has(EventType::TranscriptionCompleted));
+    assert(log.has(EventType::ResponseDone));
+
+    pipeline.stop();
+    printf("  PASS: echo_cancellation\n");
+}
+
+// ---------------------------------------------------------------------------
 // Partial transcription test
 // ---------------------------------------------------------------------------
 
@@ -3090,6 +3159,7 @@ int main() {
     test_history_token_limit();
     test_history_mask_tool_results();
     test_speech_enhancement();
+    test_echo_cancellation();
     test_partial_transcription();
     test_partial_transcription_batch_fallback();
     test_partial_transcription_disabled();


### PR DESCRIPTION
## Summary
- New `EchoCancellerInterface` with `feed_reference()` and `cancel_echo()` for acoustic echo cancellation
- Pipeline automatically feeds TTS output as far-end reference during synthesis
- `cancel_echo()` runs on mic input before enhancement and VAD in `push_audio()`
- Processing chain: `mic → AEC → enhance → VAD → STT`
- Interface is abstract — implementations can use SpeexDSP, WebRTC AEC, or platform-native AEC
- Zero new dependencies, consistent with the library's pure C++17 design
- C API: `sc_echo_canceller_vtable_t` + `sc_pipeline_set_echo_canceller()`
- AEC state reset on pipeline start

## Test plan
- [x] `echo_cancellation` — E2E: cancel_echo called on push_audio, feed_reference called during TTS, pipeline produces transcription + response
- [x] All existing tests pass unchanged (echo canceller defaults to nullptr)

Closes #17