### PR TITLE
build-litert: ship builtin_ops.h with the prebuild

### DIFF
--- a/.github/workflows/build-litert.yml
+++ b/.github/workflows/build-litert.yml
@@ -90,6 +90,9 @@ jobs:
           mkdir -p $OUT/include/tensorflow/lite/c \
                    $OUT/include/tensorflow/lite/core/c \
                    $OUT/lib
+          # builtin_ops.h is transitively included by core/c/c_api.h and
+          # core/c/common.h, so it has to ship alongside them.
+          cp tensorflow-src/tensorflow/lite/builtin_ops.h     $OUT/include/tensorflow/lite/
           cp tensorflow-src/tensorflow/lite/c/c_api.h         $OUT/include/tensorflow/lite/c/
           cp tensorflow-src/tensorflow/lite/c/c_api_types.h   $OUT/include/tensorflow/lite/c/
           cp tensorflow-src/tensorflow/lite/c/common.h        $OUT/include/tensorflow/lite/c/
@@ -108,6 +111,9 @@ jobs:
           mkdir -p $OUT/include/tensorflow/lite/c \
                    $OUT/include/tensorflow/lite/core/c \
                    $OUT/lib
+          # builtin_ops.h is transitively included by core/c/c_api.h and
+          # core/c/common.h, so it has to ship alongside them.
+          cp tensorflow-src/tensorflow/lite/builtin_ops.h     $OUT/include/tensorflow/lite/
           cp tensorflow-src/tensorflow/lite/c/c_api.h         $OUT/include/tensorflow/lite/c/
           cp tensorflow-src/tensorflow/lite/c/c_api_types.h   $OUT/include/tensorflow/lite/c/
           cp tensorflow-src/tensorflow/lite/c/common.h        $OUT/include/tensorflow/lite/c/

--- a/scripts/setup_litert.sh
+++ b/scripts/setup_litert.sh
@@ -49,6 +49,9 @@ cmake --build . --target tensorflowlite_c -j
 mkdir -p "$OUT/include/tensorflow/lite/c" "$OUT/include/tensorflow/lite/core/c" "$OUT/lib"
 
 # Copy public C headers (only what the wrappers consume).
+# builtin_ops.h is transitively included by core/c/{c_api,common}.h, so it
+# has to ship alongside them.
+cp "$TF_SRC/tensorflow/lite/builtin_ops.h"         "$OUT/include/tensorflow/lite/"
 cp "$TF_SRC/tensorflow/lite/c/c_api.h"             "$OUT/include/tensorflow/lite/c/"
 cp "$TF_SRC/tensorflow/lite/c/c_api_types.h"       "$OUT/include/tensorflow/lite/c/"
 cp "$TF_SRC/tensorflow/lite/c/common.h"            "$OUT/include/tensorflow/lite/c/"


### PR DESCRIPTION
## What's broken

The \`linux-litert\` CI lane on #25 caught this when \`speech_core_models_litert\` tried to build against the freshly published \`litert-prebuilt-v2.18.0\` prebuild:

\`\`\`
litert/include/tensorflow/lite/core/c/c_api.h:28:10:
  fatal error: tensorflow/lite/builtin_ops.h: No such file or directory
\`\`\`

\`builtin_ops.h\` is included transitively by both \`tensorflow/lite/core/c/c_api.h\` and \`tensorflow/lite/core/c/common.h\`, but the packaging step in \`build-litert.yml\` only copied the six \`c/\`-prefixed headers — the top-level \`builtin_ops.h\` was missing.

The same bug was hiding in \`scripts/setup_litert.sh\` and only went unnoticed because nobody had finished a full TFLite source build locally yet (the user's previous attempts hit kleidiai/xnnpack issues and bailed before the header copy step would have mattered).

## Fix

Add the file to both packaging paths so the include set is self-contained. Three lines each.

## Test plan

- [ ] Merge.
- [ ] Re-trigger \`Build LiteRT prebuilds\` from the Actions tab with \`create_release=true\` — needs to overwrite the existing \`litert-prebuilt-v2.18.0\` release. (Bumping the tag to \`v2.18.0-r2\` would also work but means updating the consumer pin in \`ci.yml\`/\`nightly.yml\`; overwriting is simpler.)
- [ ] Push to #25 again; \`linux-litert\` / \`windows-litert\` lanes should compile cleanly this time.