### PR TITLE
build-litert: glob-copy C API headers (fixes async/c/types.h)

### DIFF
--- a/.github/workflows/build-litert.yml
+++ b/.github/workflows/build-litert.yml
@@ -87,18 +87,16 @@ jobs:
         run: |
           PLATFORM=${{ matrix.platform }}
           OUT=litert-${PLATFORM}
-          mkdir -p $OUT/include/tensorflow/lite/c \
-                   $OUT/include/tensorflow/lite/core/c \
-                   $OUT/lib
-          # builtin_ops.h is transitively included by core/c/c_api.h and
-          # core/c/common.h, so it has to ship alongside them.
-          cp tensorflow-src/tensorflow/lite/builtin_ops.h     $OUT/include/tensorflow/lite/
-          cp tensorflow-src/tensorflow/lite/c/c_api.h         $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/c/c_api_types.h   $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/c/common.h        $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/core/c/c_api.h        $OUT/include/tensorflow/lite/core/c/
-          cp tensorflow-src/tensorflow/lite/core/c/c_api_types.h  $OUT/include/tensorflow/lite/core/c/
-          cp tensorflow-src/tensorflow/lite/core/c/common.h       $OUT/include/tensorflow/lite/core/c/
+          mkdir -p $OUT/include/tensorflow/lite $OUT/lib
+          # Copy every .h under tensorflow/lite/{c,core/c,core/async/c} plus
+          # the top-level builtin_ops.h — these are what the C API includes
+          # transitively. Globbing is safer than enumerating one file at a
+          # time (cf. fix #27 for builtin_ops.h, this one for async/c/types.h).
+          cp tensorflow-src/tensorflow/lite/builtin_ops.h $OUT/include/tensorflow/lite/
+          for subdir in c core/c core/async/c; do
+              mkdir -p $OUT/include/tensorflow/lite/$subdir
+              cp tensorflow-src/tensorflow/lite/$subdir/*.h $OUT/include/tensorflow/lite/$subdir/
+          done
           cp build/libtensorflowlite_c.so $OUT/lib/
           tar -czf libtensorflowlite_c-${{ inputs.tf_version }}-${PLATFORM}.tar.gz -C $OUT .
 
@@ -108,18 +106,13 @@ jobs:
         run: |
           PLATFORM=${{ matrix.platform }}
           OUT=litert-${PLATFORM}
-          mkdir -p $OUT/include/tensorflow/lite/c \
-                   $OUT/include/tensorflow/lite/core/c \
-                   $OUT/lib
-          # builtin_ops.h is transitively included by core/c/c_api.h and
-          # core/c/common.h, so it has to ship alongside them.
-          cp tensorflow-src/tensorflow/lite/builtin_ops.h     $OUT/include/tensorflow/lite/
-          cp tensorflow-src/tensorflow/lite/c/c_api.h         $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/c/c_api_types.h   $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/c/common.h        $OUT/include/tensorflow/lite/c/
-          cp tensorflow-src/tensorflow/lite/core/c/c_api.h        $OUT/include/tensorflow/lite/core/c/
-          cp tensorflow-src/tensorflow/lite/core/c/c_api_types.h  $OUT/include/tensorflow/lite/core/c/
-          cp tensorflow-src/tensorflow/lite/core/c/common.h       $OUT/include/tensorflow/lite/core/c/
+          mkdir -p $OUT/include/tensorflow/lite $OUT/lib
+          # Same header set as Linux — see comment above.
+          cp tensorflow-src/tensorflow/lite/builtin_ops.h $OUT/include/tensorflow/lite/
+          for subdir in c core/c core/async/c; do
+              mkdir -p $OUT/include/tensorflow/lite/$subdir
+              cp tensorflow-src/tensorflow/lite/$subdir/*.h $OUT/include/tensorflow/lite/$subdir/
+          done
           cp build/Release/tensorflowlite_c.dll $OUT/lib/
           cp build/Release/tensorflowlite_c.lib $OUT/lib/
           # 7z is preinstalled on windows runners; use it to make a zip.

--- a/scripts/setup_litert.sh
+++ b/scripts/setup_litert.sh
@@ -46,18 +46,17 @@ cmake "$TF_SRC/tensorflow/lite/c" \
 echo "[setup_litert] Building tensorflowlite_c (this takes ~20-30 minutes)..."
 cmake --build . --target tensorflowlite_c -j
 
-mkdir -p "$OUT/include/tensorflow/lite/c" "$OUT/include/tensorflow/lite/core/c" "$OUT/lib"
+mkdir -p "$OUT/include/tensorflow/lite" "$OUT/lib"
 
-# Copy public C headers (only what the wrappers consume).
-# builtin_ops.h is transitively included by core/c/{c_api,common}.h, so it
-# has to ship alongside them.
-cp "$TF_SRC/tensorflow/lite/builtin_ops.h"         "$OUT/include/tensorflow/lite/"
-cp "$TF_SRC/tensorflow/lite/c/c_api.h"             "$OUT/include/tensorflow/lite/c/"
-cp "$TF_SRC/tensorflow/lite/c/c_api_types.h"       "$OUT/include/tensorflow/lite/c/"
-cp "$TF_SRC/tensorflow/lite/c/common.h"            "$OUT/include/tensorflow/lite/c/"
-cp "$TF_SRC/tensorflow/lite/core/c/c_api.h"        "$OUT/include/tensorflow/lite/core/c/"
-cp "$TF_SRC/tensorflow/lite/core/c/c_api_types.h"  "$OUT/include/tensorflow/lite/core/c/"
-cp "$TF_SRC/tensorflow/lite/core/c/common.h"       "$OUT/include/tensorflow/lite/core/c/"
+# Copy every .h under tensorflow/lite/{c,core/c,core/async/c} plus the top-level
+# builtin_ops.h. Globbing is safer than enumerating individual files — the C
+# API has transitive includes (builtin_ops.h, core/async/c/types.h, …) that
+# changed between TF releases.
+cp "$TF_SRC/tensorflow/lite/builtin_ops.h" "$OUT/include/tensorflow/lite/"
+for subdir in c core/c core/async/c; do
+    mkdir -p "$OUT/include/tensorflow/lite/$subdir"
+    cp "$TF_SRC/tensorflow/lite/$subdir"/*.h "$OUT/include/tensorflow/lite/$subdir/"
+done
 
 # Library
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## What's broken — round 2

#27 fixed \`builtin_ops.h\` and got the build past that include error. The next attempt at the \`linux-litert\` lane on #25 hit:

\`\`\`
litert/include/tensorflow/lite/core/c/c_api.h:29:10:
  fatal error: tensorflow/lite/core/async/c/types.h: No such file or directory
\`\`\`

Same shape of bug — another transitively-included header that the packaging step didn't copy. Enumerating files one at a time turns this into whack-a-mole: every release that adds an include in \`c_api.h\` breaks our package until we patch the script.

## Fix

Switch from enumerating individual files to globbing \`*.h\` in each known public-header directory:

- \`tensorflow/lite/builtin_ops.h\` (single file at the top level)
- \`tensorflow/lite/c/*.h\`
- \`tensorflow/lite/core/c/*.h\`
- \`tensorflow/lite/core/async/c/*.h\` (new — this is what was missing)

Same change in both \`build-litert.yml\` and \`scripts/setup_litert.sh\`. The packaging step now picks up new transitive headers under those directories automatically when TF adds them.

## Test plan

- [ ] Merge.
- [ ] Delete and re-publish the \`litert-prebuilt-v2.18.0\` release via Actions tab (\`create_release=true\`).
- [ ] Push to #25 once more; \`linux-litert\` / \`windows-litert\` should be green.