### PR TITLE
README: lead with platforms + dual backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
 # Speech Core
 
-Voice agent pipeline engine in C++. Provides the orchestration layer for real-time conversational AI — state machine, turn detection, interruption handling, and speech queuing — plus a set of optional ONNX Runtime reference implementations (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3 enhancer).
+Voice agent pipeline engine in C++17 for **Linux, Windows, and Android** (plus Apple platforms via a prebuilt XCFramework). Provides the orchestration layer for real-time conversational AI — state machine, turn detection, interruption handling, speech queuing — with **zero ML dependencies in the core**.
 
-The orchestration core has zero ML dependencies. Consumers either bring their own model implementations of the abstract interfaces (STT, TTS, LLM, VAD, Enhancer), or compile in the reference implementations via `SPEECH_CORE_WITH_ONNX=ON`.
+Model inference is opt-in through two interchangeable, independent backends:
+
+- **ONNX Runtime** (`SPEECH_CORE_WITH_ONNX`) — Silero VAD, Parakeet STT, Kokoro TTS, DeepFilterNet3.
+- **LiteRT** (`SPEECH_CORE_WITH_LITERT`) — Silero VAD, Parakeet STT, VoxCPM2 TTS. Backed by Google's `ai-edge-litert` runtime (`libLiteRt`).
+
+Consumers can enable either, both, or neither — and can always bring their own implementations of the abstract interfaces (STT, TTS, LLM, VAD, Enhancer); speech-swift does this with CoreML/MLX on Apple platforms.
+
+## Supported models
+
+| Model | Interface | ONNX | LiteRT |
+|---|---|:---:|:---:|
+| Silero VAD v5 | VAD | ✓ | ✓ |
+| Parakeet TDT v3 (0.6B) | STT | ✓ | ✓ |
+| Kokoro 82M | TTS | ✓ | — |
+| DeepFilterNet3 | Enhancer | ✓ | — |
+| VoxCPM2 (2B) | TTS | — | ✓ |
+
+(Kokoro / DeepFilterNet3 don't have LiteRT exports yet, and VoxCPM2 has no ONNX export — wrappers land as `speech-models` ships the artifacts.)
+
+## Backends & platforms
+
+| Backend | Library | Runtime dep | Platforms | Setup |
+|---|---|---|---|---|
+| ONNX | `speech_core_models` | `onnxruntime` | Linux, macOS, Android | `ORT_DIR` from an ONNX Runtime release |
+| LiteRT | `speech_core_models_litert` | `libLiteRt` | Linux x86_64, Windows x86_64, Android, macOS arm64 | `scripts/fetch_litert.sh` (extracts from the `ai-edge-litert` PyPI wheel) |
+
+Both backends run CPU inference today; GPU / NNAPI / QNN delegate selection is a follow-up.
 
 ## Architecture
 
@@ -16,17 +42,18 @@ The orchestration core has zero ML dependencies. Consumers either bring their ow
 │  STTInterface  TTSInterface  LLMInterface    │  abstract interfaces
 │  VADInterface  EnhancerInterface  AEC        │
 └──────────────────────────────────────────────┘
-                       ▲
-                       │ implements (optional)
-                       │
-┌──────────────────────┴───────────────────────┐
-│   Reference models (SPEECH_CORE_WITH_ONNX)   │
-│                                              │
-│   SileroVad         : VADInterface           │
-│   ParakeetStt       : STTInterface           │
-│   KokoroTts         : TTSInterface           │
-│   DeepFilterEnhancer: EnhancerInterface      │
-└──────────────────────────────────────────────┘
+              ▲                       ▲
+              │ implements (optional) │
+              │                       │
+┌─────────────┴──────────┐  ┌─────────┴────────────────┐
+│ speech_core_models     │  │ speech_core_models_litert │
+│ (SPEECH_CORE_WITH_ONNX)│  │ (SPEECH_CORE_WITH_LITERT) │
+│                        │  │                          │
+│ SileroVad      : VAD   │  │ LiteRTSileroVad   : VAD  │
+│ ParakeetStt    : STT   │  │ LiteRTParakeetStt : STT  │
+│ KokoroTts      : TTS   │  │ LiteRTVoxCPM2Tts  : TTS  │
+│ DeepFilterEnhancer:Enh │  │                          │
+└────────────────────────┘  └──────────────────────────┘
 ```
 
 See [`docs/interfaces.md`](docs/interfaces.md) and [`docs/models.md`](docs/models.md) for details.
@@ -73,7 +100,7 @@ See [`docs/pipeline.md`](docs/pipeline.md) for state machine, turn detection, in
 
 ### Models (`include/speech_core/models/`, optional)
 
-ONNX Runtime reference implementations, compiled in only when `SPEECH_CORE_WITH_ONNX=ON`.
+ONNX wrappers (`SPEECH_CORE_WITH_ONNX`):
 
 | File | Implements | Notes |
 |---|---|---|
@@ -82,6 +109,16 @@ ONNX Runtime reference implementations, compiled in only when `SPEECH_CORE_WITH_
 | `kokoro_tts.h` | `TTSInterface` | Kokoro 82M, 24 kHz, eSpeak-free phonemizer (9 languages) |
 | `deepfilter.h` | `EnhancerInterface` | DeepFilterNet3, 48 kHz noise cancellation |
 | `onnx_engine.h` | (internal) | ORT singleton, NNAPI/QNN/CPU provider auto-selection |
+
+LiteRT wrappers (`SPEECH_CORE_WITH_LITERT`):
+
+| File | Implements | Notes |
+|---|---|---|
+| `litert_silero_vad.h` | `VADInterface` | Silero VAD v5 |
+| `litert_parakeet_stt.h` | `STTInterface` | Parakeet TDT v3, INT8 encoder |
+| `litert_voxcpm2_tts.h` | `TTSInterface` | VoxCPM2 (2B), 48 kHz, 4-graph pipeline |
+| `voxcpm2_tokenizer.h` | (internal) | Hand-rolled BPE tokenizer, pure C++17 |
+| `litert_engine.h` | (internal) | LiteRT environment + CompiledModel + TensorBuffer RAII |
 
 See [`docs/models.md`](docs/models.md) for usage.
 
@@ -93,35 +130,7 @@ See [`docs/models.md`](docs/models.md) for usage.
 
 ### Interfaces (`include/speech_core/interfaces.h`)
 
-Abstract classes:
-
-```cpp
-class STTInterface {
-    virtual TranscriptionResult transcribe(const float* audio, size_t length, int sample_rate) = 0;
-    virtual int input_sample_rate() const = 0;
-};
-
-class TTSInterface {
-    virtual void synthesize(const std::string& text, const std::string& language,
-                            TTSChunkCallback on_chunk) = 0;
-    virtual int output_sample_rate() const = 0;
-    virtual void cancel() {}
-};
-
-class LLMInterface {
-    virtual LLMResponse chat(const std::vector<Message>& messages,
-                             LLMTokenCallback on_token) = 0;
-    virtual void set_tools(const std::vector<ToolDefinition>& tools) {}
-    virtual void cancel() {}
-};
-
-class VADInterface {
-    virtual float process_chunk(const float* samples, size_t length) = 0;
-    virtual void reset() = 0;
-    virtual int input_sample_rate() const = 0;
-    virtual size_t chunk_size() const = 0;
-};
-```
+Abstract classes any backend implements: `STTInterface`, `TTSInterface`, `LLMInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`. See the header for signatures.
 
 ### Tools (`include/speech_core/tools/`)
 
@@ -143,7 +152,7 @@ cmake --build build
 cd build && ctest
 ```
 
-With ONNX Runtime reference models:
+With the **ONNX** backend:
 
 ```bash
 cmake -B build -DCMAKE_BUILD_TYPE=Release \
@@ -152,18 +161,29 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release \
 cmake --build build
 ```
 
-This builds two static libraries:
+`ORT_DIR` must contain `include/onnxruntime_c_api.h` and a platform shared library (`libonnxruntime.dylib` on macOS, `libonnxruntime.so` on Linux, `lib/${ANDROID_ABI}/libonnxruntime.so` on Android). Builds `libspeech_core_models.a` (links `speech_core` + `onnxruntime`).
 
-- `libspeech_core.a` — orchestration core, no ML deps
-- `libspeech_core_models.a` — ONNX model wrappers, links `speech_core` + `onnxruntime`
-
-`ORT_DIR` must contain `include/onnxruntime_c_api.h` and a platform shared library (`libonnxruntime.dylib` on macOS, `libonnxruntime.so` on Linux, `lib/${ANDROID_ABI}/libonnxruntime.so` on Android).
-
-To run the model integration tests (requires ~1.2 GB of model files):
+With the **LiteRT** backend:
 
 ```bash
-scripts/download_models.sh
+scripts/fetch_litert.sh build/litert        # extracts libLiteRt from the ai-edge-litert wheel
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DSPEECH_CORE_WITH_LITERT=ON \
+    -DLITERT_DIR=$PWD/build/litert
+cmake --build build
+```
+
+`LITERT_DIR` points at the directory holding `libLiteRt.{so,dylib,dll}`; headers are vendored in `third_party/litert/`. Builds `libspeech_core_models_litert.a` (links `speech_core` + `litert`). The two backends are independent and can be enabled together.
+
+To run the model integration tests (downloads model files):
+
+```bash
+scripts/download_models.sh                                   # ONNX (~1.2 GB)
 SPEECH_MODEL_DIR=scripts/models ctest --test-dir build --output-on-failure
+
+scripts/download_models_litert.sh                            # LiteRT Silero + Parakeet
+scripts/download_voxcpm2_litert.sh                           # VoxCPM2 bundle (~4.6 GB, optional)
+SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
 ```
 
 See [`docs/models.md`](docs/models.md) for the full test setup.
@@ -174,8 +194,8 @@ Add `-DSPEECH_CORE_BUILD_EXAMPLES=ON` to build the Linux example: a small C ABI 
 
 ## Design Principles
 
-- **ML inference is opt-in.** The orchestration core is pure C++17 with no ML deps. ONNX Runtime models are compiled in only when explicitly requested.
-- **No platform dependencies in the core** — pure C++17, no OS-specific APIs. The ORT-backed models use platform features (NNAPI on Android, QNN elsewhere) but only when enabled.
+- **ML inference is opt-in.** The orchestration core is pure C++17 with no ML deps. The ONNX and LiteRT backends are compiled in only when explicitly requested.
+- **No platform dependencies in the core** — pure C++17, no OS-specific APIs. The backend wrappers use platform features (NNAPI on Android, etc.) but only when enabled.
 - **No network I/O** — no sockets, no HTTP, no WebSocket.
 - **No audio I/O** — audio buffer and resampler operate on float arrays.
 - **Callback-driven** — pipeline emits events via `std::function` callbacks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Speech Core
 
-Voice agent pipeline engine in C++17 for **Linux, Windows, and Android** (plus Apple platforms via a prebuilt XCFramework). Provides the orchestration layer for real-time conversational AI — state machine, turn detection, interruption handling, speech queuing — with **zero ML dependencies in the core**.
+Voice agent pipeline engine in C++17 for **Linux, Windows, and Android** (plus Apple platforms via a prebuilt XCFramework). Provides the orchestration layer for real-time conversational AI — state machine, turn detection, interruption handling, speech queuing.
 
 Model inference is opt-in through two interchangeable, independent backends:
 


### PR DESCRIPTION
Refocuses the README around what the project actually is now.

- **Up front**: targets Linux / Windows / Android (+ Apple via XCFramework), two interchangeable backends.
- **Supported models** matrix — Silero / Parakeet / Kokoro / DeepFilter / VoxCPM2 × ONNX / LiteRT.
- **Backends & platforms** table — library, runtime dep, platforms, setup command.
- Architecture diagram now shows both `speech_core_models` and `speech_core_models_litert`; models + build sections cover the LiteRT path (`fetch_litert.sh`, `LITERT_DIR`).
- Trimmed the 28-line interface code dump down to a pointer to `interfaces.h`.

Docs-only.