### PR TITLE
Add LiteRT (TFLite) backend for Silero VAD and Parakeet STT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ speech-core — voice agent pipeline engine in C++17. Provides:
 1. **Orchestration core** — state machine, turn detection, interruption handling, speech queue, conversation context, streaming VAD state machine, audio utilities. Zero ML dependencies, pure C++17.
 2. **Abstract interfaces** — `STTInterface`, `TTSInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`, `LLMInterface` in `include/speech_core/interfaces.h`. Consumers (speech-swift, speech-android, …) implement these with their own model backends.
 3. **Optional ONNX reference implementations** — `SileroVad`, `ParakeetStt`, `KokoroTts`, `DeepFilterEnhancer` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_ONNX=ON`.
+4. **Optional LiteRT (TFLite) reference implementations** — `LiteRTSileroVad`, `LiteRTParakeetStt` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_LITERT=ON`. Kokoro and DeepFilter LiteRT exports don't exist yet; wrappers will follow once `speech-models` ships them.
 
 ## Structure
 
@@ -47,16 +48,29 @@ cmake --build build
 - Linux: `lib/libonnxruntime.so`
 - Android: `lib/${ANDROID_ABI}/libonnxruntime.so`
 
+### With LiteRT (TFLite) reference models
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DSPEECH_CORE_WITH_LITERT=ON \
+    -DLITERT_DIR=/path/to/litert
+cmake --build build
+```
+
+`LITERT_DIR` must contain `include/tensorflow/lite/c/c_api.h` and a platform shared library (`lib/libtensorflowlite_c.{so,dylib}`). Use `scripts/setup_litert.sh` to build one from TF source. Both `SPEECH_CORE_WITH_ONNX` and `SPEECH_CORE_WITH_LITERT` are independent and can be enabled together.
+
 ## CMake targets
 
 - **`speech_core`** — static library, orchestration + interfaces + audio utilities. No ORT. Always built.
 - **`speech_core_models`** — static library, ONNX Runtime reference implementations. Links `speech_core` + imported `onnxruntime`. Only built when `SPEECH_CORE_WITH_ONNX=ON`.
+- **`speech_core_models_litert`** — static library, LiteRT (TFLite) reference implementations (Silero VAD, Parakeet STT). Links `speech_core` + imported `litert`. Only built when `SPEECH_CORE_WITH_LITERT=ON`.
 
 Consumers link the targets they need:
 
 ```cmake
-target_link_libraries(my_app PRIVATE speech_core)                  # orchestration only
-target_link_libraries(my_app PRIVATE speech_core speech_core_models)  # + ONNX models
+target_link_libraries(my_app PRIVATE speech_core)                         # orchestration only
+target_link_libraries(my_app PRIVATE speech_core speech_core_models)       # + ONNX models
+target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + LiteRT models
 ```
 
 ## Key files
@@ -74,6 +88,9 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models)  # + ONNX m
 | `include/speech_core/models/kokoro_tts.h` | Kokoro 82M (ORT) — implements `TTSInterface` |
 | `include/speech_core/models/deepfilter.h` | DeepFilterNet3 (ORT) — implements `EnhancerInterface` |
 | `include/speech_core/models/onnx_engine.h` | ORT singleton with NNAPI/QNN/CPU EP selection |
+| `include/speech_core/models/litert_silero_vad.h` | Silero VAD v5 (LiteRT) — implements `VADInterface` |
+| `include/speech_core/models/litert_parakeet_stt.h` | Parakeet TDT v3 (LiteRT, INT8 encoder) — implements `STTInterface` |
+| `include/speech_core/models/litert_engine.h` | TFLite C API loader singleton (CPU only in v1) |
 
 ## Tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Options
 option(SPEECH_CORE_BUILD_TESTS "Build tests" ON)
 option(SPEECH_CORE_WITH_ONNX "Build the speech_core_models target with ONNX Runtime reference implementations (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilter)" OFF)
+option(SPEECH_CORE_WITH_LITERT "Build the speech_core_models_litert target with LiteRT (TFLite) reference implementations (Silero VAD, Parakeet STT)" OFF)
 option(SPEECH_CORE_BUILD_EXAMPLES "Build examples/ (Linux C ABI lib, ALSA demo, CLI tools, integration tests). Requires SPEECH_CORE_WITH_ONNX=ON." OFF)
 
 # ---------------------------------------------------------------------------
@@ -101,6 +102,51 @@ if(SPEECH_CORE_WITH_ONNX)
 endif()
 
 # ---------------------------------------------------------------------------
+# speech_core_models_litert — LiteRT (TFLite) reference implementations (optional)
+# ---------------------------------------------------------------------------
+
+if(SPEECH_CORE_WITH_LITERT)
+    if(NOT DEFINED LITERT_DIR)
+        message(FATAL_ERROR "SPEECH_CORE_WITH_LITERT=ON requires LITERT_DIR (path to a directory with include/tensorflow/lite/c/c_api.h and lib/libtensorflowlite_c.{so,dylib})")
+    endif()
+    get_filename_component(LITERT_DIR "${LITERT_DIR}" ABSOLUTE)
+
+    # LiteRT (TFLite C API) — imported shared library
+    add_library(litert SHARED IMPORTED)
+    if(APPLE)
+        set(_LITERT_LIB "${LITERT_DIR}/lib/libtensorflowlite_c.dylib")
+    elseif(ANDROID)
+        set(_LITERT_LIB "${LITERT_DIR}/lib/${ANDROID_ABI}/libtensorflowlite_c.so")
+    else()
+        set(_LITERT_LIB "${LITERT_DIR}/lib/libtensorflowlite_c.so")
+    endif()
+    set_target_properties(litert PROPERTIES
+        IMPORTED_LOCATION "${_LITERT_LIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LITERT_DIR}/include"
+    )
+
+    add_library(speech_core_models_litert
+        src/models/litert/litert_silero_vad.cpp
+        src/models/litert/litert_parakeet_stt.cpp
+    )
+
+    target_include_directories(speech_core_models_litert
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+
+    target_compile_options(speech_core_models_litert PRIVATE
+        -Wall -Wextra
+        $<$<CONFIG:Release>:-O2>
+    )
+
+    set_target_properties(speech_core_models_litert PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    target_link_libraries(speech_core_models_litert PUBLIC speech_core litert)
+endif()
+
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
@@ -112,7 +158,8 @@ if(SPEECH_CORE_BUILD_TESTS)
     foreach(TEST_SRC ${TEST_SOURCES})
         get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
         # test_models.cpp needs ORT — handled below when SPEECH_CORE_WITH_ONNX=ON.
-        if(TEST_NAME STREQUAL "test_models")
+        # test_litert_models.cpp needs LiteRT — handled below when SPEECH_CORE_WITH_LITERT=ON.
+        if(TEST_NAME STREQUAL "test_models" OR TEST_NAME STREQUAL "test_litert_models")
             continue()
         endif()
         add_executable(${TEST_NAME} ${TEST_SRC})
@@ -129,6 +176,16 @@ if(SPEECH_CORE_BUILD_TESTS)
             SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
         add_test(NAME test_models COMMAND test_models)
     endif()
+
+    # LiteRT model integration tests — require SPEECH_CORE_WITH_LITERT=ON.
+    # Skip gracefully at runtime when SPEECH_LITERT_MODEL_DIR isn't set.
+    if(SPEECH_CORE_WITH_LITERT AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_litert_models.cpp)
+        add_executable(test_litert_models tests/test_litert_models.cpp)
+        target_link_libraries(test_litert_models PRIVATE speech_core_models_litert)
+        target_compile_definitions(test_litert_models PRIVATE
+            SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+        add_test(NAME test_litert_models COMMAND test_litert_models)
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------
@@ -138,6 +195,9 @@ endif()
 set(_install_targets speech_core)
 if(SPEECH_CORE_WITH_ONNX)
     list(APPEND _install_targets speech_core_models)
+endif()
+if(SPEECH_CORE_WITH_LITERT)
+    list(APPEND _install_targets speech_core_models_litert)
 endif()
 
 install(TARGETS ${_install_targets}

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,6 +1,8 @@
 # Reference Model Implementations
 
-speech-core ships with four ONNX Runtime model wrappers under `include/speech_core/models/`. Each implements one of the interfaces in `interfaces.h` and is compiled in when `SPEECH_CORE_WITH_ONNX=ON`.
+speech-core ships two parallel sets of model wrappers under `include/speech_core/models/`. Each implements one of the interfaces in `interfaces.h` and is compiled in via a backend-specific CMake flag. The two backends can be enabled simultaneously — consumers link only the targets they need.
+
+### ONNX Runtime backend (`SPEECH_CORE_WITH_ONNX`)
 
 | Model | Interface | Header |
 |---|---|---|
@@ -9,7 +11,16 @@ speech-core ships with four ONNX Runtime model wrappers under `include/speech_co
 | `KokoroTts` | `TTSInterface` | `speech_core/models/kokoro_tts.h` |
 | `DeepFilterEnhancer` | `EnhancerInterface` | `speech_core/models/deepfilter.h` |
 
-All four share an internal ONNX Runtime singleton (`OnnxEngine` in `speech_core/models/onnx_engine.h`) that owns the `OrtEnv` and `OrtMemoryInfo`. The first model construction initializes it; subsequent constructions reuse it.
+### LiteRT (TFLite) backend (`SPEECH_CORE_WITH_LITERT`)
+
+| Model | Interface | Header |
+|---|---|---|
+| `LiteRTSileroVad` | `VADInterface` | `speech_core/models/litert_silero_vad.h` |
+| `LiteRTParakeetStt` | `STTInterface` | `speech_core/models/litert_parakeet_stt.h` |
+
+Kokoro 82M and DeepFilterNet3 do not yet have LiteRT exports — see `speech-models` for conversion status. When they land, wrappers will be added alongside the existing two.
+
+All ORT wrappers share an internal ONNX Runtime singleton (`OnnxEngine` in `speech_core/models/onnx_engine.h`) that owns the `OrtEnv` and `OrtMemoryInfo`. All LiteRT wrappers share `LiteRTEngine` (`speech_core/models/litert_engine.h`) which currently configures CPU-only inference with a configurable thread count. NNAPI / GPU / Hexagon delegates are not yet wired through the C API in this version.
 
 ## Building with ONNX support
 
@@ -29,6 +40,32 @@ cmake --build build
 | Android | `lib/${ANDROID_ABI}/libonnxruntime.so` |
 
 Hardware-accelerated execution providers are picked automatically: NNAPI on Android, QNN on non-Android (if available), CPU fallback otherwise.
+
+## Building with LiteRT support
+
+```bash
+cmake -S . -B build \
+    -DSPEECH_CORE_WITH_LITERT=ON \
+    -DLITERT_DIR=/path/to/litert
+cmake --build build
+```
+
+`LITERT_DIR` must contain the TFLite C API headers and a platform-appropriate shared library:
+
+| Platform | Header | Library |
+|---|---|---|
+| macOS | `include/tensorflow/lite/c/c_api.h` | `lib/libtensorflowlite_c.dylib` |
+| Linux | `include/tensorflow/lite/c/c_api.h` | `lib/libtensorflowlite_c.so` |
+| Android | `include/tensorflow/lite/c/c_api.h` | `lib/${ANDROID_ABI}/libtensorflowlite_c.so` |
+
+If you don't have a TFLite C library handy, build one from TensorFlow source:
+
+```bash
+scripts/setup_litert.sh build/litert v2.18.0
+# → build/litert/{include,lib} ready for use as LITERT_DIR
+```
+
+`SPEECH_CORE_WITH_ONNX` and `SPEECH_CORE_WITH_LITERT` are independent — enable either, both, or neither. Both flags produce separate static libraries (`speech_core_models`, `speech_core_models_litert`); consumers link only what they use.
 
 ## SileroVad
 
@@ -64,6 +101,37 @@ auto result = stt.transcribe(audio, length, 16000);
 - Language detection via `<|xx|>` BPE tokens
 - Streaming supported via `begin_stream` / `push_chunk` / `end_stream` (accumulates audio and re-transcribes each chunk; not a true streaming decoder)
 - Model files: [aufklarer/Parakeet-TDT-v3-ONNX](https://huggingface.co/aufklarer/Parakeet-TDT-v3-ONNX) — `parakeet-encoder.onnx` (FP32, plus external `.onnx.data`) or `parakeet-encoder-int8.onnx` (~840 MB / ~100 MB INT8), `parakeet-decoder-joint.onnx` / `parakeet-decoder-joint-int8.onnx`, `vocab.json`
+
+## LiteRTSileroVad
+
+```cpp
+#include <speech_core/models/litert_silero_vad.h>
+
+speech_core::LiteRTSileroVad vad("/path/to/silero-vad.tflite");
+float prob = vad.process_chunk(samples_512, 512);
+```
+
+- Same public contract as `SileroVad` (512-sample chunks, 16 kHz, [0,1] probability)
+- The LiteRT model itself takes `[1, 576]` (64 left-context + 512 chunk); the wrapper hides the context buffer so callers see the same `VADInterface`
+- Model files: [soniqo/Silero-VAD-v5-LiteRT](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) — `silero-vad.tflite` (~1.3 MB)
+
+## LiteRTParakeetStt
+
+```cpp
+#include <speech_core/models/litert_parakeet_stt.h>
+
+speech_core::LiteRTParakeetStt stt(
+    "/models/parakeet-encoder.tflite",
+    "/models/parakeet-decoder-joint.tflite",
+    "/models/vocab.json");
+
+auto result = stt.transcribe(audio, length, 16000);
+```
+
+- Same public contract and TDT decode loop as `ParakeetStt`
+- Encoder INT8 weight-quantized (~595 MB on disk vs ~840 MB ONNX FP32), decoder-joint stays FP32 to avoid LSTM drift
+- Decoder-joint exposes `(encoder_out, target, h, c)` as four discrete tensors (ORT bundles `target_length` and uses suffix-`_1`/`_2` for h/c)
+- Model files: [soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) — `parakeet-encoder.tflite`, `parakeet-decoder-joint.tflite`, `vocab.json`
 
 ## KokoroTts
 
@@ -149,6 +217,16 @@ SPEECH_MODEL_DIR=scripts/models ctest --test-dir build --output-on-failure
 ```
 
 `test_models` skips cleanly with exit code 0 when `SPEECH_MODEL_DIR` is unset or model files are missing — CI without model artifacts stays green.
+
+A separate `test_litert_models` target is added when `SPEECH_CORE_WITH_LITERT=ON`, exercising the two LiteRT wrappers against `.tflite` artifacts:
+
+```bash
+scripts/download_models_litert.sh
+scripts/setup_litert.sh                # builds libtensorflowlite_c locally
+cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$PWD/build/litert
+cmake --build build
+SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
+```
 
 ## Bring-your-own model
 

--- a/include/speech_core/models/litert_engine.h
+++ b/include/speech_core/models/litert_engine.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <tensorflow/lite/c/c_api.h>
+
+#include <stdexcept>
+#include <string>
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#ifndef LOG_TAG
+#define LOG_TAG "Speech"
+#endif
+#ifndef LOGI
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#endif
+#ifndef LOGE
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#endif
+#else
+#include <cstdio>
+#ifndef LOGI
+#define LOGI(...) do { fprintf(stderr, "[speech] "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#endif
+#ifndef LOGE
+#define LOGE(...) do { fprintf(stderr, "[speech ERROR] "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#endif
+#endif
+
+namespace speech_core {
+
+inline void litert_check(TfLiteStatus status, const char* what) {
+    if (status != kTfLiteOk) {
+        throw std::runtime_error(std::string("LiteRT: ") + what + " failed");
+    }
+}
+
+/// Shared LiteRT loader. Creates a TfLiteInterpreter from a .tflite path.
+/// hw_accel is currently a thread-count hint; NNAPI/GPU delegates are not yet wired.
+/// Returns the loaded interpreter and (out-param) the model handle the caller
+/// must free with TfLiteModelDelete after the interpreter.
+class LiteRTEngine {
+public:
+    static LiteRTEngine& get() {
+        static LiteRTEngine instance;
+        return instance;
+    }
+
+    /// Load a .tflite into an interpreter. Caller owns both returned handles
+    /// and must call TfLiteInterpreterDelete before TfLiteModelDelete.
+    TfLiteInterpreter* load(const std::string& path,
+                            bool hw_accel,
+                            TfLiteModel** out_model) {
+        TfLiteModel* model = TfLiteModelCreateFromFile(path.c_str());
+        if (!model) {
+            throw std::runtime_error("LiteRT: failed to load model from " + path);
+        }
+
+        TfLiteInterpreterOptions* opts = TfLiteInterpreterOptionsCreate();
+        // 4 threads when caller asks for hw accel, 2 otherwise. NNAPI/GPU delegates
+        // are not yet wired through the C API — track follow-up in docs/models.md.
+        TfLiteInterpreterOptionsSetNumThreads(opts, hw_accel ? 4 : 2);
+
+        LOGI("Loading LiteRT model: %s (threads=%d)",
+             path.substr(path.find_last_of('/') + 1).c_str(),
+             hw_accel ? 4 : 2);
+
+        TfLiteInterpreter* interp = TfLiteInterpreterCreate(model, opts);
+        TfLiteInterpreterOptionsDelete(opts);
+
+        if (!interp) {
+            TfLiteModelDelete(model);
+            throw std::runtime_error("LiteRT: failed to create interpreter for " + path);
+        }
+
+        litert_check(TfLiteInterpreterAllocateTensors(interp), "AllocateTensors");
+
+        *out_model = model;
+        return interp;
+    }
+
+private:
+    LiteRTEngine() = default;
+    LiteRTEngine(const LiteRTEngine&) = delete;
+    LiteRTEngine& operator=(const LiteRTEngine&) = delete;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/litert_parakeet_stt.h
+++ b/include/speech_core/models/litert_parakeet_stt.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <tensorflow/lite/c/c_api.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace speech_core {
+
+/// Parakeet TDT v3 (0.6B) — speech recognition via LiteRT (TFLite).
+/// FastConformer encoder + fused LSTM decoder/joint network.
+/// Two .tflite files: parakeet-encoder.tflite + parakeet-decoder-joint.tflite.
+/// Input: PCM Float32 audio at 16 kHz. Output: transcribed text + language.
+class LiteRTParakeetStt : public STTInterface {
+public:
+    struct Config {
+        int num_mel_bins    = 128;
+        int sample_rate     = 16000;
+        int n_fft           = 512;
+        int hop_length      = 160;
+        int win_length      = 400;
+        float pre_emphasis  = 0.97f;
+        int encoder_hidden  = 1024;
+        int decoder_hidden  = 640;
+        int decoder_layers  = 2;
+        int vocab_size      = 1024;
+        int blank_id        = 1024;
+        int num_dur_bins    = 5;
+        int duration_bins[5] = {0, 1, 2, 3, 4};
+        int total_logits    = 1030;
+        int first_text_token = 0;
+    };
+
+    LiteRTParakeetStt(const std::string& encoder_path,
+                      const std::string& decoder_joint_path,
+                      const std::string& vocab_path,
+                      bool hw_accel = true);
+    ~LiteRTParakeetStt() override;
+
+    // --- STTInterface (batch) ---
+    TranscriptionResult transcribe(const float* audio, size_t length, int sample_rate) override;
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+
+    // --- STTInterface (streaming) ---
+    bool supports_streaming() const override { return true; }
+    void begin_stream(int sample_rate) override;
+    PartialResult push_chunk(const float* audio, size_t length) override;
+    void flush_stream() override;
+    TranscriptionResult end_stream() override;
+    void cancel_stream() override;
+
+private:
+    struct DecodeResult {
+        std::string text;
+        std::string language;
+        float confidence = 0.0f;
+    };
+
+    bool load_vocab(const std::string& path);
+    std::vector<float> compute_mel(const float* audio, size_t length);
+    DecodeResult decode(const float* audio, size_t length);
+    DecodeResult tdt_decode(const float* encoded, int64_t enc_len, int64_t hidden);
+    std::string decode_tokens(const std::vector<int>& token_ids);
+
+    TfLiteModel*       enc_model_   = nullptr;
+    TfLiteInterpreter* enc_interp_  = nullptr;
+    TfLiteModel*       dec_model_   = nullptr;
+    TfLiteInterpreter* dec_interp_  = nullptr;
+    Config cfg_;
+
+    std::unordered_map<int, std::string> vocab_;
+    std::unordered_map<int, std::string> lang_tokens_;
+
+    std::vector<float> stream_buffer_;
+    int stream_sample_rate_ = 16000;
+    bool streaming_ = false;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/litert_silero_vad.h
+++ b/include/speech_core/models/litert_silero_vad.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <tensorflow/lite/c/c_api.h>
+
+#include <array>
+#include <string>
+
+namespace speech_core {
+
+/// Silero VAD v5 — voice activity detection via LiteRT (TFLite).
+/// VADInterface::process_chunk consumes 512 samples per call; the LiteRT model
+/// itself takes [1, 576] (64 left-context + 512 chunk). The wrapper keeps the
+/// 64-sample tail of the previous chunk and prepends it transparently, so the
+/// public API matches the ORT variant.
+class LiteRTSileroVad : public VADInterface {
+public:
+    explicit LiteRTSileroVad(const std::string& model_path, bool hw_accel = false);
+    ~LiteRTSileroVad() override;
+
+    float process_chunk(const float* samples, size_t length) override;
+    void reset() override;
+
+    int input_sample_rate() const override { return 16000; }
+    size_t chunk_size() const override { return 512; }
+
+private:
+    TfLiteModel*       model_   = nullptr;
+    TfLiteInterpreter* interp_  = nullptr;
+
+    static constexpr size_t kContextSamples = 64;
+    static constexpr size_t kChunkSamples   = 512;
+    static constexpr size_t kTotalSamples   = kContextSamples + kChunkSamples;  // 576
+    static constexpr size_t kStateSize      = 2 * 1 * 128;
+
+    std::array<float, kContextSamples> context_{};
+    std::array<float, kStateSize>      state_{};
+    std::array<float, kTotalSamples>   input_buffer_{};
+};
+
+}  // namespace speech_core

--- a/scripts/download_models_litert.sh
+++ b/scripts/download_models_litert.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Download LiteRT (.tflite) models for testing the speech_core_models_litert target.
+# Usage: ./download_models_litert.sh [output_dir]
+#
+# By default models are placed in scripts/models-litert/ alongside this script.
+# Tests pick the directory up via the SPEECH_LITERT_MODEL_DIR environment variable:
+#   SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build
+
+set -euo pipefail
+
+BASE_URL="https://huggingface.co/soniqo"
+OUT="${1:-$(dirname "$0")/models-litert}"
+mkdir -p "$OUT"
+
+FILES=(
+    "Silero-VAD-v5-LiteRT/silero-vad.tflite"
+    "Silero-VAD-v5-LiteRT/config.json"
+    "Parakeet-TDT-0.6B-v3-LiteRT-INT8/parakeet-encoder.tflite"
+    "Parakeet-TDT-0.6B-v3-LiteRT-INT8/parakeet-decoder-joint.tflite"
+    "Parakeet-TDT-0.6B-v3-LiteRT-INT8/vocab.json"
+    "Parakeet-TDT-0.6B-v3-LiteRT-INT8/config.json"
+)
+
+for entry in "${FILES[@]}"; do
+    repo="${entry%%/*}"
+    rel="${entry#*/}"
+    # Parakeet and Silero both have a config.json — disambiguate by prefixing
+    # with a short model tag so they don't overwrite each other.
+    case "$repo" in
+        Silero-VAD-v5-LiteRT)
+            dest="$OUT/silero-${rel}"
+            [[ "$rel" == "silero-vad.tflite" ]] && dest="$OUT/silero-vad.tflite"
+            ;;
+        Parakeet-TDT-0.6B-v3-LiteRT-INT8)
+            dest="$OUT/parakeet-${rel}"
+            [[ "$rel" == parakeet-* ]] && dest="$OUT/${rel}"
+            ;;
+        *)
+            dest="$OUT/${rel}"
+            ;;
+    esac
+
+    if [[ -f "$dest" && -s "$dest" ]]; then
+        echo "[skip] $rel (already exists)"
+        continue
+    fi
+
+    url="$BASE_URL/$repo/resolve/main/$rel"
+    echo "[fetch] $rel"
+    curl -fL --retry 3 -o "$dest" "$url"
+done
+
+echo ""
+echo "LiteRT models downloaded to: $OUT"
+echo "Run tests with: SPEECH_LITERT_MODEL_DIR=$OUT ctest --test-dir build --output-on-failure"

--- a/scripts/setup_litert.sh
+++ b/scripts/setup_litert.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build the LiteRT (TFLite) C API shared library from TensorFlow sources,
+# then arrange it under $OUT/{include,lib} so it can be used as LITERT_DIR.
+#
+# Usage:
+#     scripts/setup_litert.sh [output_dir] [tf_version]
+#
+# Defaults: output_dir = build/litert ; tf_version = v2.18.0
+#
+# The script is ~30 min on a fast machine (Bazel-equivalent CMake build with
+# eigen, xnnpack, abseil, ruy, fft2d, farmhash, flatbuffers). Pin a release
+# tag rather than HEAD to keep CI reproducible.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$ROOT/build/litert}"
+TF_VERSION="${2:-v2.18.0}"
+
+TF_SRC="$OUT/tensorflow-${TF_VERSION}"
+BUILD_DIR="$OUT/build-${TF_VERSION}"
+
+mkdir -p "$OUT"
+
+if [[ ! -d "$TF_SRC/.git" ]]; then
+    echo "[setup_litert] Cloning TensorFlow ${TF_VERSION}..."
+    git clone --depth=1 --branch="${TF_VERSION}" \
+        https://github.com/tensorflow/tensorflow "$TF_SRC"
+fi
+
+echo "[setup_litert] Configuring TFLite C build..."
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# NNAPI/GPU/Metal off — we ship CPU only in this initial wrapper. They can be
+# turned on per-platform when the wrappers learn to wire delegates.
+cmake "$TF_SRC/tensorflow/lite/c" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTFLITE_C_BUILD_SHARED_LIBS=ON \
+    -DTFLITE_ENABLE_NNAPI=OFF \
+    -DTFLITE_ENABLE_GPU=OFF \
+    -DTFLITE_ENABLE_METAL=OFF \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+echo "[setup_litert] Building tensorflowlite_c (this takes ~20-30 minutes)..."
+cmake --build . --target tensorflowlite_c -j
+
+mkdir -p "$OUT/include/tensorflow/lite/c" "$OUT/include/tensorflow/lite/core/c" "$OUT/lib"
+
+# Copy public C headers (only what the wrappers consume).
+cp "$TF_SRC/tensorflow/lite/c/c_api.h"             "$OUT/include/tensorflow/lite/c/"
+cp "$TF_SRC/tensorflow/lite/c/c_api_types.h"       "$OUT/include/tensorflow/lite/c/"
+cp "$TF_SRC/tensorflow/lite/c/common.h"            "$OUT/include/tensorflow/lite/c/"
+cp "$TF_SRC/tensorflow/lite/core/c/c_api.h"        "$OUT/include/tensorflow/lite/core/c/"
+cp "$TF_SRC/tensorflow/lite/core/c/c_api_types.h"  "$OUT/include/tensorflow/lite/core/c/"
+cp "$TF_SRC/tensorflow/lite/core/c/common.h"       "$OUT/include/tensorflow/lite/core/c/"
+
+# Library
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    cp "$BUILD_DIR/libtensorflowlite_c.dylib" "$OUT/lib/"
+else
+    cp "$BUILD_DIR/libtensorflowlite_c.so" "$OUT/lib/"
+fi
+
+echo ""
+echo "LiteRT installed at: $OUT"
+echo "Build with: cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$OUT"

--- a/src/models/litert/litert_parakeet_stt.cpp
+++ b/src/models/litert/litert_parakeet_stt.cpp
@@ -1,0 +1,375 @@
+#include "speech_core/models/litert_parakeet_stt.h"
+
+#include "speech_core/audio/mel.h"
+#include "speech_core/models/litert_engine.h"
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace speech_core {
+
+// ---------------------------------------------------------------------------
+// SentencePiece U+2581 → space, then trim
+// ---------------------------------------------------------------------------
+
+static void replace_sp_marker(std::string& s) {
+    const std::string marker = "\xE2\x96\x81";
+    size_t pos = 0;
+    while ((pos = s.find(marker, pos)) != std::string::npos) {
+        s.replace(pos, marker.size(), " ");
+        pos += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+LiteRTParakeetStt::LiteRTParakeetStt(
+    const std::string& encoder_path,
+    const std::string& decoder_joint_path,
+    const std::string& vocab_path,
+    bool hw_accel)
+{
+    auto& engine = LiteRTEngine::get();
+    enc_interp_ = engine.load(encoder_path,       hw_accel, &enc_model_);
+    dec_interp_ = engine.load(decoder_joint_path, false,    &dec_model_);
+
+    load_vocab(vocab_path);
+}
+
+LiteRTParakeetStt::~LiteRTParakeetStt() {
+    if (dec_interp_) TfLiteInterpreterDelete(dec_interp_);
+    if (dec_model_)  TfLiteModelDelete(dec_model_);
+    if (enc_interp_) TfLiteInterpreterDelete(enc_interp_);
+    if (enc_model_)  TfLiteModelDelete(enc_model_);
+}
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+bool LiteRTParakeetStt::load_vocab(const std::string& path) {
+    auto text = json::read_file(path);
+    if (text.empty()) return false;
+
+    auto flat = json::parse_flat_object(text);
+    for (auto& [key, val] : flat) {
+        try {
+            int id = std::stoi(key);
+            vocab_[id] = val;
+
+            if (val.size() >= 5 && val.size() <= 6 &&
+                val.substr(0, 2) == "<|" && val.substr(val.size() - 2) == "|>") {
+                std::string code = val.substr(2, val.size() - 4);
+                lang_tokens_[id] = code;
+            }
+        } catch (...) {}
+    }
+
+    if (!vocab_.empty()) {
+        cfg_.vocab_size = static_cast<int>(vocab_.size());
+        cfg_.blank_id = cfg_.vocab_size;
+        cfg_.total_logits = cfg_.vocab_size + 1 + cfg_.num_dur_bins;
+    }
+
+    LOGI("LiteRT Parakeet vocab: %zu tokens, %zu language tokens, blank=%d",
+         vocab_.size(), lang_tokens_.size(), cfg_.blank_id);
+    return !vocab_.empty();
+}
+
+std::string LiteRTParakeetStt::decode_tokens(const std::vector<int>& token_ids) {
+    std::string pieces;
+    for (int id : token_ids) {
+        auto it = vocab_.find(id);
+        if (it != vocab_.end()) pieces += it->second;
+    }
+    replace_sp_marker(pieces);
+
+    size_t start = pieces.find_first_not_of(' ');
+    if (start == std::string::npos) return "";
+    size_t end = pieces.find_last_not_of(' ');
+    return pieces.substr(start, end - start + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Mel spectrogram (same as ORT wrapper)
+// ---------------------------------------------------------------------------
+
+std::vector<float> LiteRTParakeetStt::compute_mel(const float* audio, size_t length) {
+    std::vector<float> emphasized(length);
+    emphasized[0] = audio[0];
+    for (size_t i = 1; i < length; i++) {
+        emphasized[i] = audio[i] - cfg_.pre_emphasis * audio[i - 1];
+    }
+
+    auto mel = audio::mel_spectrogram(
+        emphasized.data(), emphasized.size(),
+        cfg_.sample_rate, cfg_.n_fft, cfg_.hop_length,
+        cfg_.win_length, cfg_.num_mel_bins);
+
+    int num_frames = static_cast<int>(mel.size() / cfg_.num_mel_bins);
+    if (num_frames > 1) {
+        for (int m = 0; m < cfg_.num_mel_bins; m++) {
+            float sum = 0, sq_sum = 0;
+            for (int t = 0; t < num_frames; t++) {
+                float v = mel[m * num_frames + t];
+                sum += v;
+                sq_sum += v * v;
+            }
+            float mean = sum / num_frames;
+            float var = sq_sum / num_frames - mean * mean;
+            float stddev = (var > 0) ? std::sqrt(var) : 1.0f;
+            for (int t = 0; t < num_frames; t++) {
+                mel[m * num_frames + t] = (mel[m * num_frames + t] - mean) / stddev;
+            }
+        }
+    }
+
+    return mel;
+}
+
+// ---------------------------------------------------------------------------
+// Decode (mel → encoder → tdt_decode)
+// ---------------------------------------------------------------------------
+
+LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::decode(const float* audio, size_t length) {
+    auto mel = compute_mel(audio, length);
+    int64_t num_frames = static_cast<int64_t>(mel.size() / cfg_.num_mel_bins);
+
+    // Encoder input 0: audio_signal [1, 128, T]
+    // Encoder input 1: length [1] int64
+    const int enc_audio_dims[] = {1, cfg_.num_mel_bins, static_cast<int>(num_frames)};
+    litert_check(TfLiteInterpreterResizeInputTensor(enc_interp_, 0, enc_audio_dims, 3),
+                 "Encoder ResizeInputTensor(audio_signal)");
+    const int enc_len_dims[] = {1};
+    litert_check(TfLiteInterpreterResizeInputTensor(enc_interp_, 1, enc_len_dims, 1),
+                 "Encoder ResizeInputTensor(length)");
+    litert_check(TfLiteInterpreterAllocateTensors(enc_interp_), "Encoder AllocateTensors");
+
+    TfLiteTensor* in_audio  = TfLiteInterpreterGetInputTensor(enc_interp_, 0);
+    TfLiteTensor* in_length = TfLiteInterpreterGetInputTensor(enc_interp_, 1);
+
+    litert_check(TfLiteTensorCopyFromBuffer(in_audio, mel.data(),
+                                            mel.size() * sizeof(float)),
+                 "Encoder CopyFromBuffer(audio_signal)");
+    int64_t mel_len = num_frames;
+    litert_check(TfLiteTensorCopyFromBuffer(in_length, &mel_len, sizeof(int64_t)),
+                 "Encoder CopyFromBuffer(length)");
+
+    litert_check(TfLiteInterpreterInvoke(enc_interp_), "Encoder Invoke");
+
+    // Encoder output 0: encoded [1, hidden, T']
+    // Encoder output 1: encoded_lengths [1] int64
+    const TfLiteTensor* out_encoded     = TfLiteInterpreterGetOutputTensor(enc_interp_, 0);
+    const TfLiteTensor* out_encoded_len = TfLiteInterpreterGetOutputTensor(enc_interp_, 1);
+
+    int32_t enc_dims = TfLiteTensorNumDims(out_encoded);
+    int64_t hidden  = (enc_dims >= 3) ? TfLiteTensorDim(out_encoded, 1) : cfg_.encoder_hidden;
+    int64_t enc_t   = (enc_dims >= 3) ? TfLiteTensorDim(out_encoded, 2) : 0;
+
+    std::vector<float> encoded(static_cast<size_t>(hidden * enc_t));
+    litert_check(TfLiteTensorCopyToBuffer(out_encoded, encoded.data(),
+                                          encoded.size() * sizeof(float)),
+                 "Encoder CopyToBuffer(encoded)");
+
+    int64_t enc_len = 0;
+    litert_check(TfLiteTensorCopyToBuffer(out_encoded_len, &enc_len, sizeof(int64_t)),
+                 "Encoder CopyToBuffer(encoded_lengths)");
+
+    LOGI("LiteRT STT: frames=%lld enc_len=%lld hidden=%lld audio=%zu",
+         (long long)num_frames, (long long)enc_len, (long long)hidden, length);
+
+    auto result = tdt_decode(encoded.data(), enc_len, hidden);
+
+    LOGI("LiteRT STT: text='%.60s' conf=%.4f", result.text.c_str(), result.confidence);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public batch transcribe (STTInterface)
+// ---------------------------------------------------------------------------
+
+TranscriptionResult LiteRTParakeetStt::transcribe(
+    const float* audio, size_t length, int /*sample_rate*/)
+{
+    auto r = decode(audio, length);
+    TranscriptionResult out;
+    out.text = std::move(r.text);
+    out.language = std::move(r.language);
+    out.confidence = r.confidence;
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// TDT greedy decoding with fused decoder_joint model
+// ---------------------------------------------------------------------------
+
+LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::tdt_decode(
+    const float* encoded, int64_t enc_len, int64_t hidden)
+{
+    std::vector<int> token_ids;
+    std::string detected_language;
+    float log_prob_sum = 0.0f;
+    int log_prob_count = 0;
+
+    int64_t state_size = cfg_.decoder_layers * 1 * cfg_.decoder_hidden;
+    std::vector<float> h_state(state_size, 0.0f);
+    std::vector<float> c_state(state_size, 0.0f);
+
+    int64_t prev_token = static_cast<int64_t>(cfg_.blank_id);
+    int64_t t = 0;
+
+    std::vector<float> enc_frame(hidden);
+    std::vector<float> logits(cfg_.total_logits);
+
+    while (t < enc_len) {
+        // Encoder frame at time t: [1, 1, hidden] — note LiteRT decoder takes
+        // (B, T_enc=1, H) per convert_litert.py, vs ORT's (B, H, T_enc=1).
+        for (int64_t h = 0; h < hidden; h++) {
+            enc_frame[h] = encoded[h * enc_len + t];
+        }
+
+        TfLiteTensor* in_enc    = TfLiteInterpreterGetInputTensor(dec_interp_, 0);
+        TfLiteTensor* in_target = TfLiteInterpreterGetInputTensor(dec_interp_, 1);
+        TfLiteTensor* in_h      = TfLiteInterpreterGetInputTensor(dec_interp_, 2);
+        TfLiteTensor* in_c      = TfLiteInterpreterGetInputTensor(dec_interp_, 3);
+
+        litert_check(TfLiteTensorCopyFromBuffer(in_enc, enc_frame.data(),
+                                                enc_frame.size() * sizeof(float)),
+                     "Decoder CopyFromBuffer(encoder_out)");
+        litert_check(TfLiteTensorCopyFromBuffer(in_target, &prev_token, sizeof(int64_t)),
+                     "Decoder CopyFromBuffer(target)");
+        litert_check(TfLiteTensorCopyFromBuffer(in_h, h_state.data(),
+                                                h_state.size() * sizeof(float)),
+                     "Decoder CopyFromBuffer(h)");
+        litert_check(TfLiteTensorCopyFromBuffer(in_c, c_state.data(),
+                                                c_state.size() * sizeof(float)),
+                     "Decoder CopyFromBuffer(c)");
+
+        litert_check(TfLiteInterpreterInvoke(dec_interp_), "Decoder Invoke");
+
+        const TfLiteTensor* out_logits = TfLiteInterpreterGetOutputTensor(dec_interp_, 0);
+        const TfLiteTensor* out_h      = TfLiteInterpreterGetOutputTensor(dec_interp_, 1);
+        const TfLiteTensor* out_c      = TfLiteInterpreterGetOutputTensor(dec_interp_, 2);
+
+        litert_check(TfLiteTensorCopyToBuffer(out_logits, logits.data(),
+                                              logits.size() * sizeof(float)),
+                     "Decoder CopyToBuffer(logits)");
+
+        int token_end = cfg_.vocab_size + 1;
+
+        int best_token = 0;
+        float best_score = logits[0];
+        for (int i = 1; i < token_end; i++) {
+            if (logits[i] > best_score) {
+                best_score = logits[i];
+                best_token = i;
+            }
+        }
+
+        if (best_token == cfg_.blank_id) {
+            t += 1;
+        } else {
+            if (best_token >= cfg_.first_text_token && best_token < cfg_.vocab_size) {
+                auto lang_it = lang_tokens_.find(best_token);
+                if (lang_it != lang_tokens_.end()) {
+                    if (detected_language.empty()) {
+                        detected_language = lang_it->second;
+                    }
+                } else {
+                    token_ids.push_back(best_token);
+                    log_prob_sum += best_score;
+                    log_prob_count++;
+                }
+            }
+
+            const float* dur_logits = logits.data() + token_end;
+            int dur_idx = 0;
+            float best_dur = dur_logits[0];
+            for (int d = 1; d < cfg_.num_dur_bins; d++) {
+                if (dur_logits[d] > best_dur) {
+                    best_dur = dur_logits[d];
+                    dur_idx = d;
+                }
+            }
+            t += std::max(cfg_.duration_bins[dur_idx], 1);
+
+            prev_token = best_token;
+
+            litert_check(TfLiteTensorCopyToBuffer(out_h, h_state.data(),
+                                                  h_state.size() * sizeof(float)),
+                         "Decoder CopyToBuffer(h_new)");
+            litert_check(TfLiteTensorCopyToBuffer(out_c, c_state.data(),
+                                                  c_state.size() * sizeof(float)),
+                         "Decoder CopyToBuffer(c_new)");
+        }
+    }
+
+    DecodeResult result;
+    result.text = decode_tokens(token_ids);
+    result.language = detected_language;
+
+    if (log_prob_count > 0) {
+        float mean_logit = log_prob_sum / static_cast<float>(log_prob_count);
+        result.confidence = 1.0f / (1.0f + std::exp(-mean_logit * 0.1f));
+    }
+
+    if (!result.language.empty()) {
+        LOGI("LiteRT STT: detected language=%s", result.language.c_str());
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming: accumulate audio and re-transcribe (same shape as ORT wrapper)
+// ---------------------------------------------------------------------------
+
+void LiteRTParakeetStt::begin_stream(int sample_rate) {
+    stream_buffer_.clear();
+    stream_sample_rate_ = sample_rate;
+    streaming_ = true;
+}
+
+PartialResult LiteRTParakeetStt::push_chunk(const float* audio, size_t length) {
+    stream_buffer_.insert(stream_buffer_.end(), audio, audio + length);
+
+    if (stream_buffer_.size() < static_cast<size_t>(stream_sample_rate_ / 2)) {
+        return {};
+    }
+
+    auto r = decode(stream_buffer_.data(), stream_buffer_.size());
+    PartialResult out;
+    out.text = std::move(r.text);
+    out.language = std::move(r.language);
+    out.confidence = r.confidence;
+    return out;
+}
+
+TranscriptionResult LiteRTParakeetStt::end_stream() {
+    streaming_ = false;
+    if (stream_buffer_.empty()) return {};
+
+    auto r = decode(stream_buffer_.data(), stream_buffer_.size());
+    stream_buffer_.clear();
+
+    TranscriptionResult out;
+    out.text = std::move(r.text);
+    out.language = std::move(r.language);
+    out.confidence = r.confidence;
+    return out;
+}
+
+void LiteRTParakeetStt::cancel_stream() {
+    stream_buffer_.clear();
+    streaming_ = false;
+}
+
+void LiteRTParakeetStt::flush_stream() {
+    // No-op — single-utterance sessions only
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_silero_vad.cpp
+++ b/src/models/litert/litert_silero_vad.cpp
@@ -1,0 +1,74 @@
+#include "speech_core/models/litert_silero_vad.h"
+
+#include "speech_core/models/litert_engine.h"
+
+#include <cstring>
+#include <stdexcept>
+
+namespace speech_core {
+
+LiteRTSileroVad::LiteRTSileroVad(const std::string& model_path, bool hw_accel) {
+    interp_ = LiteRTEngine::get().load(model_path, hw_accel, &model_);
+
+    // Sanity: model exports as forward(audio[1,576], state[2,1,128]) → (prob, state_out)
+    const int32_t in_count  = TfLiteInterpreterGetInputTensorCount(interp_);
+    const int32_t out_count = TfLiteInterpreterGetOutputTensorCount(interp_);
+    if (in_count != 2 || out_count != 2) {
+        throw std::runtime_error("LiteRT Silero: expected 2 inputs and 2 outputs, got "
+                                 + std::to_string(in_count) + "/" + std::to_string(out_count));
+    }
+
+    reset();
+}
+
+LiteRTSileroVad::~LiteRTSileroVad() {
+    if (interp_) TfLiteInterpreterDelete(interp_);
+    if (model_)  TfLiteModelDelete(model_);
+}
+
+void LiteRTSileroVad::reset() {
+    context_.fill(0.0f);
+    state_.fill(0.0f);
+}
+
+float LiteRTSileroVad::process_chunk(const float* samples, size_t length) {
+    if (length != kChunkSamples) {
+        throw std::runtime_error("LiteRT Silero: expected " + std::to_string(kChunkSamples)
+                                 + " samples per chunk, got " + std::to_string(length));
+    }
+
+    // Assemble [context(64) | chunk(512)] for the model input.
+    std::memcpy(input_buffer_.data(),                   context_.data(), kContextSamples * sizeof(float));
+    std::memcpy(input_buffer_.data() + kContextSamples, samples,         kChunkSamples   * sizeof(float));
+
+    TfLiteTensor* in_audio = TfLiteInterpreterGetInputTensor(interp_, 0);
+    TfLiteTensor* in_state = TfLiteInterpreterGetInputTensor(interp_, 1);
+
+    litert_check(TfLiteTensorCopyFromBuffer(in_audio, input_buffer_.data(),
+                                            kTotalSamples * sizeof(float)),
+                 "CopyFromBuffer(audio)");
+    litert_check(TfLiteTensorCopyFromBuffer(in_state, state_.data(),
+                                            kStateSize * sizeof(float)),
+                 "CopyFromBuffer(state)");
+
+    litert_check(TfLiteInterpreterInvoke(interp_), "Invoke");
+
+    const TfLiteTensor* out_prob  = TfLiteInterpreterGetOutputTensor(interp_, 0);
+    const TfLiteTensor* out_state = TfLiteInterpreterGetOutputTensor(interp_, 1);
+
+    float prob = 0.0f;
+    litert_check(TfLiteTensorCopyToBuffer(out_prob, &prob, sizeof(float)),
+                 "CopyToBuffer(prob)");
+    litert_check(TfLiteTensorCopyToBuffer(out_state, state_.data(),
+                                          kStateSize * sizeof(float)),
+                 "CopyToBuffer(state_out)");
+
+    // Keep the last 64 samples of the chunk as next call's left context.
+    std::memcpy(context_.data(),
+                samples + (kChunkSamples - kContextSamples),
+                kContextSamples * sizeof(float));
+
+    return prob;
+}
+
+}  // namespace speech_core

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -1,0 +1,377 @@
+// Integration tests for the speech_core_models_litert target.
+//
+// Each test loads real .tflite models from $SPEECH_LITERT_MODEL_DIR and exercises
+// one LiteRT wrapper. Skipped (with exit code 0) when SPEECH_LITERT_MODEL_DIR is
+// unset or the expected files are missing — keeps CI green when models aren't
+// fetched.
+//
+// To run locally:
+//     scripts/download_models_litert.sh
+//     cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=/path/to/litert
+//     cmake --build build
+//     SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_parakeet_stt.h"
+#include "speech_core/models/litert_silero_vad.h"
+#include "speech_core/vad/streaming_vad.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+#define REQUIRE(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "  FAIL: %s (line %d)\n", #cond, __LINE__); \
+        ++failures; \
+        return; \
+    } \
+} while (0)
+
+bool file_exists(const std::string& path) {
+    std::ifstream f(path);
+    return f.good();
+}
+
+std::string env_model_dir() {
+    const char* env = std::getenv("SPEECH_LITERT_MODEL_DIR");
+    return env ? env : "";
+}
+
+std::string test_audio_path() {
+#ifdef SPEECH_CORE_TEST_DATA_DIR
+    return std::string(SPEECH_CORE_TEST_DATA_DIR) + "/test_audio.wav";
+#else
+    return "tests/data/test_audio.wav";
+#endif
+}
+
+struct WavData {
+    std::vector<float> samples;
+    int sample_rate = 0;
+};
+WavData load_wav_mono_pcm16(const std::string& path) {
+    WavData out;
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return out;
+
+    char riff[4], wave[4];
+    uint32_t file_size, fmt_size;
+    f.read(riff, 4);
+    f.read(reinterpret_cast<char*>(&file_size), 4);
+    f.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) return out;
+
+    char chunk_id[4];
+    uint32_t chunk_size;
+    uint16_t audio_format = 0, num_channels = 0, bits_per_sample = 0;
+    uint32_t sample_rate = 0;
+    bool have_fmt = false, have_data = false;
+
+    while (f.read(chunk_id, 4)) {
+        f.read(reinterpret_cast<char*>(&chunk_size), 4);
+        if (std::memcmp(chunk_id, "fmt ", 4) == 0) {
+            f.read(reinterpret_cast<char*>(&audio_format), 2);
+            f.read(reinterpret_cast<char*>(&num_channels), 2);
+            f.read(reinterpret_cast<char*>(&sample_rate), 4);
+            f.seekg(6, std::ios::cur);
+            f.read(reinterpret_cast<char*>(&bits_per_sample), 2);
+            if (chunk_size > 16) f.seekg(chunk_size - 16, std::ios::cur);
+            have_fmt = true;
+        } else if (std::memcmp(chunk_id, "data", 4) == 0) {
+            if (!have_fmt || audio_format != 1 || num_channels != 1 || bits_per_sample != 16) return out;
+            size_t n_samples = chunk_size / 2;
+            std::vector<int16_t> pcm(n_samples);
+            f.read(reinterpret_cast<char*>(pcm.data()), chunk_size);
+            out.samples.resize(n_samples);
+            for (size_t i = 0; i < n_samples; ++i) {
+                out.samples[i] = static_cast<float>(pcm[i]) / 32768.0f;
+            }
+            out.sample_rate = static_cast<int>(sample_rate);
+            have_data = true;
+            break;
+        } else {
+            f.seekg(chunk_size, std::ios::cur);
+        }
+    }
+    if (!have_data) out = {};
+    return out;
+}
+
+std::vector<float> generate_tone(int sample_rate, float freq, float seconds, float amp = 0.3f) {
+    size_t n = static_cast<size_t>(seconds * sample_rate);
+    std::vector<float> out(n);
+    for (size_t i = 0; i < n; ++i) {
+        out[i] = amp * std::sin(2.0f * static_cast<float>(M_PI) * freq * i / sample_rate);
+    }
+    return out;
+}
+
+std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+
+void test_litert_silero_vad(const std::string& dir) {
+    std::string model = dir + "/silero-vad.tflite";
+    if (!file_exists(model)) {
+        std::printf("  [skip] silero-vad.tflite not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_silero_vad ... ");
+
+    speech_core::LiteRTSileroVad vad(model);
+    REQUIRE(vad.input_sample_rate() == 16000);
+    REQUIRE(vad.chunk_size() == 512);
+
+    std::vector<float> silence(512, 0.0f);
+    float p_silence = vad.process_chunk(silence.data(), silence.size());
+    REQUIRE(p_silence >= 0.0f && p_silence <= 1.0f);
+
+    vad.reset();
+    auto tone = generate_tone(16000, 220.0f, 0.5f, 0.4f);
+    float p_tone_max = 0.0f;
+    for (size_t i = 0; i + 512 <= tone.size(); i += 512) {
+        float p = vad.process_chunk(tone.data() + i, 512);
+        if (p > p_tone_max) p_tone_max = p;
+    }
+    REQUIRE(p_tone_max > p_silence);
+
+    vad.reset();
+    float p_after_reset = vad.process_chunk(silence.data(), silence.size());
+    REQUIRE(std::abs(p_after_reset - p_silence) < 0.2f);
+
+    std::printf("ok (silence=%.3f tone_peak=%.3f)\n", p_silence, p_tone_max);
+}
+
+// ---------------------------------------------------------------------------
+// VAD on real speech — same fixture as the ORT test (test_audio.wav).
+// Asserts speech_start ∈ (3, 7) and speech_end ∈ (7, 10) seconds.
+// ---------------------------------------------------------------------------
+
+void test_litert_silero_vad_real_speech(const std::string& dir) {
+    std::string model = dir + "/silero-vad.tflite";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(model)) {
+        std::printf("  [skip] silero-vad.tflite not in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_silero_vad_real_speech ... ");
+
+    speech_core::LiteRTSileroVad vad(model);
+
+    auto audio_16k = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    REQUIRE(!audio_16k.empty());
+
+    constexpr size_t kChunk = 512;
+    const float chunk_dur = static_cast<float>(kChunk) / 16000.0f;
+    speech_core::StreamingVAD events(speech_core::VADConfig::silero_default(), chunk_dur);
+
+    float speech_start = -1.0f, speech_end = -1.0f;
+    for (size_t i = 0; i + kChunk <= audio_16k.size(); i += kChunk) {
+        float p = vad.process_chunk(audio_16k.data() + i, kChunk);
+        for (const auto& ev : events.process(p)) {
+            if (ev.type == speech_core::VADEvent::SpeechStarted && speech_start < 0)
+                speech_start = ev.start_time;
+            if (ev.type == speech_core::VADEvent::SpeechEnded)
+                speech_end = ev.end_time;
+        }
+    }
+    for (const auto& ev : events.flush()) {
+        if (ev.type == speech_core::VADEvent::SpeechEnded)
+            speech_end = ev.end_time;
+    }
+
+    std::printf("start=%.2fs end=%.2fs ", speech_start, speech_end);
+
+    REQUIRE(speech_start >= 3.0f && speech_start <= 7.0f);
+    REQUIRE(speech_end   >= 7.0f && speech_end   <= 10.0f);
+
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+
+void test_litert_parakeet_stt(const std::string& dir) {
+    std::string enc   = dir + "/parakeet-encoder.tflite";
+    std::string dec   = dir + "/parakeet-decoder-joint.tflite";
+    std::string vocab = dir + "/vocab.json";
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(vocab)) {
+        std::printf("  [skip] parakeet files not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_parakeet_stt ... ");
+
+    speech_core::LiteRTParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
+    REQUIRE(stt.input_sample_rate() == 16000);
+    REQUIRE(stt.supports_streaming());
+
+    std::vector<float> silence(16000 * 1, 0.0f);
+    auto result = stt.transcribe(silence.data(), silence.size(), 16000);
+    REQUIRE(result.confidence >= 0.0f && result.confidence <= 1.0f);
+
+    std::printf("ok (silence text=\"%s\" conf=%.3f)\n",
+                result.text.c_str(), result.confidence);
+}
+
+// ---------------------------------------------------------------------------
+// Parakeet on real speech — runs the fixture through LiteRT STT and checks
+// the transcript contains something. The fixture is short Spanish speech, so
+// we only assert non-empty output rather than expected content.
+// ---------------------------------------------------------------------------
+
+void test_litert_parakeet_real_speech(const std::string& dir) {
+    std::string enc   = dir + "/parakeet-encoder.tflite";
+    std::string dec   = dir + "/parakeet-decoder-joint.tflite";
+    std::string vocab = dir + "/vocab.json";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(vocab)) {
+        std::printf("  [skip] parakeet files not in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_parakeet_real_speech ... ");
+
+    speech_core::LiteRTParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
+
+    auto audio_16k = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    REQUIRE(!audio_16k.empty());
+
+    auto result = stt.transcribe(audio_16k.data(), audio_16k.size(), 16000);
+    std::printf("text=\"%s\" conf=%.3f lang=\"%s\" ",
+                result.text.c_str(), result.confidence, result.language.c_str());
+
+    REQUIRE(!result.text.empty());
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// VAD → STT pipeline e2e — runs the fixture through LiteRTSileroVad +
+// StreamingVAD to locate the speech segment, slices the audio at the detected
+// boundaries (with a small pre-/post-roll), and hands it to LiteRTParakeetStt.
+// Catches integration bugs between the two backends that the per-model real-
+// speech tests miss: window alignment, context-buffer state, off-by-one in
+// the speech-segment slice, language detection on truncated audio.
+// ---------------------------------------------------------------------------
+
+void test_litert_vad_to_stt_pipeline(const std::string& dir) {
+    std::string vad_model = dir + "/silero-vad.tflite";
+    std::string enc       = dir + "/parakeet-encoder.tflite";
+    std::string dec       = dir + "/parakeet-decoder-joint.tflite";
+    std::string vocab     = dir + "/vocab.json";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(vad_model) || !file_exists(enc) || !file_exists(dec) || !file_exists(vocab)) {
+        std::printf("  [skip] pipeline needs both silero and parakeet files in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_vad_to_stt_pipeline ... ");
+
+    auto audio_16k = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    REQUIRE(!audio_16k.empty());
+
+    // Stage 1: VAD → detect speech start/end (seconds).
+    speech_core::LiteRTSileroVad vad(vad_model);
+    constexpr size_t kChunk = 512;
+    const float chunk_dur = static_cast<float>(kChunk) / 16000.0f;
+    speech_core::StreamingVAD events(speech_core::VADConfig::silero_default(), chunk_dur);
+
+    float speech_start = -1.0f, speech_end = -1.0f;
+    for (size_t i = 0; i + kChunk <= audio_16k.size(); i += kChunk) {
+        float p = vad.process_chunk(audio_16k.data() + i, kChunk);
+        for (const auto& ev : events.process(p)) {
+            if (ev.type == speech_core::VADEvent::SpeechStarted && speech_start < 0)
+                speech_start = ev.start_time;
+            if (ev.type == speech_core::VADEvent::SpeechEnded)
+                speech_end = ev.end_time;
+        }
+    }
+    for (const auto& ev : events.flush()) {
+        if (ev.type == speech_core::VADEvent::SpeechEnded)
+            speech_end = ev.end_time;
+    }
+    REQUIRE(speech_start >= 0.0f);
+    REQUIRE(speech_end > speech_start);
+
+    // Stage 2: slice the detected segment with 100 ms pre/post-roll, clamped
+    // to the audio bounds.
+    constexpr float kPad = 0.10f;
+    size_t lo = static_cast<size_t>(std::max(0.0f, speech_start - kPad) * 16000.0f);
+    size_t hi = std::min(audio_16k.size(),
+                         static_cast<size_t>((speech_end + kPad) * 16000.0f));
+    REQUIRE(hi > lo);
+    std::vector<float> segment(audio_16k.begin() + lo, audio_16k.begin() + hi);
+
+    // Stage 3: STT on the segment.
+    speech_core::LiteRTParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
+    auto result = stt.transcribe(segment.data(), segment.size(), 16000);
+
+    std::printf("vad=[%.2fs..%.2fs] segment=%.2fs text=\"%s\" conf=%.3f lang=\"%s\" ",
+                speech_start, speech_end,
+                static_cast<float>(segment.size()) / 16000.0f,
+                result.text.c_str(), result.confidence, result.language.c_str());
+
+    REQUIRE(!result.text.empty());
+    std::printf("ok\n");
+}
+
+}  // namespace
+
+int main() {
+    std::string dir = env_model_dir();
+    if (dir.empty()) {
+        std::printf("SPEECH_LITERT_MODEL_DIR not set — skipping LiteRT model tests\n");
+        std::printf("(run scripts/download_models_litert.sh and re-run with "
+                    "SPEECH_LITERT_MODEL_DIR=scripts/models-litert)\n");
+        return 0;
+    }
+
+    std::printf("Running LiteRT model tests against %s\n", dir.c_str());
+
+    test_litert_silero_vad(dir);
+    test_litert_silero_vad_real_speech(dir);
+    test_litert_parakeet_stt(dir);
+    test_litert_parakeet_real_speech(dir);
+    test_litert_vad_to_stt_pipeline(dir);
+
+    if (failures > 0) {
+        std::fprintf(stderr, "\n%d test(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("\nAll LiteRT model tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

New `speech_core_models_litert` static library, parallel to `speech_core_models` (ORT), gated by `SPEECH_CORE_WITH_LITERT=ON`. Two new wrappers:

- `LiteRTSileroVad` implements `VADInterface` against `soniqo/Silero-VAD-v5-LiteRT`
- `LiteRTParakeetStt` implements `STTInterface` against `soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8`

Both backends can be enabled together; consumers link whichever combination they want.

### Scope

| Model | ORT | LiteRT |
|---|---|---|
| Silero VAD v5 | ✅ | ✅ (this PR) |
| Parakeet TDT 0.6B v3 | ✅ | ✅ (this PR) |
| Kokoro 82M | ✅ | ❌ no LiteRT export yet |
| DeepFilterNet3 | ✅ | ❌ no LiteRT export yet |

Kokoro / DeepFilter LiteRT wrappers will follow when `speech-models` ships `.tflite` exports.

### Implementation notes

- `LiteRTSileroVad` transparently manages the 64-sample left-context buffer the TFLite model expects (it takes `[1, 576]` vs the ORT `[1, 512]`).
- `LiteRTParakeetStt` reuses the mel preprocessor and TDT greedy decode shape from the ORT wrapper. The decoder-joint signature is `(encoder_out, target, h, c)` per the ai_edge_torch export — no separate `target_length`, and `h`/`c` are discrete instead of `input_states_1/_2`.
- `LiteRTEngine` is a header-only singleton wrapping the TFLite C API. CPU inference only in this initial cut; NNAPI / GPU / Hexagon delegates noted as follow-up.

### Local setup

```bash
scripts/setup_litert.sh                 # ~30 min — builds libtensorflowlite_c from TF source
scripts/download_models_litert.sh       # ~600 MB — pulls .tflite artifacts from soniqo HF
cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=\$PWD/build/litert
cmake --build build
SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
```

### Tests

`test_litert_models` (gated on `SPEECH_LITERT_MODEL_DIR`):
- silence vs tone smoke checks for both wrappers
- VAD on real speech — `tests/data/test_audio.wav`, asserts speech_start ∈ (3,7)s, end ∈ (7,10)s
- Parakeet on real speech — asserts non-empty transcript
- **VAD→STT pipeline e2e** — detects the speech segment via `LiteRTSileroVad` + `StreamingVAD`, slices it with 100 ms pre/post-roll, transcribes with `LiteRTParakeetStt`, asserts non-empty text

### CI

No LiteRT CI job in this PR — the TFLite build is ~30 min and would slow default CI substantially. Will land behind a cache + opt-in gate in a follow-up.

### Local validation

- Default build: 9/9 tests pass (no regression)
- ORT build: 10/10 tests pass (no regression)
- LiteRT configure correctly errors when `LITERT_DIR` missing
- LiteRT wrapper symbols verified against `tensorflow/lite/core/c/c_api.h`

## Test plan

- [ ] Default build green on macOS + Ubuntu
- [ ] ORT build green
- [ ] Reviewer can opt-in to local LiteRT validation via `scripts/setup_litert.sh`
- [ ] No surprise dependencies (LiteRT path entirely behind the flag)