### PR TITLE
Add VoxCPM2Tokenizer (hand-rolled BPE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/litert_silero_vad.cpp
         src/models/litert/litert_parakeet_stt.cpp
         src/models/litert/litert_voxcpm2_tts.cpp
+        src/models/litert/voxcpm2_tokenizer.cpp
     )
 
     target_include_directories(speech_core_models_litert

--- a/include/speech_core/models/litert_voxcpm2_tts.h
+++ b/include/speech_core/models/litert_voxcpm2_tts.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "speech_core/interfaces.h"
+#include "speech_core/models/voxcpm2_tokenizer.h"
 
 #include <tensorflow/lite/c/c_api.h>
 
+#include <memory>
 #include <string>
 
 namespace speech_core {
@@ -47,8 +49,8 @@ private:
     TfLiteModel*       audio_decoder_model_  = nullptr;
     TfLiteInterpreter* audio_decoder_        = nullptr;
 
-    std::string tokenizer_path_;
-    bool        cancelled_ = false;
+    std::unique_ptr<VoxCPM2Tokenizer> tokenizer_;
+    bool                              cancelled_ = false;
 };
 
 }  // namespace speech_core

--- a/include/speech_core/models/voxcpm2_tokenizer.h
+++ b/include/speech_core/models/voxcpm2_tokenizer.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace speech_core {
+
+/// VoxCPM2 BPE tokenizer.
+///
+/// Loads `tokenizer.json` (HuggingFace `tokenizers` format) and reproduces the
+/// reference encode / decode pipeline:
+///
+///   encode(text):
+///     1. Normalize: prepend ▁, replace each ' ' with ▁ (SentencePiece-style)
+///     2. BPE on Unicode codepoints with byte fallback (<0xXX> for codepoints
+///        absent from the vocab)
+///     3. Post-process: prepend BOS (<s>, id=1)
+///
+///   decode(ids):
+///     1. Skip special tokens
+///     2. Join token strings
+///     3. Replace ▁ with space, collapse consecutive <0xXX> back into raw bytes
+///     4. Strip the single leading space introduced by the normalizer
+///
+/// Hand-rolled instead of pulling tokenizers-cpp because the latter brings a
+/// Rust toolchain dependency that breaks our Android cross-compile and Yocto
+/// build paths. The tokenizer model is fixed (VoxCPM2 doesn't update it
+/// across releases), so a targeted reimplementation has the same correctness
+/// profile as the wrapper would, at zero extra build cost.
+class VoxCPM2Tokenizer {
+public:
+    explicit VoxCPM2Tokenizer(const std::string& tokenizer_json_path);
+
+    /// Encode UTF-8 text → token IDs, including the BOS prefix.
+    std::vector<int> encode(const std::string& text) const;
+
+    /// Decode token IDs → UTF-8 text. Special tokens are skipped.
+    std::string decode(const std::vector<int>& ids) const;
+
+    int bos_id() const { return bos_id_; }
+    int eos_id() const { return eos_id_; }
+    int unk_id() const { return unk_id_; }
+
+    size_t vocab_size() const { return id_to_token_.size(); }
+
+private:
+    // vocab_["▁hello"] = 31986;  id_to_token_[31986] = "▁hello"
+    std::unordered_map<std::string, int> vocab_;
+    std::vector<std::string>             id_to_token_;
+
+    // merge_rank_["▁ t"] = 4  → merge ("▁","t") at priority 4 (lower = first)
+    std::unordered_map<std::string, int> merge_rank_;
+
+    // Special tokens are skipped during decode and never participate in BPE.
+    std::unordered_set<int> special_ids_;
+
+    int  bos_id_         = 1;
+    int  eos_id_         = 2;
+    int  unk_id_         = 0;
+    bool byte_fallback_  = false;
+
+    // Cached <0x00>..<0xFF> → ID (only populated if byte_fallback_ is true).
+    std::vector<int> byte_token_ids_;  // index by byte value, -1 if missing
+
+    // BPE engine — operates on already-normalized text.
+    std::vector<int> bpe(const std::string& word) const;
+};
+
+}  // namespace speech_core

--- a/src/models/litert/litert_voxcpm2_tts.cpp
+++ b/src/models/litert/litert_voxcpm2_tts.cpp
@@ -2,7 +2,6 @@
 
 #include "speech_core/models/litert_engine.h"
 
-#include <fstream>
 #include <stdexcept>
 
 namespace speech_core {
@@ -13,7 +12,6 @@ LiteRTVoxCPM2Tts::LiteRTVoxCPM2Tts(const std::string& text_prefill_path,
                                     const std::string& audio_decoder_path,
                                     const std::string& tokenizer_path,
                                     bool hw_accel)
-    : tokenizer_path_(tokenizer_path)
 {
     // The four graphs are independent .tflite files; load each via the shared
     // LiteRT engine. The model handles are owned by this wrapper and freed in
@@ -24,14 +22,9 @@ LiteRTVoxCPM2Tts::LiteRTVoxCPM2Tts(const std::string& text_prefill_path,
     audio_encoder_ = engine.load(audio_encoder_path, hw_accel, &audio_encoder_model_);
     audio_decoder_ = engine.load(audio_decoder_path, hw_accel, &audio_decoder_model_);
 
-    // The full pipeline needs a HuggingFace BPE tokenizer at runtime; for the
-    // skeleton we just verify the file is readable so a misconfiguration is
-    // caught at construction rather than during synthesize().
-    std::ifstream tf(tokenizer_path);
-    if (!tf) {
-        throw std::runtime_error("LiteRT VoxCPM2: tokenizer file not readable: "
-                                 + tokenizer_path);
-    }
+    // Tokenizer is parsed at construction so a malformed tokenizer.json is
+    // caught immediately rather than on the first synthesize() call.
+    tokenizer_ = std::make_unique<VoxCPM2Tokenizer>(tokenizer_path);
 }
 
 LiteRTVoxCPM2Tts::~LiteRTVoxCPM2Tts() {

--- a/src/models/litert/voxcpm2_tokenizer.cpp
+++ b/src/models/litert/voxcpm2_tokenizer.cpp
@@ -1,0 +1,336 @@
+#include "speech_core/models/voxcpm2_tokenizer.h"
+
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+
+namespace speech_core {
+
+// SentencePiece-style space marker: U+2581 LOWER ONE EIGHTH BLOCK ("▁").
+// Spaces are replaced with this single Unicode character before BPE so the
+// tokenizer can recover word boundaries during decode.
+static constexpr const char* kSpaceMarker = "\xE2\x96\x81";
+
+// ---------------------------------------------------------------------------
+// JSON helpers — minimal, scoped to this file because util/json.h doesn't
+// expose nested-object navigation. tokenizer.json is too large for the flat
+// parser and we don't want to add a JSON dependency just for this file.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Find the value substring for "key" within an object `s[i..end]`. Returns
+// the index of the first char of the value (past the colon and whitespace),
+// or std::string::npos if not found. Assumes `i` points just inside `{`.
+size_t find_member(const std::string& s, size_t i, size_t end, const std::string& key) {
+    while (i < end) {
+        ::json::skip_ws(s, i);
+        if (i >= end || s[i] == '}') return std::string::npos;
+        if (s[i] == ',') { ++i; continue; }
+
+        size_t key_start = i;
+        std::string k = ::json::parse_string(s, i);
+        (void)key_start;
+        ::json::skip_ws(s, i);
+        if (i < end && s[i] == ':') ++i;
+        ::json::skip_ws(s, i);
+        if (k == key) return i;
+        ::json::skip_value(s, i);
+    }
+    return std::string::npos;
+}
+
+// Parse an integer token literal (no exponent, no fraction) at position `i`.
+int parse_int(const std::string& s, size_t& i) {
+    bool neg = false;
+    if (i < s.size() && s[i] == '-') { neg = true; ++i; }
+    long long val = 0;
+    while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+        val = val * 10 + (s[i] - '0');
+        ++i;
+    }
+    return static_cast<int>(neg ? -val : val);
+}
+
+// Parse a bool literal ("true" / "false") at position `i`.
+bool parse_bool(const std::string& s, size_t& i) {
+    if (i + 3 < s.size() && std::strncmp(&s[i], "true", 4) == 0) { i += 4; return true; }
+    if (i + 4 < s.size() && std::strncmp(&s[i], "false", 5) == 0) { i += 5; return false; }
+    return false;
+}
+
+// Decompose a UTF-8 string into a vector of "characters" (each a 1–4 byte
+// substring representing one Unicode codepoint). Invalid sequences pass
+// through one byte at a time.
+std::vector<std::string> utf8_chars(const std::string& s) {
+    std::vector<std::string> out;
+    out.reserve(s.size());
+    size_t i = 0;
+    while (i < s.size()) {
+        unsigned char c = static_cast<unsigned char>(s[i]);
+        size_t len = 1;
+        if      ((c & 0x80) == 0x00) len = 1;
+        else if ((c & 0xE0) == 0xC0) len = 2;
+        else if ((c & 0xF0) == 0xE0) len = 3;
+        else if ((c & 0xF8) == 0xF0) len = 4;
+        // Clamp in case the buffer is truncated mid-codepoint.
+        if (i + len > s.size()) len = s.size() - i;
+        out.emplace_back(s.substr(i, len));
+        i += len;
+    }
+    return out;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Constructor: parse tokenizer.json
+// ---------------------------------------------------------------------------
+
+VoxCPM2Tokenizer::VoxCPM2Tokenizer(const std::string& path) {
+    std::string text = ::json::read_file(path);
+    if (text.empty()) {
+        throw std::runtime_error("VoxCPM2Tokenizer: cannot read " + path);
+    }
+
+    // Find the root object.
+    size_t root = 0;
+    ::json::skip_ws(text, root);
+    if (root >= text.size() || text[root] != '{') {
+        throw std::runtime_error("VoxCPM2Tokenizer: tokenizer.json is not a JSON object");
+    }
+    ++root;
+    const size_t end = text.size();
+
+    // --- added_tokens: array of {id, content, special} ---
+    size_t at_pos = find_member(text, root, end, "added_tokens");
+    if (at_pos != std::string::npos && at_pos < end && text[at_pos] == '[') {
+        size_t p = at_pos + 1;
+        while (p < end) {
+            ::json::skip_ws(text, p);
+            if (p >= end || text[p] == ']') break;
+            if (text[p] == ',') { ++p; continue; }
+            if (text[p] != '{') { ++p; continue; }
+
+            size_t obj_start = p + 1;
+            size_t obj_end_scan = p;
+            ::json::skip_value(text, obj_end_scan);
+            const size_t obj_end = obj_end_scan;
+
+            int  id = -1;
+            std::string content;
+            bool special = false;
+            for (auto key : {"id", "content", "special"}) {
+                size_t v = find_member(text, obj_start, obj_end, key);
+                if (v == std::string::npos) continue;
+                if (std::strcmp(key, "id") == 0) {
+                    id = parse_int(text, v);
+                } else if (std::strcmp(key, "content") == 0) {
+                    content = ::json::parse_string(text, v);
+                } else if (std::strcmp(key, "special") == 0) {
+                    special = parse_bool(text, v);
+                }
+            }
+            if (id >= 0 && !content.empty()) {
+                if (static_cast<int>(id_to_token_.size()) <= id) id_to_token_.resize(id + 1);
+                id_to_token_[id] = content;
+                vocab_[content] = id;
+                if (special) {
+                    special_ids_.insert(id);
+                    if      (content == "<s>")   bos_id_ = id;
+                    else if (content == "</s>")  eos_id_ = id;
+                    else if (content == "<unk>") unk_id_ = id;
+                }
+            }
+            p = obj_end;
+        }
+    }
+
+    // --- model.* ---
+    size_t model_pos = find_member(text, root, end, "model");
+    if (model_pos == std::string::npos || text[model_pos] != '{') {
+        throw std::runtime_error("VoxCPM2Tokenizer: missing model object");
+    }
+    const size_t model_inner = model_pos + 1;
+    size_t model_end_scan = model_pos;
+    ::json::skip_value(text, model_end_scan);
+    const size_t model_end = model_end_scan;
+
+    // byte_fallback
+    size_t bf = find_member(text, model_inner, model_end, "byte_fallback");
+    if (bf != std::string::npos) byte_fallback_ = parse_bool(text, bf);
+
+    // vocab: {"token": id, ...}
+    size_t vocab_pos = find_member(text, model_inner, model_end, "vocab");
+    if (vocab_pos == std::string::npos || text[vocab_pos] != '{') {
+        throw std::runtime_error("VoxCPM2Tokenizer: missing model.vocab");
+    }
+    size_t v = vocab_pos + 1;
+    while (v < model_end) {
+        ::json::skip_ws(text, v);
+        if (v >= model_end || text[v] == '}') break;
+        if (text[v] == ',') { ++v; continue; }
+
+        std::string tok = ::json::parse_string(text, v);
+        ::json::skip_ws(text, v);
+        if (v < model_end && text[v] == ':') ++v;
+        ::json::skip_ws(text, v);
+        int id = parse_int(text, v);
+        if (static_cast<int>(id_to_token_.size()) <= id) id_to_token_.resize(id + 1);
+        // added_tokens parsed above take precedence (already populated); for any
+        // overlap we keep the existing mapping. For non-added tokens this just
+        // assigns the standard vocab entry.
+        if (vocab_.find(tok) == vocab_.end()) {
+            vocab_[tok] = id;
+            id_to_token_[id] = tok;
+        }
+    }
+
+    // merges: ["left right", ...]  (lower index = higher merge priority)
+    size_t merges_pos = find_member(text, model_inner, model_end, "merges");
+    if (merges_pos == std::string::npos || text[merges_pos] != '[') {
+        throw std::runtime_error("VoxCPM2Tokenizer: missing model.merges");
+    }
+    size_t m = merges_pos + 1;
+    int merge_idx = 0;
+    while (m < model_end) {
+        ::json::skip_ws(text, m);
+        if (m >= model_end || text[m] == ']') break;
+        if (text[m] == ',') { ++m; continue; }
+        if (text[m] != '"') { ++m; continue; }
+        std::string entry = ::json::parse_string(text, m);
+        merge_rank_[entry] = merge_idx++;
+    }
+
+    // Cache byte-fallback token IDs for 0x00..0xFF.
+    if (byte_fallback_) {
+        byte_token_ids_.assign(256, -1);
+        char buf[8];
+        for (int b = 0; b < 256; ++b) {
+            std::snprintf(buf, sizeof(buf), "<0x%02X>", b);
+            auto it = vocab_.find(buf);
+            if (it != vocab_.end()) byte_token_ids_[b] = it->second;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encode
+// ---------------------------------------------------------------------------
+
+std::vector<int> VoxCPM2Tokenizer::encode(const std::string& text) const {
+    // Normalize: prepend ▁ and replace every space with ▁.
+    std::string normalized = kSpaceMarker;
+    for (char c : text) {
+        if (c == ' ') normalized += kSpaceMarker;
+        else          normalized += c;
+    }
+    // Empty input still receives the BOS prefix but no content tokens.
+    std::vector<int> out;
+    out.push_back(bos_id_);
+    if (text.empty()) return out;
+
+    auto ids = bpe(normalized);
+    out.insert(out.end(), ids.begin(), ids.end());
+    return out;
+}
+
+std::vector<int> VoxCPM2Tokenizer::bpe(const std::string& word) const {
+    // Initial token list: one entry per Unicode codepoint. Codepoints not in
+    // the vocab are split into their UTF-8 bytes (byte fallback).
+    std::vector<std::string> tokens;
+    for (const auto& ch : utf8_chars(word)) {
+        if (vocab_.find(ch) != vocab_.end()) {
+            tokens.push_back(ch);
+        } else if (byte_fallback_) {
+            for (unsigned char b : ch) {
+                char buf[8];
+                std::snprintf(buf, sizeof(buf), "<0x%02X>", b);
+                tokens.emplace_back(buf);
+            }
+        } else {
+            tokens.push_back(ch);  // will resolve to <unk> below if missing
+        }
+    }
+
+    // Greedy lowest-rank-pair merging. O(N^2) but each step shrinks the list
+    // and inputs are short prompts — fine for TTS-scale text.
+    while (tokens.size() >= 2) {
+        int  best_rank = std::numeric_limits<int>::max();
+        long best_idx  = -1;
+        for (size_t i = 0; i + 1 < tokens.size(); ++i) {
+            std::string key = tokens[i] + ' ' + tokens[i + 1];
+            auto it = merge_rank_.find(key);
+            if (it != merge_rank_.end() && it->second < best_rank) {
+                best_rank = it->second;
+                best_idx  = static_cast<long>(i);
+            }
+        }
+        if (best_idx < 0) break;
+        tokens[best_idx] = tokens[best_idx] + tokens[best_idx + 1];
+        tokens.erase(tokens.begin() + best_idx + 1);
+    }
+
+    // Resolve each token to its ID; missing → <unk>.
+    std::vector<int> ids;
+    ids.reserve(tokens.size());
+    for (const auto& t : tokens) {
+        auto it = vocab_.find(t);
+        ids.push_back(it != vocab_.end() ? it->second : unk_id_);
+    }
+    return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Decode
+// ---------------------------------------------------------------------------
+
+std::string VoxCPM2Tokenizer::decode(const std::vector<int>& ids) const {
+    std::string out;
+    // Buffer for collapsing consecutive <0xXX> tokens back into raw bytes
+    // before they hit the rest of the decoder pipeline.
+    std::vector<unsigned char> byte_buf;
+    auto flush_bytes = [&]() {
+        if (byte_buf.empty()) return;
+        out.append(reinterpret_cast<const char*>(byte_buf.data()), byte_buf.size());
+        byte_buf.clear();
+    };
+
+    for (int id : ids) {
+        if (special_ids_.count(id)) { flush_bytes(); continue; }
+        if (id < 0 || id >= static_cast<int>(id_to_token_.size())) continue;
+        const std::string& tok = id_to_token_[id];
+        if (tok.empty()) continue;
+
+        // Detect byte-fallback tokens: literal "<0xXX>" (6 chars).
+        if (tok.size() == 6 && tok[0] == '<' && tok[1] == '0' && tok[2] == 'x' && tok.back() == '>') {
+            unsigned int b = 0;
+            if (std::sscanf(tok.c_str() + 3, "%2X", &b) == 1) {
+                byte_buf.push_back(static_cast<unsigned char>(b));
+                continue;
+            }
+        }
+        flush_bytes();
+
+        // Replace ▁ with space inside the token.
+        for (size_t j = 0; j < tok.size(); ) {
+            if (j + 3 <= tok.size() && std::memcmp(&tok[j], kSpaceMarker, 3) == 0) {
+                out += ' ';
+                j += 3;
+            } else {
+                out += tok[j++];
+            }
+        }
+    }
+    flush_bytes();
+
+    // Strip the single leading space introduced by the normalizer.
+    if (!out.empty() && out.front() == ' ') out.erase(out.begin());
+    return out;
+}
+
+}  // namespace speech_core

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -16,6 +16,7 @@
 #include "speech_core/models/litert_parakeet_stt.h"
 #include "speech_core/models/litert_silero_vad.h"
 #include "speech_core/models/litert_voxcpm2_tts.h"
+#include "speech_core/models/voxcpm2_tokenizer.h"
 #include "speech_core/vad/streaming_vad.h"
 
 #include <algorithm>
@@ -425,6 +426,60 @@ void test_litert_voxcpm2_load(const std::string& dir) {
     std::printf("ok\n");
 }
 
+// ---------------------------------------------------------------------------
+// VoxCPM2 tokenizer — pins encode/decode to the reference output from the
+// Python HuggingFace `tokenizers` library against the published
+// tokenizer.json. Only requires the tokenizer file, not the .tflite graphs,
+// so it runs whenever tokenizer.json is present.
+// ---------------------------------------------------------------------------
+
+void test_voxcpm2_tokenizer(const std::string& dir) {
+    std::string tok_path = dir + "/tokenizer.json";
+    if (!file_exists(tok_path)) {
+        std::printf("  [skip] tokenizer.json not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_voxcpm2_tokenizer ... ");
+
+    speech_core::VoxCPM2Tokenizer t(tok_path);
+    REQUIRE(t.bos_id() == 1);
+    REQUIRE(t.eos_id() == 2);
+    REQUIRE(t.unk_id() == 0);
+    REQUIRE(t.vocab_size() > 73000);
+
+    // Reference outputs from python `tokenizers.Tokenizer.from_file(...).encode(s).ids`.
+    // The trailing roundtrip check exercises the decoder (skip-specials,
+    // ▁→space, byte fallback collapse, strip leading space).
+    struct Case { std::string text; std::vector<int> ids; };
+    const std::vector<Case> cases = {
+        {"Hello world",                    {1, 21045, 2809}},
+        {"The quick brown fox jumps over the lazy dog.",
+                                           {1, 1507, 4766, 13329, 49712, 43384, 1865, 1358, 29117, 6595, 72}},
+        {"Hello, world!",                  {1, 21045, 59342, 2809, 73}},
+        {"\xE4\xBD\xA0\xE5\xA5\xBD",       {1, 59320, 23523}},   // "你好"
+        {"caf\xC3\xA9",                    {1, 33903, 60025}},   // "café"
+        {"",                               {1}},
+        {" ",                              {1, 1345}},
+        {"a b  c",                         {1, 1348, 1376, 1345, 59333}},
+        // Byte-fallback path — rare CJK U+20BB7 encodes to F0 A0 AE B7
+        {"\xF0\xA0\xAE\xB7",               {1, 59320, 1329, 1249, 1263, 1272}},
+    };
+    for (const auto& c : cases) {
+        auto got = t.encode(c.text);
+        if (got != c.ids) {
+            std::printf("\n    encode(\"%s\"): got [", c.text.c_str());
+            for (size_t i = 0; i < got.size(); ++i) std::printf("%s%d", i ? "," : "", got[i]);
+            std::printf("], want [");
+            for (size_t i = 0; i < c.ids.size(); ++i) std::printf("%s%d", i ? "," : "", c.ids[i]);
+            std::printf("] ");
+        }
+        REQUIRE(got == c.ids);
+        // Roundtrip: encode then decode should return the original text.
+        REQUIRE(t.decode(got) == c.text);
+    }
+    std::printf("ok\n");
+}
+
 }  // namespace
 
 int main() {
@@ -444,6 +499,7 @@ int main() {
     test_litert_parakeet_real_speech(dir);
     test_litert_parakeet_streaming(dir);
     test_litert_vad_to_stt_pipeline(dir);
+    test_voxcpm2_tokenizer(dir);
     test_litert_voxcpm2_load(dir);
 
     if (failures > 0) {


### PR DESCRIPTION
## What this is

First half of "add VoxCPM2 support". Pure-C++ implementation of the VoxCPM2 tokenizer — `tokenizer.json` parsing, BPE encode, decode round-trip — pinned byte-for-byte to the reference HuggingFace Python tokenizer output. The 4-graph LiteRT inference loop is the next PR.

## Why hand-roll instead of `tokenizers-cpp`

I originally suggested `tokenizers-cpp`. Reflecting on it more carefully: that brings a Rust toolchain (rustc/cargo) into the build, which breaks the Android cross-compile and Yocto paths that speech-core's downstream consumers care about. The VoxCPM2 tokenizer model is fixed across releases (it's part of the published bundle and won't change shape), so a targeted reimplementation has the same correctness profile for this specific model at zero extra build cost — no Rust toolchain on any platform.

## Pipeline (matches HuggingFace `tokenizers` behaviour exactly)

**encode(text):**
1. Normalize: prepend U+2581 (`▁`) and replace each space with `▁`.
2. BPE on Unicode codepoints; codepoints absent from the vocab fall back to `<0xXX>` byte tokens (`byte_fallback=true` per `tokenizer.json`).
3. Post-process: prepend BOS (`<s>`, id=1).

**decode(ids):**
1. Skip special tokens.
2. Join token strings; collapse runs of `<0xXX>` tokens back into raw bytes.
3. Replace `▁` with space; strip the single leading space introduced by the normalizer.

## Pinned reference outputs

`test_voxcpm2_tokenizer` exercises nine cases against ground truth from `tokenizers.Tokenizer.from_file('tokenizer.json').encode(s).ids` in Python:

| Input | Expected IDs |
|-------|---|
| `Hello world` | `[1, 21045, 2809]` |
| `The quick brown fox jumps over the lazy dog.` | `[1, 1507, 4766, 13329, 49712, 43384, 1865, 1358, 29117, 6595, 72]` |
| `Hello, world!` | `[1, 21045, 59342, 2809, 73]` |
| `你好` | `[1, 59320, 23523]` |
| `café` | `[1, 33903, 60025]` |
| `` (empty) | `[1]` |
| ` ` (single space) | `[1, 1345]` |
| `a b  c` | `[1, 1348, 1376, 1345, 59333]` |
| `𠮷` (CJK U+20BB7 → byte fallback) | `[1, 59320, 1329, 1249, 1263, 1272]` |

Each case also round-trips through `decode(encode(text)) == text`.

## What's still deferred (next PR)

- The 4-graph LiteRT orchestration loop: `text_prefill → token_step ×N → audio_decode` with explicit K/V cache handoff every step.
- Audio output streaming via `TTSChunkCallback`.
- Optional reference-audio path through `audio_encoder` for voice cloning.
- Weekly CI workflow that downloads the ~4.6 GB bundle and runs an end-to-end synth test.

`LiteRTVoxCPM2Tts::synthesize()` still throws \`std::runtime_error\` — only the tokenizer is wired up, instantiated at constructor time so a malformed `tokenizer.json` fails fast instead of on the first synthesise call.

## Test plan

- [x] Local validation: tokenizer compiles standalone and all 9 reference cases pass byte-for-byte (verified against Python HF tokenizer).
- [x] Default build 9/9 green.
- [ ] PR CI green — `linux-litert` / `windows-litert` build the new sources into `speech_core_models_litert`.
- [ ] `test_voxcpm2_tokenizer` runs when `tokenizer.json` is in `SPEECH_LITERT_MODEL_DIR` (skips cleanly otherwise — no need for the 4.6 GB graphs).