### PR TITLE
Add LiteRTVoxCPM2Tts skeleton (build-only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ if(SPEECH_CORE_WITH_LITERT)
     add_library(speech_core_models_litert
         src/models/litert/litert_silero_vad.cpp
         src/models/litert/litert_parakeet_stt.cpp
+        src/models/litert/litert_voxcpm2_tts.cpp
     )
 
     target_include_directories(speech_core_models_litert

--- a/docs/models.md
+++ b/docs/models.md
@@ -13,12 +13,15 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 
 ### LiteRT (TFLite) backend (`SPEECH_CORE_WITH_LITERT`)
 
-| Model | Interface | Header |
-|---|---|---|
-| `LiteRTSileroVad` | `VADInterface` | `speech_core/models/litert_silero_vad.h` |
-| `LiteRTParakeetStt` | `STTInterface` | `speech_core/models/litert_parakeet_stt.h` |
+| Model | Interface | Header | Status |
+|---|---|---|---|
+| `LiteRTSileroVad` | `VADInterface` | `speech_core/models/litert_silero_vad.h` | full |
+| `LiteRTParakeetStt` | `STTInterface` | `speech_core/models/litert_parakeet_stt.h` | full |
+| `LiteRTVoxCPM2Tts` | `TTSInterface` | `speech_core/models/litert_voxcpm2_tts.h` | **skeleton** |
 
 Kokoro 82M and DeepFilterNet3 do not yet have LiteRT exports — see `speech-models` for conversion status. When they land, wrappers will be added alongside the existing two.
+
+`LiteRTVoxCPM2Tts` is intentionally a load-and-validate skeleton: the constructor loads the four LiteRT graphs (`text-prefill`, `token-step`, `audio-encoder`, `audio-decoder`) and verifies the HF `tokenizer.json` exists, but `synthesize()` throws. The full orchestration loop (HF BPE tokenizer → `text_prefill` → `token_step` ×N → `audio_decode`, with explicit K/V cache handoff every step) is deferred to a follow-up.
 
 All ORT wrappers share an internal ONNX Runtime singleton (`OnnxEngine` in `speech_core/models/onnx_engine.h`) that owns the `OrtEnv` and `OrtMemoryInfo`. All LiteRT wrappers share `LiteRTEngine` (`speech_core/models/litert_engine.h`) which currently configures CPU-only inference with a configurable thread count. NNAPI / GPU / Hexagon delegates are not yet wired through the C API in this version.
 
@@ -132,6 +135,31 @@ auto result = stt.transcribe(audio, length, 16000);
 - Encoder INT8 weight-quantized (~595 MB on disk vs ~840 MB ONNX FP32), decoder-joint stays FP32 to avoid LSTM drift
 - Decoder-joint exposes `(encoder_out, target, h, c)` as four discrete tensors (ORT bundles `target_length` and uses suffix-`_1`/`_2` for h/c)
 - Model files: [soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) — `parakeet-encoder.tflite`, `parakeet-decoder-joint.tflite`, `vocab.json`
+
+## LiteRTVoxCPM2Tts (skeleton)
+
+```cpp
+#include <speech_core/models/litert_voxcpm2_tts.h>
+
+speech_core::LiteRTVoxCPM2Tts tts(
+    "/models/voxcpm2-text-prefill.tflite",
+    "/models/voxcpm2-token-step.tflite",
+    "/models/voxcpm2-audio-encoder.tflite",
+    "/models/voxcpm2-audio-decoder.tflite",
+    "/models/tokenizer.json");
+
+// tts.synthesize(...) currently throws std::runtime_error — skeleton only.
+```
+
+- 2B-parameter multilingual TTS, 48 kHz studio-quality output. Voice cloning and instruction-driven voice design supported by the upstream model.
+- Ships as **four** LiteRT graphs plus an HF BPE tokenizer:
+  - `text-prefill`: text + (optional) reference-audio prefix → LM hidden + initial K/V cache
+  - `token-step`: one autoregressive step (called up to 2048 times per generation), consumes and emits the K/V cache explicitly
+  - `audio-encoder`: 16 kHz PCM reference clip → conditioning features
+  - `audio-decoder`: latent → 48 kHz PCM output
+- **Constructor** loads all four graphs via `LiteRTEngine` and verifies the tokenizer file exists. **`synthesize()` throws** — the orchestration loop and the HF-tokenizer integration are deferred.
+- Bundle is large (~4.6 GB total). Download with the dedicated script `scripts/download_voxcpm2_litert.sh`; we deliberately don't include it in `download_models_litert.sh` because the bundle blows the standard nightly's `actions/cache` budget.
+- Model files: [aufklarer/VoxCPM2-LiteRT](https://huggingface.co/aufklarer/VoxCPM2-LiteRT) — `voxcpm2-{text-prefill,token-step,audio-encoder,audio-decoder}.tflite`, `tokenizer.json`, `config.json`
 
 ## KokoroTts
 

--- a/include/speech_core/models/litert_voxcpm2_tts.h
+++ b/include/speech_core/models/litert_voxcpm2_tts.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <tensorflow/lite/c/c_api.h>
+
+#include <string>
+
+namespace speech_core {
+
+/// VoxCPM2 — 2B-parameter multilingual TTS via LiteRT (TFLite).
+/// 48 kHz studio-quality output, voice cloning, instruction-driven voice design.
+/// Model: https://huggingface.co/aufklarer/VoxCPM2-LiteRT
+///
+/// Skeleton status (this file): the constructor loads the four LiteRT graphs
+/// and verifies the tokenizer file exists, but `synthesize()` throws — the
+/// orchestration loop (HF tokenizer → text_prefill → token_step ×N →
+/// audio_decode, with explicit K/V cache management) is deferred to a
+/// follow-up. The PR CI lanes prove that the wrapper compiles and links
+/// cleanly against `libtensorflowlite_c`; the load smoke test (when models
+/// are downloaded) proves the four graphs and tokenizer parse.
+class LiteRTVoxCPM2Tts : public TTSInterface {
+public:
+    /// Construct from the four LiteRT graph files + a HuggingFace `tokenizer.json`.
+    LiteRTVoxCPM2Tts(const std::string& text_prefill_path,
+                     const std::string& token_step_path,
+                     const std::string& audio_encoder_path,
+                     const std::string& audio_decoder_path,
+                     const std::string& tokenizer_path,
+                     bool hw_accel = false);
+    ~LiteRTVoxCPM2Tts() override;
+
+    // --- TTSInterface ---
+    void synthesize(const std::string& text,
+                    const std::string& language,
+                    TTSChunkCallback on_chunk) override;
+    int output_sample_rate() const override { return 48000; }
+    void cancel() override;
+
+private:
+    TfLiteModel*       text_prefill_model_   = nullptr;
+    TfLiteInterpreter* text_prefill_         = nullptr;
+    TfLiteModel*       token_step_model_     = nullptr;
+    TfLiteInterpreter* token_step_           = nullptr;
+    TfLiteModel*       audio_encoder_model_  = nullptr;
+    TfLiteInterpreter* audio_encoder_        = nullptr;
+    TfLiteModel*       audio_decoder_model_  = nullptr;
+    TfLiteInterpreter* audio_decoder_        = nullptr;
+
+    std::string tokenizer_path_;
+    bool        cancelled_ = false;
+};
+
+}  // namespace speech_core

--- a/scripts/download_voxcpm2_litert.sh
+++ b/scripts/download_voxcpm2_litert.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Download VoxCPM2 LiteRT model bundle (~4.6 GB) for the LiteRTVoxCPM2Tts
+# skeleton test. Kept separate from download_models_litert.sh because the
+# bundle is too large to fit comfortably in the nightly's actions/cache
+# budget (10 GB per repo, shared).
+#
+# Usage:
+#     scripts/download_voxcpm2_litert.sh [output_dir]
+#
+# Output defaults to scripts/models-voxcpm2/. Point the existing LiteRT
+# test runner at it via:
+#     SPEECH_LITERT_MODEL_DIR=scripts/models-voxcpm2 ctest --test-dir build
+
+set -euo pipefail
+
+BASE_URL="https://huggingface.co/aufklarer/VoxCPM2-LiteRT/resolve/main"
+OUT="${1:-$(dirname "$0")/models-voxcpm2}"
+mkdir -p "$OUT"
+
+FILES=(
+    "voxcpm2-text-prefill.tflite"
+    "voxcpm2-token-step.tflite"
+    "voxcpm2-audio-encoder.tflite"
+    "voxcpm2-audio-decoder.tflite"
+    "tokenizer.json"
+    "tokenizer_config.json"
+    "special_tokens_map.json"
+    "generation_config.json"
+    "config.json"
+)
+
+for rel in "${FILES[@]}"; do
+    dest="$OUT/$rel"
+    if [[ -f "$dest" && -s "$dest" ]]; then
+        echo "[skip] $rel (already exists)"
+        continue
+    fi
+    echo "[fetch] $rel"
+    if ! curl -fL --retry 3 -o "$dest" "$BASE_URL/$rel"; then
+        echo "[warn] $rel not available (HTTP error) — leaving missing"
+        rm -f "$dest"
+    fi
+done
+
+echo ""
+echo "VoxCPM2 LiteRT bundle downloaded to: $OUT"
+echo "Run the skeleton load test with:"
+echo "  SPEECH_LITERT_MODEL_DIR=$OUT ctest --test-dir build --output-on-failure -R test_litert_models"

--- a/src/models/litert/litert_voxcpm2_tts.cpp
+++ b/src/models/litert/litert_voxcpm2_tts.cpp
@@ -1,0 +1,66 @@
+#include "speech_core/models/litert_voxcpm2_tts.h"
+
+#include "speech_core/models/litert_engine.h"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace speech_core {
+
+LiteRTVoxCPM2Tts::LiteRTVoxCPM2Tts(const std::string& text_prefill_path,
+                                    const std::string& token_step_path,
+                                    const std::string& audio_encoder_path,
+                                    const std::string& audio_decoder_path,
+                                    const std::string& tokenizer_path,
+                                    bool hw_accel)
+    : tokenizer_path_(tokenizer_path)
+{
+    // The four graphs are independent .tflite files; load each via the shared
+    // LiteRT engine. The model handles are owned by this wrapper and freed in
+    // the dtor below (interpreter first, then model — required by the C API).
+    auto& engine = LiteRTEngine::get();
+    text_prefill_  = engine.load(text_prefill_path,  hw_accel, &text_prefill_model_);
+    token_step_    = engine.load(token_step_path,    hw_accel, &token_step_model_);
+    audio_encoder_ = engine.load(audio_encoder_path, hw_accel, &audio_encoder_model_);
+    audio_decoder_ = engine.load(audio_decoder_path, hw_accel, &audio_decoder_model_);
+
+    // The full pipeline needs a HuggingFace BPE tokenizer at runtime; for the
+    // skeleton we just verify the file is readable so a misconfiguration is
+    // caught at construction rather than during synthesize().
+    std::ifstream tf(tokenizer_path);
+    if (!tf) {
+        throw std::runtime_error("LiteRT VoxCPM2: tokenizer file not readable: "
+                                 + tokenizer_path);
+    }
+}
+
+LiteRTVoxCPM2Tts::~LiteRTVoxCPM2Tts() {
+    if (audio_decoder_)       TfLiteInterpreterDelete(audio_decoder_);
+    if (audio_decoder_model_) TfLiteModelDelete(audio_decoder_model_);
+    if (audio_encoder_)       TfLiteInterpreterDelete(audio_encoder_);
+    if (audio_encoder_model_) TfLiteModelDelete(audio_encoder_model_);
+    if (token_step_)          TfLiteInterpreterDelete(token_step_);
+    if (token_step_model_)    TfLiteModelDelete(token_step_model_);
+    if (text_prefill_)        TfLiteInterpreterDelete(text_prefill_);
+    if (text_prefill_model_)  TfLiteModelDelete(text_prefill_model_);
+}
+
+void LiteRTVoxCPM2Tts::synthesize(const std::string& /*text*/,
+                                   const std::string& /*language*/,
+                                   TTSChunkCallback /*on_chunk*/)
+{
+    // Skeleton: the full pipeline is text_prefill → token_step (×N) → audio_decode,
+    // with a HF BPE tokenizer for input and explicit K/V cache passed through
+    // every token_step call. Not yet implemented — this wrapper currently only
+    // proves the four graphs and the tokenizer file load cleanly.
+    throw std::runtime_error(
+        "LiteRTVoxCPM2Tts::synthesize is not implemented in the skeleton; "
+        "the wrapper currently only verifies the four LiteRT graphs and "
+        "tokenizer.json can be loaded.");
+}
+
+void LiteRTVoxCPM2Tts::cancel() {
+    cancelled_ = true;
+}
+
+}  // namespace speech_core

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -15,6 +15,7 @@
 #include "speech_core/interfaces.h"
 #include "speech_core/models/litert_parakeet_stt.h"
 #include "speech_core/models/litert_silero_vad.h"
+#include "speech_core/models/litert_voxcpm2_tts.h"
 #include "speech_core/vad/streaming_vad.h"
 
 #include <algorithm>
@@ -400,6 +401,30 @@ void test_litert_vad_to_stt_pipeline(const std::string& dir) {
     std::printf("ok\n");
 }
 
+// ---------------------------------------------------------------------------
+// VoxCPM2 skeleton load — proves the four LiteRT graphs and the HF tokenizer
+// file parse. The wrapper's synthesize() is intentionally a stub; this test
+// only covers what the skeleton does.
+// ---------------------------------------------------------------------------
+
+void test_litert_voxcpm2_load(const std::string& dir) {
+    std::string pref = dir + "/voxcpm2-text-prefill.tflite";
+    std::string step = dir + "/voxcpm2-token-step.tflite";
+    std::string enc  = dir + "/voxcpm2-audio-encoder.tflite";
+    std::string dec  = dir + "/voxcpm2-audio-decoder.tflite";
+    std::string tok  = dir + "/tokenizer.json";
+    if (!file_exists(pref) || !file_exists(step) || !file_exists(enc)
+        || !file_exists(dec) || !file_exists(tok)) {
+        std::printf("  [skip] voxcpm2 files not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_voxcpm2_load ... ");
+
+    speech_core::LiteRTVoxCPM2Tts tts(pref, step, enc, dec, tok, /*hw_accel=*/false);
+    REQUIRE(tts.output_sample_rate() == 48000);
+    std::printf("ok\n");
+}
+
 }  // namespace
 
 int main() {
@@ -419,6 +444,7 @@ int main() {
     test_litert_parakeet_real_speech(dir);
     test_litert_parakeet_streaming(dir);
     test_litert_vad_to_stt_pipeline(dir);
+    test_litert_voxcpm2_load(dir);
 
     if (failures > 0) {
         std::fprintf(stderr, "\n%d test(s) failed\n", failures);


### PR DESCRIPTION
## What this is

A **build-only skeleton** of a TTSInterface backed by [aufklarer/VoxCPM2-LiteRT](https://huggingface.co/aufklarer/VoxCPM2-LiteRT) — a 2B-parameter multilingual TTS that ships as **four** separate LiteRT graphs (text-prefill, token-step, audio-encoder, audio-decoder) plus an HF BPE tokenizer.

Scope was set by the user request: "build skeleton". Real synth comes in a follow-up.

## What ships

| File | Purpose |
|------|---------|
| `include/speech_core/models/litert_voxcpm2_tts.h` | `TTSInterface` subclass declaration |
| `src/models/litert/litert_voxcpm2_tts.cpp` | Constructor loads all four graphs via the existing `LiteRTEngine` and verifies the tokenizer file is readable. `synthesize()` throws \`std::runtime_error\`. |
| `CMakeLists.txt` | New \`.cpp\` picked up under `speech_core_models_litert` — Linux/Windows LiteRT CI lanes (added in #25) build it automatically. |
| `tests/test_litert_models.cpp` | New \`test_litert_voxcpm2_load\` smoke test that instantiates the wrapper when model files are present, skips cleanly otherwise. |
| `scripts/download_voxcpm2_litert.sh` | Standalone fetch script — bundle is ~4.6 GB so it's deliberately not added to \`download_models_litert.sh\` (would blow the nightly's actions/cache budget). |
| `docs/models.md` | New section explicitly labelling the wrapper "skeleton" with the four graphs + tokenizer documented. |

## Deferred (next PR)

- HF BPE tokenizer integration. speech-core has no BPE tokenizer today — design call: bring in `tokenizers-cpp` as a dep, or port a minimal subset.
- The 4-graph orchestration loop: `text_prefill → token_step (×N, up to 2048) → audio_decode`, with explicit K/V cache handed in/out of every \`token_step\`.
- Voice cloning via \`audio_encoder\`.
- Voice design via the upstream model's natural-language style control.

## Test plan

- [x] Default build green locally (9/9).
- [x] Skeleton syntax-checks against the v2.18.0 LiteRT headers locally.
- [ ] PR CI green — \`linux-litert\` and \`windows-litert\` link the new wrapper into \`speech_core_models_litert\` successfully.
- [ ] (Optional) Run the load test locally after \`scripts/download_voxcpm2_litert.sh\` and \`SPEECH_LITERT_MODEL_DIR=scripts/models-voxcpm2 ctest\`.