### PR TITLE
build-litert: cap Linux parallelism, drop macOS arm64

### DIFF
--- a/.github/workflows/build-litert.yml
+++ b/.github/workflows/build-litert.yml
@@ -1,8 +1,9 @@
 name: Build LiteRT prebuilds
 
-# Produces libtensorflowlite_c.{so,dylib,dll} (+ headers) for Linux x86_64,
-# macOS arm64, and Windows x86_64, packaged so it can drop directly into
-# LITERT_DIR. Manually triggered — refresh whenever bumping TF version.
+# Produces libtensorflowlite_c.{so,dll} (+ headers) for Linux x86_64 and
+# Windows x86_64, packaged so it can drop directly into LITERT_DIR. Manually
+# triggered — refresh whenever bumping TF version. macOS arm64 is deferred
+# (kleidiai download flake from gitlab.arm.com).
 #
 # Pinned CMake 3.24 because the TFLite source tree's older subprojects
 # (xnnpack, fp16, etc.) declare deprecated CMake policies that newer CMake
@@ -29,10 +30,18 @@ jobs:
         include:
           - os: ubuntu-22.04
             platform: linux-x86_64
-          - os: macos-latest
-            platform: macos-arm64
+            # GH-hosted Linux runners have only ~7 GB usable RAM. Full-parallel
+            # TF compilation (4-wide) OOM-killed the runner at ~5 min; cap to
+            # 2 parallel jobs so peak memory stays under the limit.
+            build_jobs: 2
           - os: windows-latest
             platform: windows-x86_64
+            # Windows runners have more headroom and finished in ~18 min on
+            # full parallelism — keep as-is.
+            build_jobs: 0
+          # macOS arm64 deferred: xnnpack pulls in Arm's kleidiai library from
+          # gitlab.arm.com, which has intermittent TLS failures. Users on
+          # Apple Silicon can build locally with scripts/setup_litert.sh.
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
 
@@ -65,10 +74,15 @@ jobs:
       - name: Build tensorflowlite_c
         shell: bash
         run: |
-          cmake --build build --target tensorflowlite_c --config Release -j
+          # build_jobs=0 means "use all cores"; >0 caps parallelism.
+          if [[ "${{ matrix.build_jobs }}" == "0" ]]; then
+              cmake --build build --target tensorflowlite_c --config Release -j
+          else
+              cmake --build build --target tensorflowlite_c --config Release -j ${{ matrix.build_jobs }}
+          fi
 
-      - name: Package (Linux / macOS)
-        if: runner.os != 'Windows'
+      - name: Package (Linux)
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           PLATFORM=${{ matrix.platform }}
@@ -82,11 +96,7 @@ jobs:
           cp tensorflow-src/tensorflow/lite/core/c/c_api.h        $OUT/include/tensorflow/lite/core/c/
           cp tensorflow-src/tensorflow/lite/core/c/c_api_types.h  $OUT/include/tensorflow/lite/core/c/
           cp tensorflow-src/tensorflow/lite/core/c/common.h       $OUT/include/tensorflow/lite/core/c/
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-              cp build/libtensorflowlite_c.dylib $OUT/lib/
-          else
-              cp build/libtensorflowlite_c.so $OUT/lib/
-          fi
+          cp build/libtensorflowlite_c.so $OUT/lib/
           tar -czf libtensorflowlite_c-${{ inputs.tf_version }}-${PLATFORM}.tar.gz -C $OUT .
 
       - name: Package (Windows)
@@ -137,4 +147,4 @@ jobs:
           gh release create litert-prebuilt-${{ inputs.tf_version }} \
               artifacts/* \
               --title "LiteRT prebuilds ${{ inputs.tf_version }}" \
-              --notes "Prebuilt libtensorflowlite_c for Linux x86_64, macOS arm64, and Windows x86_64. Consumed by the linux-litert / windows-litert CI lanes; see scripts/setup_litert.sh for the equivalent local build recipe."
+              --notes "Prebuilt libtensorflowlite_c for Linux x86_64 and Windows x86_64. Consumed by the linux-litert / windows-litert CI lanes; see scripts/setup_litert.sh for the equivalent local build recipe (macOS users build locally — kleidiai/arm64 prebuild deferred)."


### PR DESCRIPTION
## What's broken

First run of \`build-litert.yml\` (#26456856382, against #24 as merged) revealed two issues:

| Platform | Result | Cause |
|---|---|---|
| Linux x86_64 | ✗ at 5m31s | Runner SIGKILLed mid-compile. \`ubuntu-22.04\` runners have ~7 GB usable RAM; full-parallel TF compile (4-wide) peaks above that. |
| Windows x86_64 | ✓ at 18m42s | — |
| macOS arm64 | ✗ at 2m38s | xnnpack pulls in Arm's kleidiai kernel library; the source ExternalProject downloads from \`gitlab.arm.com\`, which returns \"A bad protocol version\" on the TLS handshake intermittently. |

## Fix

- **Linux**: per-matrix \`build_jobs\` override. Linux gets \`-j 2\`; Windows keeps \`-j\` (full parallel). Pushed both into a single conditional in the build step.
- **macOS arm64**: dropped from the matrix. Apple Silicon users can still build locally with \`scripts/setup_litert.sh\` — that's the same source flow, just doesn't bake the bad gitlab.arm.com download into our CI dependency.

Net effect: the workflow now produces exactly the two artifacts the \`linux-litert\` and \`windows-litert\` CI lanes consume.

## Test plan

- [ ] Merge.
- [ ] Trigger \`Build LiteRT prebuilds\` from the Actions tab with \`create_release=true\`. Both Linux and Windows should finish and the \`litert-prebuilt-v2.18.0\` release should appear.
- [ ] Push to #25 to re-trigger its CI; the \`linux-litert\` and \`windows-litert\` lanes should now go green.