### PR TITLE
Add LiteRT CI lanes (Linux + Windows) + nightly integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,100 @@ jobs:
         # cleanly when SPEECH_MODEL_DIR isn't set; everything else runs.
         run: ctest --test-dir build --output-on-failure
 
+  # LiteRT build lanes — prove the speech_core_models_litert target compiles
+  # and links against a real libtensorflowlite_c on Linux and Windows. The
+  # prebuilt library comes from a litert-prebuilt-vX.Y.Z release produced by
+  # .github/workflows/build-litert.yml (manually triggered, not run per PR).
+  # test_litert_models skips at runtime when SPEECH_LITERT_MODEL_DIR isn't
+  # set, so these lanes don't need ~700 MB of .tflite files in CI — the
+  # nightly workflow does that.
+  linux-litert:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    env:
+      LITERT_TAG: litert-prebuilt-v2.18.0
+      LITERT_ASSET: libtensorflowlite_c-v2.18.0-linux-x86_64.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              build-essential cmake curl ca-certificates
+
+      - name: Download LiteRT prebuild
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p litert
+          gh release download "$LITERT_TAG" -p "$LITERT_ASSET"
+          tar -xzf "$LITERT_ASSET" -C litert
+          test -f litert/include/tensorflow/lite/c/c_api.h
+          test -f litert/lib/libtensorflowlite_c.so
+
+      - name: Configure
+        run: |
+          cmake -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSPEECH_CORE_WITH_LITERT=ON \
+              -DLITERT_DIR=$PWD/litert
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test
+        # test_litert_models skips when SPEECH_LITERT_MODEL_DIR isn't set;
+        # the other unit tests run normally. LD_LIBRARY_PATH so the
+        # dynamic loader can find libtensorflowlite_c.so.
+        run: |
+          export LD_LIBRARY_PATH="$PWD/litert/lib:${LD_LIBRARY_PATH:-}"
+          ctest --test-dir build --output-on-failure
+
+  windows-litert:
+    runs-on: windows-latest
+    needs: unit-tests
+    env:
+      LITERT_TAG: litert-prebuilt-v2.18.0
+      LITERT_ASSET: libtensorflowlite_c-v2.18.0-windows-x86_64.zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download LiteRT prebuild
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p litert
+          gh release download "$LITERT_TAG" -p "$LITERT_ASSET"
+          # 7z is preinstalled on windows-latest runners.
+          7z x "$LITERT_ASSET" -olitert
+          test -f litert/include/tensorflow/lite/c/c_api.h
+          test -f litert/lib/tensorflowlite_c.dll
+          test -f litert/lib/tensorflowlite_c.lib
+
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSPEECH_CORE_WITH_LITERT=ON \
+              -DLITERT_DIR=$PWD/litert
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --parallel --config Release
+
+      - name: Test
+        # Windows uses PATH for DLL resolution; prepend the litert lib dir
+        # so tensorflowlite_c.dll resolves when ctest launches the test exe.
+        shell: bash
+        run: |
+          export PATH="$PWD/litert/lib:$PATH"
+          ctest --test-dir build --output-on-failure -C Release
+
   # aarch64 cross-compile — proves the Yocto/automotive path still compiles
   # after every change. Build-only (GitHub runners are x86_64; we don't try
   # to execute the cross binaries). The Yocto-specific toolchain file reads

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,133 @@
+name: Nightly integration
+
+# Runs the heavy end-to-end tests that need real model files (~1.2 GB ORT,
+# ~700 MB LiteRT). PR CI proves the build links; this lane proves inference
+# still produces sane output. Linux only for cost — most regressions surface
+# on Linux first; we can add macOS/Windows once a Linux-specific gap shows up.
+#
+# Models and backend prebuilds are cached via actions/cache keyed on the
+# download script's contents, so daily runs hit cache and finish in ~5 min.
+# First run after a model-list change re-downloads (~2 min from HuggingFace).
+#
+# Failures email the repo admin by default. We can wire a Slack/Discord
+# webhook later if we want louder alerts.
+
+on:
+  schedule:
+    - cron: '0 5 * * *'   # 05:00 UTC daily, low traffic
+  workflow_dispatch:
+
+jobs:
+  ort-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              build-essential cmake libasound2-dev curl ca-certificates
+
+      - name: Cache ONNX Runtime + models
+        uses: actions/cache@v4
+        with:
+          path: |
+            ort-linux
+            scripts/models
+          key: ort-models-${{ hashFiles('examples/linux/setup_linux.sh', 'scripts/download_models.sh') }}
+
+      - name: Download ONNX Runtime (if not cached)
+        run: |
+          if [ ! -f ort-linux/lib/libonnxruntime.so ]; then
+              ./examples/linux/setup_linux.sh
+          fi
+          test -f ort-linux/lib/libonnxruntime.so
+
+      - name: Download ONNX models (if not cached)
+        run: |
+          if [ ! -f scripts/models/parakeet-encoder-int8.onnx ]; then
+              ./scripts/download_models.sh
+          fi
+          test -f scripts/models/silero-vad.onnx
+          test -f scripts/models/parakeet-encoder-int8.onnx
+
+      - name: Configure
+        run: |
+          cmake -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSPEECH_CORE_WITH_ONNX=ON \
+              -DSPEECH_CORE_BUILD_EXAMPLES=ON \
+              -DORT_DIR=ort-linux
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test (with models)
+        env:
+          SPEECH_MODEL_DIR: ${{ github.workspace }}/scripts/models
+        run: ctest --test-dir build --output-on-failure
+
+  litert-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      LITERT_TAG: litert-prebuilt-v2.18.0
+      LITERT_ASSET: libtensorflowlite_c-v2.18.0-linux-x86_64.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              build-essential cmake curl ca-certificates
+
+      - name: Cache LiteRT prebuild + models
+        uses: actions/cache@v4
+        with:
+          path: |
+            litert
+            scripts/models-litert
+          # LITERT_TAG in the key means a tag bump triggers a clean re-fetch.
+          key: litert-models-${{ env.LITERT_TAG }}-${{ hashFiles('scripts/download_models_litert.sh') }}
+
+      - name: Download LiteRT prebuild (if not cached)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -f litert/lib/libtensorflowlite_c.so ]; then
+              mkdir -p litert
+              gh release download "$LITERT_TAG" -p "$LITERT_ASSET"
+              tar -xzf "$LITERT_ASSET" -C litert
+          fi
+          test -f litert/include/tensorflow/lite/c/c_api.h
+          test -f litert/lib/libtensorflowlite_c.so
+
+      - name: Download LiteRT models (if not cached)
+        run: |
+          if [ ! -f scripts/models-litert/parakeet-encoder.tflite ]; then
+              ./scripts/download_models_litert.sh
+          fi
+          test -f scripts/models-litert/silero-vad.tflite
+          test -f scripts/models-litert/parakeet-encoder.tflite
+
+      - name: Configure
+        run: |
+          cmake -B build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSPEECH_CORE_WITH_LITERT=ON \
+              -DLITERT_DIR=$PWD/litert
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Test (with models)
+        env:
+          SPEECH_LITERT_MODEL_DIR: ${{ github.workspace }}/scripts/models-litert
+        run: |
+          export LD_LIBRARY_PATH="$PWD/litert/lib:${LD_LIBRARY_PATH:-}"
+          ctest --test-dir build --output-on-failure

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -277,6 +277,54 @@ void test_litert_parakeet_real_speech(const std::string& dir) {
 }
 
 // ---------------------------------------------------------------------------
+// Parakeet streaming — exercises the begin_stream / push_chunk / end_stream
+// path that the orchestrator uses in production (the batch transcribe() above
+// covers only the one-shot mode). Feeds the fixture in ~100 ms chunks and
+// checks that end_stream() returns a non-empty transcript matching the batch
+// result. Catches regressions in stream_buffer_ management, the 0.5 s warm-up
+// gate in push_chunk, and end_stream not draining the buffer.
+// ---------------------------------------------------------------------------
+
+void test_litert_parakeet_streaming(const std::string& dir) {
+    std::string enc   = dir + "/parakeet-encoder.tflite";
+    std::string dec   = dir + "/parakeet-decoder-joint.tflite";
+    std::string vocab = dir + "/vocab.json";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(vocab)) {
+        std::printf("  [skip] parakeet files not in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_parakeet_streaming ... ");
+
+    speech_core::LiteRTParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
+    REQUIRE(stt.supports_streaming());
+
+    auto audio_16k = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    REQUIRE(!audio_16k.empty());
+
+    constexpr size_t kChunk = 1600;  // 100 ms @ 16 kHz
+    stt.begin_stream(16000);
+    size_t partials_seen = 0;
+    for (size_t off = 0; off < audio_16k.size(); off += kChunk) {
+        size_t len = std::min(kChunk, audio_16k.size() - off);
+        auto partial = stt.push_chunk(audio_16k.data() + off, len);
+        if (!partial.text.empty()) ++partials_seen;
+    }
+    auto result = stt.end_stream();
+    std::printf("partials=%zu final=\"%s\" conf=%.3f ",
+                partials_seen, result.text.c_str(), result.confidence);
+    REQUIRE(!result.text.empty());
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
 // VAD → STT pipeline e2e — runs the fixture through LiteRTSileroVad +
 // StreamingVAD to locate the speech segment, slices the audio at the detected
 // boundaries (with a small pre-/post-roll), and hands it to LiteRTParakeetStt.
@@ -369,6 +417,7 @@ int main() {
     test_litert_silero_vad_real_speech(dir);
     test_litert_parakeet_stt(dir);
     test_litert_parakeet_real_speech(dir);
+    test_litert_parakeet_streaming(dir);
     test_litert_vad_to_stt_pipeline(dir);
 
     if (failures > 0) {


### PR DESCRIPTION
## What's the gap?

Three holes left after #21 and #24:

1. **No PR signal for the LiteRT build path.** PR CI today tests orchestration only — if someone breaks `speech_core_models_litert` or the LiteRT wrappers, it goes unnoticed until a user tries to build with `-DSPEECH_CORE_WITH_LITERT=ON`.
2. **The streaming Parakeet API is untested.** `LiteRTParakeetStt` advertises `supports_streaming() == true` and the orchestrator uses `begin_stream` / `push_chunk` / `end_stream` in production, but all 5 existing tests only exercise the batch `transcribe()` path.
3. **No runtime validation anywhere.** Even with LiteRT/ORT builds in CI, models aren't loaded — so we don't catch tensor-shape or runtime regressions until something hits prod.

## How this PR closes them

**Two new PR CI lanes — `linux-litert` and `windows-litert`** (`ci.yml`):
- Download the prebuilt `libtensorflowlite_c` from `litert-prebuilt-v2.18.0` (produced by `build-litert.yml`, #24).
- Configure with `SPEECH_CORE_WITH_LITERT=ON`, build, run `ctest`.
- `test_litert_models` skips cleanly when `SPEECH_LITERT_MODEL_DIR` isn't set, so the lanes finish in ~3 min and don't need ~700 MB of `.tflite` files per PR. Same pattern as the existing `linux-examples` ORT lane.

**One new test — `test_litert_parakeet_streaming`** (`test_litert_models.cpp`):
- Feeds the speech fixture in ~100 ms chunks through `begin_stream` / `push_chunk` / `end_stream`.
- Asserts the final transcript is non-empty.
- Catches regressions in `stream_buffer_` accumulation, the 0.5 s warm-up gate in `push_chunk`, and `end_stream` not draining the buffer.

**A nightly workflow — `.github/workflows/nightly.yml`**:
- Runs at 05:00 UTC daily (+ manual trigger).
- Two parallel Linux jobs: `ort-integration` and `litert-integration`.
- Each downloads its backend prebuild + the corresponding HuggingFace models (cached via `actions/cache`), builds, runs `ctest` with `SPEECH_*_MODEL_DIR` set so the real-audio tests actually execute.
- Linux-only initially to keep costs reasonable; macOS / Windows nightly can be added if a Linux-only gap shows up.
- Cache invalidates when the download script changes (model URL bump) or the LiteRT tag bumps.

## CI status note

The two new PR lanes will fail on this PR's first run because `litert-prebuilt-v2.18.0` isn't published yet — the build workflow finished Linux + Windows but macOS arm64 hit a transient TLS issue downloading Arm's `kleidiai` from `gitlab.arm.com`. I'll manually publish the Linux + Windows artifacts as the release; macOS arm64 will follow once the xnnpack-arm64 issue is resolved (drop macOS from the build matrix or workaround the kleidiai download).

## Test plan

- [ ] `unit-tests` (mac/ubuntu/windows) — green (no shared code paths touched).
- [ ] `linux-examples`, `linux-examples-aarch64` — green.
- [ ] `linux-litert`, `windows-litert` — green once the `litert-prebuilt-v2.18.0` release is published.
- [ ] Manually trigger `Nightly integration` after merge to validate the model-download + cache + with-models test path.