### PR TITLE
VoxCPM2 test: pass a non-empty instruction

### DIFF
--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -456,6 +456,11 @@ void test_litert_voxcpm2_synthesize(const std::string& dir) {
     // has enough audio to recognise. min_stop_steps_=32 ignores stop-signal
     // for the first 32 steps (~5 s) — empirically enough to cover the
     // phrase before the model flips its stop bit on a natural pause.
+    //
+    // Also set a non-empty instruction: VoxCPM2 was trained on
+    // "({instruction}){text}" prompts and an empty "()..." prefix tends to
+    // make the model emit a one-word filler ("Yeah.") instead of the text.
+    tts.set_instruction("clear, natural delivery");
     tts.set_max_steps(128);
     tts.set_min_steps_before_stop(32);
 


### PR DESCRIPTION
## Why

First weekly run on the new runtime succeeded structurally (VoxCPM2 synth produced a real 522 KB / 5.44 s WAV) but the ASR round-trip failed: Parakeet only heard 'Yeah.'. Silero VAD inside speech_transcribe marks just ~0.5 s of the WAV as speech — the model is generating filler then silence.

Root cause: our test left the instruction slot empty (\`tts.set_instruction("")\`), so the prompt was \`'()The quick brown fox jumps over the lazy dog'\`. VoxCPM2 was trained on \`'({instruction}){text}'\` and reacts to empty parens by emitting a short filler. The upstream Python smoke uses \`'calm, reassuring delivery'\` by default and gets the full sentence.

## Fix

One-line change: \`tts.set_instruction("clear, natural delivery")\` before \`synthesize()\`.

## Test plan

- [ ] Re-trigger \`Weekly VoxCPM2 integration\` from main after merge; expect the ASR round-trip step to pass (transcript should contain at least 6 of: quick, brown, fox, jumps, lazy, dog).