### PR TITLE
Fix LiteRTSileroVad output ordering + tolerate missing ONNX model files

### DIFF
--- a/include/speech_core/models/litert_silero_vad.h
+++ b/include/speech_core/models/litert_silero_vad.h
@@ -34,6 +34,12 @@ private:
     static constexpr size_t kTotalSamples   = kContextSamples + kChunkSamples;  // 576
     static constexpr size_t kStateSize      = 2 * 1 * 128;
 
+    // Output indices vary between TFLite converter runs (it doesn't preserve
+    // the source model's output order). Resolved at construction by tensor
+    // byte size — prob = 1 float, state_out = 256 floats.
+    int prob_idx_  = -1;
+    int state_idx_ = -1;
+
     std::array<float, kContextSamples> context_{};
     std::array<float, kStateSize>      state_{};
     std::array<float, kTotalSamples>   input_buffer_{};

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -49,7 +49,13 @@ for entry in "${FILES[@]}"; do
 
     url="$BASE_URL/$repo/resolve/main/$rel"
     echo "[fetch] $rel"
-    curl -fL --retry 3 -o "$dest" "$url"
+    # Tolerate 404s so a single missing file (e.g. DeepFilterNet3-ONNX/deepfilter.onnx
+    # is not yet published) doesn't kill the whole download. The corresponding
+    # test_* function in test_models.cpp skips at runtime when its files are absent.
+    if ! curl -fL --retry 3 -o "$dest" "$url"; then
+        echo "[warn] $rel not available (HTTP error) — leaving missing"
+        rm -f "$dest"
+    fi
 done
 
 echo ""

--- a/src/models/litert/litert_silero_vad.cpp
+++ b/src/models/litert/litert_silero_vad.cpp
@@ -18,6 +18,19 @@ LiteRTSileroVad::LiteRTSileroVad(const std::string& model_path, bool hw_accel) {
                                  + std::to_string(in_count) + "/" + std::to_string(out_count));
     }
 
+    // Resolve output indices by byte size — the TFLite converter does not
+    // preserve the original output order, and the two outputs are unambiguously
+    // distinguishable: prob is exactly one float, state_out is 256 floats.
+    for (int i = 0; i < out_count; ++i) {
+        const TfLiteTensor* t = TfLiteInterpreterGetOutputTensor(interp_, i);
+        const size_t bytes = TfLiteTensorByteSize(t);
+        if      (bytes == sizeof(float))               prob_idx_  = i;
+        else if (bytes == kStateSize * sizeof(float))  state_idx_ = i;
+    }
+    if (prob_idx_ < 0 || state_idx_ < 0) {
+        throw std::runtime_error("LiteRT Silero: could not identify prob/state_out outputs by size");
+    }
+
     reset();
 }
 
@@ -53,8 +66,8 @@ float LiteRTSileroVad::process_chunk(const float* samples, size_t length) {
 
     litert_check(TfLiteInterpreterInvoke(interp_), "Invoke");
 
-    const TfLiteTensor* out_prob  = TfLiteInterpreterGetOutputTensor(interp_, 0);
-    const TfLiteTensor* out_state = TfLiteInterpreterGetOutputTensor(interp_, 1);
+    const TfLiteTensor* out_prob  = TfLiteInterpreterGetOutputTensor(interp_, prob_idx_);
+    const TfLiteTensor* out_state = TfLiteInterpreterGetOutputTensor(interp_, state_idx_);
 
     float prob = 0.0f;
     litert_check(TfLiteTensorCopyToBuffer(out_prob, &prob, sizeof(float)),


### PR DESCRIPTION
## Both bugs from the first nightly run

Nightly worked end-to-end as a regression catcher and surfaced two unrelated real bugs.

### Bug 1 — LiteRTSileroVad output indices

\`\`\`
[speech] Loading LiteRT model: silero-vad.tflite (threads=2)
terminate called after throwing an instance of 'std::runtime_error'
  what():  LiteRT: CopyToBuffer(prob) failed
\`\`\`

The wrapper assumed output[0] was the probability tensor and output[1] was the LSTM state. I verified against the published model:

\`\`\`
$ tflite Interpreter('silero-vad.tflite').get_output_details()
  idx=121 name=StatefulPartitionedCall:1 shape=[2, 1, 128] dtype=float32   # state
  idx=119 name=StatefulPartitionedCall:0 shape=[1, 1]      dtype=float32   # prob
\`\`\`

The TFLite converter reversed the output order — output[0] is the 256-float state, output[1] is the 1-float prob. \`TfLiteTensorCopyToBuffer\` then rejected \`sizeof(float)\` against the state tensor's 1024 bytes.

**Fix**: resolve the two indices at construction time by tensor byte size (1 float vs 256 floats — unambiguous). Robust to any future converter run that reorders outputs.

### Bug 2 — download_models.sh aborts on missing deepfilter.onnx

\`\`\`
[fetch] deepfilter.onnx
curl: (22) The requested URL returned error: 404
\`\`\`

Confirmed via the HF API — the file genuinely isn't in the repo:

\`\`\`
$ curl -s https://huggingface.co/api/models/aufklarer/DeepFilterNet3-ONNX | jq -r '.siblings[].rfilename'
.gitattributes
README.md
config.json
deepfilter-auxiliary.bin
\`\`\`

**Fix**: make per-file fetches non-fatal. On HTTP error, log a warning and continue. \`test_deepfilter\` in \`test_models.cpp\` already skips when its files are missing, so ORT nightly still validates Silero/Parakeet/Kokoro end-to-end.

## What this PR doesn't address

The Parakeet wrapper has the same shape of hard-coded output-index assumptions (encoder outputs [encoded, encoded_len], decoder outputs [logits, h, c]). Those may also be wrong but I didn't preemptively change them — the nightly after this lands will tell us. If they crash the same way, follow-up PR applies the same byte-size resolution pattern.

## Test plan

- [x] Default build green locally.
- [x] LiteRT wrapper syntax-checks against the v2.18.0 prebuilt headers.
- [ ] PR CI green (\`linux-litert\` / \`windows-litert\` build-only, won't exercise the fix).
- [ ] Manually trigger nightly after merge → \`litert-integration\` Silero VAD test passes; \`ort-integration\` skips deepfilter cleanly and runs the rest.