### PR TITLE
build-litert: auto-export all DLL symbols on Windows

### DIFF
--- a/.github/workflows/build-litert.yml
+++ b/.github/workflows/build-litert.yml
@@ -64,12 +64,18 @@ jobs:
         run: |
           mkdir -p build
           cd build
+          # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS auto-generates a .def file that
+          # exports every extern function from the DLL. Needed because TF
+          # v2.18's c_api headers reference TfLiteOperator* via inline alias
+          # functions, but the DLL only marks the older TfLiteRegistration*
+          # entry points with __declspec(dllexport). Harmless on non-Windows.
           cmake ../tensorflow-src/tensorflow/lite/c \
               -DCMAKE_BUILD_TYPE=Release \
               -DTFLITE_C_BUILD_SHARED_LIBS=ON \
               -DTFLITE_ENABLE_NNAPI=OFF \
               -DTFLITE_ENABLE_GPU=OFF \
-              -DTFLITE_ENABLE_METAL=OFF
+              -DTFLITE_ENABLE_METAL=OFF \
+              -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 
       - name: Build tensorflowlite_c
         shell: bash

--- a/scripts/setup_litert.sh
+++ b/scripts/setup_litert.sh
@@ -41,7 +41,8 @@ cmake "$TF_SRC/tensorflow/lite/c" \
     -DTFLITE_ENABLE_NNAPI=OFF \
     -DTFLITE_ENABLE_GPU=OFF \
     -DTFLITE_ENABLE_METAL=OFF \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 
 echo "[setup_litert] Building tensorflowlite_c (this takes ~20-30 minutes)..."
 cmake --build . --target tensorflowlite_c -j


### PR DESCRIPTION
## What's broken — round 3

Progress from #28: \`linux-litert\` lane went green. \`windows-litert\` failed at link time with ~30 unresolved \`__imp_TfLiteOperator*\` symbols.

\`\`\`
test_litert_models.obj : error LNK2019: unresolved external symbol
  __imp_TfLiteOperatorCreate referenced in function
  \"void __cdecl \`dynamic initializer for 'TfLiteRegistrationExternalCreate''\"
\`\`\`

## Root cause

TF v2.18's \`c_api.h\` declares inline alias functions like:

\`\`\`c
inline TfLiteRegistrationExternal* TfLiteRegistrationExternalCreate(...) {
    return TfLiteOperatorCreate(...);
}
\`\`\`

The DLL marks the older \`TfLiteRegistrationExternal*\` entry points with \`__declspec(dllexport)\`, but the newer \`TfLiteOperator*\` family (that the inlines call into) doesn't get the export attribute. So every TU that includes \`c_api.h\` synthesises a reference to \`__imp_TfLiteOperatorCreate\` etc., and the import library has no matching record.

## Fix

\`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON\` tells CMake to auto-generate a \`.def\` file that exports every extern function from the DLL, bypassing the missing \`__declspec(dllexport)\` attributes. Symbols of both API generations end up in the import library; the linker is happy.

Same flag added to \`scripts/setup_litert.sh\` for parity with local Windows users (when we have any). It's silently ignored on Linux/macOS builds.

## Test plan

- [ ] Merge.
- [ ] Delete and re-publish \`litert-prebuilt-v2.18.0\` (the DLL needs rebuilding with the new export setting).
- [ ] Push to #25 once more; \`windows-litert\` should join \`linux-litert\` in green.