### PR TITLE
VoxCPM2: implement voice cloning in the LiteRT backend

### DIFF
--- a/.github/workflows/weekly-voxcpm2.yml
+++ b/.github/workflows/weekly-voxcpm2.yml
@@ -104,11 +104,13 @@ jobs:
         env:
           SPEECH_LITERT_MODEL_DIR: ${{ github.workspace }}/scripts/models-voxcpm2
           VOXCPM2_SYNTH_WAV:       ${{ github.workspace }}/voxcpm2-synth.wav
+          VOXCPM2_CLONE_WAV:       ${{ github.workspace }}/voxcpm2-clone.wav
         run: |
           export LD_LIBRARY_PATH="$PWD/litert:${LD_LIBRARY_PATH:-}"
           ctest --test-dir build --output-on-failure -R test_litert_models
           test -f voxcpm2-synth.wav
-          ls -la voxcpm2-synth.wav
+          test -f voxcpm2-clone.wav
+          ls -la voxcpm2-synth.wav voxcpm2-clone.wav
 
       # --- Semantic round-trip: feed the WAV through our own Parakeet ORT
       # CLI and assert the input phrase shows up in the transcript. This is
@@ -141,3 +143,27 @@ jobs:
               exit 1
           fi
           echo "OK: all required words present in transcript"
+
+      # --- Same round-trip for the voice-cloned output (test_litert_models'
+      # clone test conditions on the fixture clip, then synthesises the phrase
+      # in that voice). Proves the audio_encoder → prefill conditioning path
+      # produces intelligible cloned speech, not just non-silent audio.
+      - name: ASR round-trip — cloned voice (Parakeet ORT)
+        run: |
+          export LD_LIBRARY_PATH="$PWD/ort-linux/lib:${LD_LIBRARY_PATH:-}"
+          set +e
+          output="$(./build/examples/linux/speech_transcribe scripts/models voxcpm2-clone.wav 2>&1)"
+          set -e
+          echo "$output"
+          lower="$(echo "$output" | tr '[:upper:]' '[:lower:]')"
+          missing=""
+          for w in quick brown fox jumps lazy dog; do
+              if ! echo "$lower" | grep -q "$w"; then
+                  missing="$missing $w"
+              fi
+          done
+          if [ -n "$missing" ]; then
+              echo "FAIL: cloned transcript missing words:$missing" >&2
+              exit 1
+          fi
+          echo "OK: cloned voice transcript intelligible"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/litert_silero_vad.cpp
         src/models/litert/litert_parakeet_stt.cpp
         src/models/litert/litert_voxcpm2_tts.cpp
+        src/models/litert/voxcpm2_c.cpp
         src/models/litert/voxcpm2_tokenizer.cpp
     )
 
@@ -181,6 +182,16 @@ if(SPEECH_CORE_WITH_LITERT)
     set_target_properties(speech_core_models_litert PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
     target_link_libraries(speech_core_models_litert PUBLIC speech_core litert)
+
+    # VoxCPM2 voice-cloning CLI — desktop only (skipped on Android/embedded
+    # consumers that link the library but don't want an executable target).
+    if(NOT ANDROID)
+        add_executable(speech_voxcpm2_clone examples/litert/voxcpm2_clone.cpp)
+        target_link_libraries(speech_voxcpm2_clone PRIVATE speech_core_models_litert)
+        if(MSVC)
+            target_compile_definitions(speech_voxcpm2_clone PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------

--- a/examples/litert/voxcpm2_clone.cpp
+++ b/examples/litert/voxcpm2_clone.cpp
@@ -1,0 +1,187 @@
+// Standalone VoxCPM2 voice-cloning CLI (LiteRT backend).
+//
+// Loads a VoxCPM2 LiteRT bundle, conditions on a reference speaker clip, and
+// synthesizes the given text in that voice — writing a 48 kHz mono WAV.
+//
+// Usage:
+//   speech_voxcpm2_clone <bundle_dir> <ref.wav> "<text>" <out.wav> \
+//       [instruction] [max_steps]
+//
+//   bundle_dir  : directory holding voxcpm2-{text-prefill,token-step,
+//                 audio-encoder,audio-decoder}.tflite + tokenizer.json
+//   ref.wav     : reference speaker clip (mono/stereo PCM-16 WAV, any rate;
+//                 resampled to 16 kHz and trimmed/padded to 6.4 s internally)
+//   instruction : optional style prefix, e.g. "calm, clear delivery"
+//   max_steps   : optional AR step cap (default 256, ~40 s ceiling)
+//
+// Pairs with speech_transcribe for a clone → ASR round-trip sanity check.
+
+#include <speech_core/models/litert_voxcpm2_tts.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kOutSampleRate = 48000;
+
+// Minimal mono-float loader for a canonical PCM-16 RIFF/WAVE file. Multi-channel
+// input is down-mixed by averaging. Returns false on any parse failure.
+bool load_wav_mono(const std::string& path, std::vector<float>& out, int& sample_rate) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) { std::fprintf(stderr, "cannot open %s\n", path.c_str()); return false; }
+
+    char riff[4], wave[4];
+    uint32_t file_size = 0;
+    f.read(riff, 4);
+    f.read(reinterpret_cast<char*>(&file_size), 4);
+    f.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
+        std::fprintf(stderr, "%s is not a RIFF/WAVE file\n", path.c_str());
+        return false;
+    }
+
+    char chunk_id[4];
+    uint32_t chunk_size = 0;
+    uint16_t audio_format = 0, channels = 0, bits = 0;
+    uint32_t rate = 0;
+    bool have_fmt = false;
+
+    while (f.read(chunk_id, 4)) {
+        f.read(reinterpret_cast<char*>(&chunk_size), 4);
+        if (std::memcmp(chunk_id, "fmt ", 4) == 0) {
+            f.read(reinterpret_cast<char*>(&audio_format), 2);
+            f.read(reinterpret_cast<char*>(&channels), 2);
+            f.read(reinterpret_cast<char*>(&rate), 4);
+            f.seekg(6, std::ios::cur);                 // byte_rate + block_align
+            f.read(reinterpret_cast<char*>(&bits), 2);
+            if (chunk_size > 16) f.seekg(chunk_size - 16, std::ios::cur);
+            have_fmt = true;
+        } else if (std::memcmp(chunk_id, "data", 4) == 0) {
+            if (!have_fmt || audio_format != 1 || bits != 16 || channels == 0) {
+                std::fprintf(stderr, "%s: only 16-bit PCM WAV is supported\n", path.c_str());
+                return false;
+            }
+            const size_t n = chunk_size / 2;
+            std::vector<int16_t> pcm(n);
+            f.read(reinterpret_cast<char*>(pcm.data()), chunk_size);
+            const size_t frames = n / channels;
+            out.resize(frames);
+            for (size_t i = 0; i < frames; ++i) {
+                int acc = 0;
+                for (uint16_t c = 0; c < channels; ++c) acc += pcm[i * channels + c];
+                out[i] = static_cast<float>(acc) / (channels * 32768.0f);
+            }
+            sample_rate = static_cast<int>(rate);
+            return true;
+        } else {
+            f.seekg(chunk_size, std::ios::cur);
+        }
+    }
+    std::fprintf(stderr, "%s: no data chunk\n", path.c_str());
+    return false;
+}
+
+bool write_wav(const std::string& path, const float* samples, size_t count, int rate) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return false;
+    auto put32 = [&](uint32_t v) {
+        char b[4] = {char(v & 0xFF), char((v >> 8) & 0xFF),
+                     char((v >> 16) & 0xFF), char((v >> 24) & 0xFF)};
+        f.write(b, 4);
+    };
+    auto put16 = [&](uint16_t v) {
+        char b[2] = {char(v & 0xFF), char((v >> 8) & 0xFF)};
+        f.write(b, 2);
+    };
+    const uint32_t data_bytes = static_cast<uint32_t>(count) * 2;
+    f.write("RIFF", 4); put32(36 + data_bytes);
+    f.write("WAVE", 4);
+    f.write("fmt ", 4); put32(16);
+    put16(1);                                          // PCM
+    put16(1);                                          // mono
+    put32(static_cast<uint32_t>(rate));
+    put32(static_cast<uint32_t>(rate) * 2);            // byte rate
+    put16(2);                                          // block align
+    put16(16);                                         // bits/sample
+    f.write("data", 4); put32(data_bytes);
+    for (size_t i = 0; i < count; ++i) {
+        float s = samples[i];
+        if (s < -1.0f) s = -1.0f;
+        if (s >  1.0f) s =  1.0f;
+        put16(static_cast<uint16_t>(static_cast<int16_t>(s * 32767.0f)));
+    }
+    return f.good();
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        std::fprintf(stderr,
+            "usage: %s <bundle_dir> <ref.wav> \"<text>\" <out.wav> "
+            "[instruction] [max_steps]\n",
+            argv[0]);
+        return 2;
+    }
+    const std::string bundle      = argv[1];
+    const std::string ref_wav     = argv[2];
+    const std::string text        = argv[3];
+    const std::string out_wav     = argv[4];
+    const std::string instruction = (argc >= 6) ? argv[5] : "clear, natural delivery";
+    const int         max_steps   = (argc >= 7) ? std::atoi(argv[6]) : 256;
+
+    const bool no_ref = (ref_wav == "none");
+    std::vector<float> ref;
+    int ref_rate = 0;
+    if (!no_ref) {
+        if (!load_wav_mono(ref_wav, ref, ref_rate)) return 1;
+        std::fprintf(stderr, "reference: %zu samples @ %d Hz (%.2fs)\n",
+                     ref.size(), ref_rate, ref.empty() ? 0.0 : double(ref.size()) / ref_rate);
+    } else {
+        std::fprintf(stderr, "reference: none (uncloned baseline)\n");
+    }
+
+    try {
+        speech_core::LiteRTVoxCPM2Tts tts(
+            bundle + "/voxcpm2-text-prefill.tflite",
+            bundle + "/voxcpm2-token-step.tflite",
+            bundle + "/voxcpm2-audio-encoder.tflite",
+            bundle + "/voxcpm2-audio-decoder.tflite",
+            bundle + "/tokenizer.json",
+            /*hw_accel=*/false);
+
+        if (!instruction.empty()) tts.set_instruction(instruction);
+        tts.set_max_steps(max_steps);
+        tts.set_min_steps_before_stop(32);
+        if (!no_ref) tts.set_reference(ref.data(), ref.size(), ref_rate);
+
+        std::vector<float> audio;
+        bool got_final = false;
+        tts.synthesize(text, "auto",
+            [&](const float* chunk, size_t length, bool is_final) {
+                if (chunk && length) audio.insert(audio.end(), chunk, chunk + length);
+                if (is_final) got_final = true;
+            });
+
+        if (!got_final || audio.empty()) {
+            std::fprintf(stderr, "synthesis produced no audio\n");
+            return 1;
+        }
+        if (!write_wav(out_wav, audio.data(), audio.size(), kOutSampleRate)) {
+            std::fprintf(stderr, "could not write %s\n", out_wav.c_str());
+            return 1;
+        }
+        std::fprintf(stderr, "wrote %zu samples (%.2fs @ %d Hz) to %s\n",
+                     audio.size(), double(audio.size()) / kOutSampleRate,
+                     kOutSampleRate, out_wav.c_str());
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
+    return 0;
+}

--- a/include/speech_core/models/litert_voxcpm2_tts.h
+++ b/include/speech_core/models/litert_voxcpm2_tts.h
@@ -12,11 +12,14 @@
 namespace speech_core {
 
 /// VoxCPM2 — 2B-parameter multilingual TTS via LiteRT.
-/// 48 kHz output. Voice cloning + voice design (cloning surface deferred —
-/// `synthesize()` always feeds zero audio_feats today).
+/// 48 kHz output. Plain TTS by default; voice cloning when a reference clip is
+/// set via set_reference() — that runs the audio_encoder graph and conditions
+/// the prefill on the encoded reference latents.
 /// Model: https://huggingface.co/aufklarer/VoxCPM2-LiteRT
 ///
 /// Pipeline (four LiteRT graphs orchestrated here):
+///   audio_encoder  : (audio [1, 102400] = 6.4 s @ 16 kHz)
+///                    → (audio_feats [1, 40, 4, 64])    — cloning only
 ///   text_prefill   : (tokens, masks, audio_feats, audio_mask, context_len)
 ///                    → (lm_hidden, residual_hidden, prefix_feat_cond, base_cache, residual_cache)
 ///   token_step ×N  : (lm_hidden, residual_hidden, prefix_feat_cond, base_cache,
@@ -24,6 +27,11 @@ namespace speech_core {
 ///                    → (pred_feat, stop_logits, next_lm_hidden, next_residual_hidden,
 ///                       base_cache, residual_cache)
 ///   audio_decoder  : (latent [1, 64, 256]) → PCM [1, 491520] (10.24 s @ 48 kHz)
+///
+/// Cloning builds the prefill sequence as
+///   [ <|ref_audio_start|>, refLatent×N, <|ref_audio_end|>, text…, <|audio_start|> ]
+/// with text_mask on the boundary/text tokens and audio_mask on the N latent
+/// slots — mirroring the MLX ICL clone path in speech-swift's VoxCPM2TTS.
 ///
 /// Caches grow from text_prefill's 512-slot output to the 2560-slot view that
 /// token_step expects (zero-padded along axis 4). Every 64 token_step calls
@@ -59,6 +67,20 @@ public:
     /// the very first few steps. Default 8 mirrors the upstream smoke test.
     void set_min_steps_before_stop(int min_steps) { min_stop_steps_ = min_steps; }
 
+    /// Condition subsequent synthesize() calls on a reference speaker clip.
+    /// `pcm` is mono float samples in [-1, 1] at `sample_rate`; it's resampled
+    /// to 16 kHz and padded/truncated to the encoder's fixed 6.4 s window, then
+    /// run through audio_encoder. The encoded latents are cached and reused on
+    /// every synthesize() until clear_reference() (or a new set_reference()).
+    /// Throws if the bundle's tokenizer lacks the reference boundary tokens.
+    void set_reference(const float* pcm, size_t length, int sample_rate);
+
+    /// Drop any reference clip; synthesize() falls back to plain (uncloned) TTS.
+    void clear_reference();
+
+    /// Whether a reference clip is currently set.
+    bool has_reference() const { return ref_frames_ > 0; }
+
 private:
     LiteRtModel         text_prefill_model_    = nullptr;
     LiteRtCompiledModel text_prefill_compiled_ = nullptr;
@@ -70,12 +92,17 @@ private:
     LiteRtCompiledModel audio_decoder_compiled_= nullptr;
 
     std::unique_ptr<VoxCPM2Tokenizer> tokenizer_;
-    int audio_start_token_ = -1;
+    int audio_start_token_     = -1;
+    int ref_audio_start_token_ = -1;   // <|ref_audio_start|>, cloning only
+    int ref_audio_end_token_   = -1;   // <|ref_audio_end|>, cloning only
 
-    // Shape constants pulled from config.json (max_text_tokens = 512,
-    // max_generated_tokens = 2048, hidden = 2048, etc.). Kept here so the
-    // implementation file is just allocations and tensor-copy plumbing.
-    static constexpr int  kMaxText             = 512;
+    // Cached reference latents from the last set_reference() call. Laid out as
+    // ref_frames_ consecutive [patch, feat] frames (kPredFeatFloats each),
+    // matching one audio_feats slot per frame. Empty ⇒ plain TTS.
+    std::vector<float> ref_feats_;
+    int                ref_frames_ = 0;
+
+    // Bundle-invariant shape constants (same across every VoxCPM2 export).
     static constexpr int  kMaxGenerated        = 2048;
     static constexpr int  kHidden              = 2048;
     static constexpr int  kFeatDim             = 64;
@@ -85,10 +112,29 @@ private:
     static constexpr int  kDecoderInputFloats  = kFramesPerChunk * kPredFeatFloats; // 16384
     static constexpr int  kDecoderOutputFloats = 491520;     // 10.24 s @ 48 kHz
     static constexpr int  kSamplesPerStep      = 7680;       // 160 ms @ 48 kHz
-    static constexpr long kBaseCacheFloats     = 2L * 28 * 1 * 2 * 2560 * 128;     // ~36.7 M
-    static constexpr long kResidualCacheFloats = 2L *  8 * 1 * 2 * 2560 * 128;     // ~10.5 M
-    static constexpr long kBasePrefillFloats   = 2L * 28 * 1 * 2 * 512  * 128;     // ~7.3 M
-    static constexpr long kResidualPrefillFloats = 2L * 8 * 1 * 2 * 512  * 128;    //  2.1 M
+    static constexpr int  kBaseLayers          = 28;
+    static constexpr int  kResidualLayers      = 8;
+    static constexpr int  kKvHeads             = 2;
+    static constexpr int  kHeadDim             = 128;
+
+    // Reference-audio conditioning (audio_encoder graph). The graph's input
+    // length is baked at export (audio_conditioning_sample_rate × seconds =
+    // 16 kHz × 6.4 s = 102400 samples) and emits one latent frame per 2560
+    // input samples (= patch_size 4 × VAE downsample 640), so 40 frames max.
+    static constexpr int  kCondSampleRate      = 16000;
+    static constexpr int  kRefAudioSamples     = 102400;   // 6.4 s @ 16 kHz
+    static constexpr int  kRefFrameStride      = 2560;     // samples per latent frame
+    static constexpr int  kMaxRefFrames        = kRefAudioSamples / kRefFrameStride; // 40
+
+    // Context geometry — queried from the text_prefill graph at load (its
+    // audio_feats input is [1, max_text, patch, feat]) so 256- and 512-token
+    // exports both work. token_step grows the cache to max_text + max_generated.
+    int  max_text_               = 512;
+    int  full_seq_               = 512 + kMaxGenerated;
+    long base_cache_floats_      = 0;
+    long residual_cache_floats_  = 0;
+    long base_prefill_floats_    = 0;
+    long residual_prefill_floats_= 0;
 
     std::string       instruction_;
     int               max_steps_       = kMaxGenerated;

--- a/include/speech_core/voxcpm2_c.h
+++ b/include/speech_core/voxcpm2_c.h
@@ -1,0 +1,87 @@
+#ifndef SPEECH_CORE_VOXCPM2_C_H
+#define SPEECH_CORE_VOXCPM2_C_H
+
+// C ABI for VoxCPM2 voice cloning (LiteRT backend).
+//
+// This is a standalone, one-shot synthesis surface — distinct from the
+// real-time pipeline in speech_core_c.h. It exists so non-C++ hosts (e.g. the
+// speech-studio Tauri app, via Rust FFI) can clone a speaker from a reference
+// clip and synthesize text in that voice on Linux/Windows, where the macOS
+// MLX sidecar isn't available.
+//
+// Symbols live in the speech_core_models_litert library; link that plus the
+// imported `litert` runtime. Available only when speech-core is built with
+// SPEECH_CORE_WITH_LITERT=ON.
+//
+// Typical use:
+//   sc_voxcpm2_t v = sc_voxcpm2_create("/path/to/bundle");
+//   sc_voxcpm2_set_instruction(v, "calm, clear delivery");
+//   sc_voxcpm2_set_reference(v, ref_pcm, ref_len, 16000);
+//   sc_voxcpm2_synthesize(v, "Hello there", on_chunk, user_ctx);
+//   sc_voxcpm2_destroy(v);
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct sc_voxcpm2_s* sc_voxcpm2_t;
+
+/// Streaming output callback. `samples` is mono float PCM in [-1, 1] at the
+/// model's output rate (48 kHz). `is_final` marks the last call of a synthesis
+/// (and may carry length 0). Do not retain `samples` past the call.
+typedef void (*sc_voxcpm2_chunk_fn)(const float* samples, size_t length,
+                                    bool is_final, void* context);
+
+/// Create a synthesizer from a VoxCPM2 LiteRT bundle directory (holding
+/// voxcpm2-{text-prefill,token-step,audio-encoder,audio-decoder}.tflite and
+/// tokenizer.json). Returns NULL on failure (reason logged to stderr).
+sc_voxcpm2_t sc_voxcpm2_create(const char* bundle_dir);
+
+/// Destroy a synthesizer and free its resources.
+void sc_voxcpm2_destroy(sc_voxcpm2_t synth);
+
+/// Style prefix prepended as "({instruction})text" (VoxCPM2's training format).
+/// Pass NULL or "" to clear. Persists across synthesize() calls.
+void sc_voxcpm2_set_instruction(sc_voxcpm2_t synth, const char* instruction);
+
+/// Cap AR steps per synthesize() (default 2048 = model max). Each step is
+/// ~160 ms of audio; lowering it bounds latency.
+void sc_voxcpm2_set_max_steps(sc_voxcpm2_t synth, int max_steps);
+
+/// Ignore the model's stop signal for this many initial steps (default 8).
+void sc_voxcpm2_set_min_steps_before_stop(sc_voxcpm2_t synth, int min_steps);
+
+/// Condition subsequent synthesize() calls on a reference speaker clip.
+/// `pcm` is mono float in [-1, 1] at `sample_rate` (resampled to 16 kHz and
+/// trimmed/padded to the encoder's 6.4 s window internally). Returns 0 on
+/// success, non-zero on failure (see sc_voxcpm2_last_error). Cleared by
+/// sc_voxcpm2_clear_reference() — without a reference, output is uncloned.
+int sc_voxcpm2_set_reference(sc_voxcpm2_t synth, const float* pcm,
+                             size_t length, int sample_rate);
+
+/// Drop any reference clip set by sc_voxcpm2_set_reference().
+void sc_voxcpm2_clear_reference(sc_voxcpm2_t synth);
+
+/// Output sample rate in Hz (48000).
+int sc_voxcpm2_output_sample_rate(sc_voxcpm2_t synth);
+
+/// Synthesize `text`, streaming audio via `on_chunk`. Returns 0 on success,
+/// non-zero on failure (see sc_voxcpm2_last_error).
+int sc_voxcpm2_synthesize(sc_voxcpm2_t synth, const char* text,
+                          sc_voxcpm2_chunk_fn on_chunk, void* context);
+
+/// Cancel an in-progress synthesize() (thread-safe; checked between AR steps).
+void sc_voxcpm2_cancel(sc_voxcpm2_t synth);
+
+/// Last error message for the most recent failed call on this handle. Returns a
+/// pointer valid until the next call on the same handle; never NULL ("" = none).
+const char* sc_voxcpm2_last_error(sc_voxcpm2_t synth);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // SPEECH_CORE_VOXCPM2_C_H

--- a/src/models/litert/litert_voxcpm2_tts.cpp
+++ b/src/models/litert/litert_voxcpm2_tts.cpp
@@ -1,12 +1,46 @@
 #include "speech_core/models/litert_voxcpm2_tts.h"
 
+#include "speech_core/audio/resampler.h"
+
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <random>
 #include <stdexcept>
+#include <vector>
 
 namespace speech_core {
+
+namespace {
+
+// Read the prefill context window (max_text_tokens) from the loaded graph: its
+// audio_feats input is the only rank-4 tensor, shaped [1, max_text, patch,
+// feat]. Lets a 256- or 512-token export both work. Falls back to 512 (the
+// deployed bundle) if introspection isn't available.
+int query_prefill_context(LiteRtModel model) {
+    constexpr int kDefault = 512;
+    if (!model) return kDefault;
+    LiteRtParamIndex main_idx = 0;
+    if (LiteRtGetMainModelSubgraphIndex(model, &main_idx) != kLiteRtStatusOk) return kDefault;
+    LiteRtSubgraph sg = nullptr;
+    if (LiteRtGetModelSubgraph(model, main_idx, &sg) != kLiteRtStatusOk) return kDefault;
+    LiteRtParamIndex n = 0;
+    if (LiteRtGetNumSubgraphInputs(sg, &n) != kLiteRtStatusOk) return kDefault;
+    for (LiteRtParamIndex i = 0; i < n; ++i) {
+        LiteRtTensor t = nullptr;
+        if (LiteRtGetSubgraphInput(sg, i, &t) != kLiteRtStatusOk) continue;
+        LiteRtRankedTensorType rt{};
+        if (LiteRtGetRankedTensorType(t, &rt) != kLiteRtStatusOk) continue;
+        if (rt.layout.rank == 4) {  // audio_feats: [1, max_text, patch, feat]
+            const int dim = static_cast<int>(rt.layout.dimensions[1]);
+            if (dim > 0) return dim;
+        }
+    }
+    return kDefault;
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // Constructor / destructor
@@ -25,12 +59,24 @@ LiteRTVoxCPM2Tts::LiteRTVoxCPM2Tts(const std::string& text_prefill_path,
     engine.load(audio_encoder_path, hw_accel, &audio_encoder_model_, &audio_encoder_compiled_);
     engine.load(audio_decoder_path, hw_accel, &audio_decoder_model_, &audio_decoder_compiled_);
 
+    // Derive the context geometry from the prefill graph, then the cache sizes.
+    max_text_                = query_prefill_context(text_prefill_model_);
+    full_seq_                = max_text_ + kMaxGenerated;
+    base_cache_floats_       = 2L * kBaseLayers     * kKvHeads * full_seq_ * kHeadDim;
+    residual_cache_floats_   = 2L * kResidualLayers * kKvHeads * full_seq_ * kHeadDim;
+    base_prefill_floats_     = 2L * kBaseLayers     * kKvHeads * max_text_ * kHeadDim;
+    residual_prefill_floats_ = 2L * kResidualLayers * kKvHeads * max_text_ * kHeadDim;
+
     tokenizer_         = std::make_unique<VoxCPM2Tokenizer>(tokenizer_path);
     audio_start_token_ = tokenizer_->token_id("<|audio_start|>");
     if (audio_start_token_ < 0) {
         throw std::runtime_error(
             "LiteRT VoxCPM2: tokenizer is missing <|audio_start|> — bundle is malformed");
     }
+    // Reference boundary tokens are only needed for cloning; absence is not
+    // fatal here (set_reference() throws if they're missing when used).
+    ref_audio_start_token_ = tokenizer_->token_id("<|ref_audio_start|>");
+    ref_audio_end_token_   = tokenizer_->token_id("<|ref_audio_end|>");
 }
 
 LiteRTVoxCPM2Tts::~LiteRTVoxCPM2Tts() {
@@ -49,6 +95,98 @@ void LiteRTVoxCPM2Tts::cancel() {
 }
 
 // ---------------------------------------------------------------------------
+// Reference conditioning — run audio_encoder on a speaker clip and cache the
+// encoded latents for subsequent synthesize() calls.
+// ---------------------------------------------------------------------------
+
+void LiteRTVoxCPM2Tts::clear_reference() {
+    ref_feats_.clear();
+    ref_feats_.shrink_to_fit();
+    ref_frames_ = 0;
+}
+
+void LiteRTVoxCPM2Tts::set_reference(const float* pcm, size_t length, int sample_rate) {
+    clear_reference();
+    if (!pcm || length == 0) return;
+    if (ref_audio_start_token_ < 0 || ref_audio_end_token_ < 0) {
+        throw std::runtime_error(
+            "LiteRT VoxCPM2: tokenizer lacks <|ref_audio_start|>/<|ref_audio_end|> — "
+            "this bundle does not support voice cloning");
+    }
+
+    // Resample the reference to the encoder's conditioning rate (16 kHz).
+    std::vector<float> mono;
+    if (sample_rate != kCondSampleRate) {
+        mono = Resampler::resample(pcm, length, sample_rate, kCondSampleRate);
+    } else {
+        mono.assign(pcm, pcm + length);
+    }
+    if (mono.empty()) return;
+
+    // Trim leading silence. The encoder window is a fixed 6.4 s taken from the
+    // front, so a quiet lead-in (common in user clips) would otherwise fill it
+    // with silence and clone a silent speaker. Gate on a fraction of the clip's
+    // peak so quiet-but-real speech isn't trimmed; keep a 100 ms pre-roll. If
+    // the clip is entirely below the gate, leave it as-is.
+    {
+        float peak = 0.0f;
+        for (float v : mono) peak = std::max(peak, std::abs(v));
+        const float gate = std::max(0.01f, 0.1f * peak);
+        constexpr int kWin = 320;  // 20 ms @ 16 kHz
+        size_t start = 0;
+        for (; start + kWin <= mono.size(); start += kWin) {
+            double ss = 0.0;
+            for (int i = 0; i < kWin; ++i) ss += double(mono[start + i]) * mono[start + i];
+            if (std::sqrt(ss / kWin) > gate) break;
+        }
+        if (start + kWin <= mono.size() && start > 0) {
+            const size_t preroll = std::min<size_t>(start, kCondSampleRate / 10);
+            mono.erase(mono.begin(), mono.begin() + (start - preroll));
+        }
+    }
+
+    // Frames backed by *real* (pre-pad) audio. The encoder always emits
+    // kMaxRefFrames, but trailing frames over zero-padding carry silence — we
+    // condition only on the real ones (matches the MLX dynamic-length path).
+    const size_t real_samples = std::min<size_t>(mono.size(), kRefAudioSamples);
+    int real_frames = static_cast<int>((real_samples + kRefFrameStride - 1) / kRefFrameStride);
+    real_frames = std::clamp(real_frames, 1, kMaxRefFrames);
+
+    // The audio_encoder graph has a fixed-length input — pad/truncate to it.
+    mono.resize(kRefAudioSamples, 0.0f);
+
+    auto env = LiteRTEngine::get().env();
+    auto t_in  = make_type(kLiteRtElementTypeFloat32, {1, kRefAudioSamples});
+    auto t_out = make_type(kLiteRtElementTypeFloat32,
+                           {1, kMaxRefFrames, kPatchSize, kFeatDim});
+
+    LiteRtHostBuffer in_audio(env, t_in, mono.size() * sizeof(float), mono.data());
+    std::vector<float> enc_out(static_cast<size_t>(kMaxRefFrames) * kPredFeatFloats);
+    LiteRtHostBuffer out_feats(env, t_out, enc_out.size() * sizeof(float));
+
+    LiteRtTensorBuffer ins[1]  = { in_audio.raw() };
+    LiteRtTensorBuffer outs[1] = { out_feats.raw() };
+    litert_check(LiteRtRunCompiledModel(audio_encoder_compiled_, 0, 1, ins, 1, outs),
+                 "audio_encoder Run");
+    out_feats.read(enc_out.data(), enc_out.size() * sizeof(float));
+
+    // Keep the first real_frames frames; each is one audio_feats slot.
+    ref_feats_.assign(enc_out.begin(),
+                      enc_out.begin() + static_cast<size_t>(real_frames) * kPredFeatFloats);
+    ref_frames_ = real_frames;
+
+    if (std::getenv("VOXCPM2_DEBUG")) {
+        double ss = 0.0;
+        for (float v : ref_feats_) ss += static_cast<double>(v) * v;
+        const double rms = ref_feats_.empty() ? 0.0 : std::sqrt(ss / ref_feats_.size());
+        LOGI("VoxCPM2 reference: %d frames (%zu real samples), feats rms=%.4f "
+             "[tokens: audio_start=%d ref_start=%d ref_end=%d]",
+             ref_frames_, real_samples, rms,
+             audio_start_token_, ref_audio_start_token_, ref_audio_end_token_);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // synthesize() — mirrors speech-models/.../smoke_litert_roundtrip.py
 // ---------------------------------------------------------------------------
 
@@ -59,46 +197,93 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
     if (!on_chunk) return;
     cancelled_.store(false, std::memory_order_relaxed);
 
-    // --- 1. Tokenize: VoxCPM2 was trained on "({instruction}){text}" prompts.
-    // <|audio_start|> signals the model to begin generating audio.
+    // --- 1. Build the prefill sequence. The target text is
+    // "({instruction}){text}" followed by <|audio_start|> (the cue to begin
+    // generating audio). When a reference clip is set, a
+    // [<|ref_audio_start|>, latents…, <|ref_audio_end|>] block is prepended and
+    // its latents fill audio_feats (audio_mask=1), conditioning the output on
+    // the reference speaker. Mirrors the MLX ICL clone path in speech-swift.
     std::string prompt = "(" + instruction_ + ")" + text;
-    std::vector<int> ids = tokenizer_->encode(prompt);
-    ids.push_back(audio_start_token_);
-    if (ids.size() > static_cast<size_t>(kMaxText)) ids.resize(kMaxText);
-    const int context_length = static_cast<int>(ids.size());
+    std::vector<int> target_ids = tokenizer_->encode(prompt);
+    target_ids.push_back(audio_start_token_);
 
-    std::vector<int64_t> text_tokens(kMaxText, 0);
-    std::vector<float>   text_mask  (kMaxText, 0.0f);
-    for (int i = 0; i < context_length; ++i) {
-        text_tokens[i] = ids[i];
-        text_mask[i]   = 1.0f;
+    // With a reference block, the target text must not carry the leading BOS
+    // that encode() prepends: the model was trained on
+    // [ref_block, text, <|audio_start|>] with no sentence-start marker after
+    // the reference. A stray <s> there makes it stop early and emit silence.
+    // (The MLX clone path tokenizes without a BOS for the same reason.)
+    if (ref_frames_ > 0 && !target_ids.empty()
+        && target_ids.front() == tokenizer_->bos_id()) {
+        target_ids.erase(target_ids.begin());
     }
-    // No reference audio — feed zero audio_feats/audio_mask. Voice cloning
-    // would replace these with the audio_encoder output padded to [1,512,4,64].
-    std::vector<float> audio_feats(kMaxText * kPredFeatFloats, 0.0f);
-    std::vector<float> audio_mask (kMaxText, 0.0f);
+
+    std::vector<int64_t> text_tokens(max_text_, 0);
+    std::vector<float>   text_mask  (max_text_, 0.0f);
+    std::vector<float>   audio_feats(static_cast<size_t>(max_text_) * kPredFeatFloats, 0.0f);
+    std::vector<float>   audio_mask (max_text_, 0.0f);
+
+    int pos = 0;
+    if (ref_frames_ > 0) {
+        // Reserve room for the ref block plus at least one target token.
+        if (2 + ref_frames_ + 1 > max_text_) {
+            throw std::runtime_error(
+                "LiteRT VoxCPM2: reference block does not fit the context window");
+        }
+        text_tokens[pos] = ref_audio_start_token_;
+        text_mask[pos]   = 1.0f;
+        ++pos;
+        for (int f = 0; f < ref_frames_; ++f) {
+            audio_mask[pos] = 1.0f;
+            std::memcpy(audio_feats.data() + static_cast<size_t>(pos) * kPredFeatFloats,
+                        ref_feats_.data()  + static_cast<size_t>(f)   * kPredFeatFloats,
+                        kPredFeatFloats * sizeof(float));
+            ++pos;
+        }
+        text_tokens[pos] = ref_audio_end_token_;
+        text_mask[pos]   = 1.0f;
+        ++pos;
+    }
+
+    // Target text fills the rest of the window. If it would overflow, drop from
+    // the front but always keep the trailing <|audio_start|> cue.
+    const int avail = max_text_ - pos;
+    if (static_cast<int>(target_ids.size()) > avail) {
+        std::vector<int> trimmed;
+        trimmed.reserve(static_cast<size_t>(avail));
+        for (int i = 0; i < avail - 1; ++i) trimmed.push_back(target_ids[i]);
+        trimmed.push_back(audio_start_token_);
+        target_ids.swap(trimmed);
+    }
+    for (int id : target_ids) {
+        text_tokens[pos] = id;
+        text_mask[pos]   = 1.0f;
+        ++pos;
+    }
+    const int     context_length        = pos;
     const int64_t context_length_scalar = context_length;
 
     // --- 2. text_prefill → initial hiddens + caches.
     std::vector<float> lm_hidden       (kHidden);
     std::vector<float> residual_hidden (kHidden);
     std::vector<float> prefix_feat_cond(kPredFeatFloats);
-    std::vector<float> base_prefill    (kBasePrefillFloats);
-    std::vector<float> residual_prefill(kResidualPrefillFloats);
+    std::vector<float> base_prefill    (base_prefill_floats_);
+    std::vector<float> residual_prefill(residual_prefill_floats_);
     auto env = LiteRTEngine::get().env();
     {
-        auto t_text_tokens = make_type(kLiteRtElementTypeInt64,   {1, kMaxText});
-        auto t_text_mask   = make_type(kLiteRtElementTypeFloat32, {1, kMaxText});
+        auto t_text_tokens = make_type(kLiteRtElementTypeInt64,   {1, max_text_});
+        auto t_text_mask   = make_type(kLiteRtElementTypeFloat32, {1, max_text_});
         auto t_audio_feats = make_type(kLiteRtElementTypeFloat32,
-                                        {1, kMaxText, kPatchSize, kFeatDim});
-        auto t_audio_mask  = make_type(kLiteRtElementTypeFloat32, {1, kMaxText});
+                                        {1, max_text_, kPatchSize, kFeatDim});
+        auto t_audio_mask  = make_type(kLiteRtElementTypeFloat32, {1, max_text_});
         auto t_ctxlen      = make_type(kLiteRtElementTypeInt64,   {});
 
         auto t_lm    = make_type(kLiteRtElementTypeFloat32, {1, kHidden});
         auto t_resid = make_type(kLiteRtElementTypeFloat32, {1, kHidden});
         auto t_pfc   = make_type(kLiteRtElementTypeFloat32, {1, kPatchSize, kFeatDim});
-        auto t_bcache = make_type(kLiteRtElementTypeFloat32, {2, 28, 1, 2, 512, 128});
-        auto t_rcache = make_type(kLiteRtElementTypeFloat32, {2,  8, 1, 2, 512, 128});
+        auto t_bcache = make_type(kLiteRtElementTypeFloat32,
+                                  {2, kBaseLayers,     1, kKvHeads, max_text_, kHeadDim});
+        auto t_rcache = make_type(kLiteRtElementTypeFloat32,
+                                  {2, kResidualLayers, 1, kKvHeads, max_text_, kHeadDim});
 
         LiteRtHostBuffer in_tokens (env, t_text_tokens, text_tokens.size() * sizeof(int64_t), text_tokens.data());
         LiteRtHostBuffer in_tmask  (env, t_text_mask,   text_mask.size()   * sizeof(float),   text_mask.data());
@@ -128,17 +313,27 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
         out_rcache.read(residual_prefill.data(), residual_prefill.size() * sizeof(float));
     }
 
-    // --- 3. Grow caches 512 → 2560 by zero-padding axis 4. Layout is
-    // [2 (K/V), layers, 1 (batch), kv_heads, seq, head_dim]; we copy the first
-    // 512 seq slots and leave the remaining 2048 zeroed.
-    auto pad_cache = [](const std::vector<float>& src, std::vector<float>& dst,
-                        int layers, int kv_heads, int head_dim) {
-        constexpr int kPrefSeq = 512;
-        constexpr int kFullSeq = 2560;
+    if (std::getenv("VOXCPM2_DEBUG")) {
+        auto rms = [](const std::vector<float>& v) {
+            double s = 0.0; for (float x : v) s += double(x) * x;
+            return v.empty() ? 0.0 : std::sqrt(s / v.size());
+        };
+        LOGI("VoxCPM2 prefill: ctx_len=%d ref_frames=%d lm_rms=%.4f resid_rms=%.4f pfc_rms=%.4f",
+             context_length, ref_frames_, rms(lm_hidden), rms(residual_hidden),
+             rms(prefix_feat_cond));
+    }
+
+    // --- 3. Grow caches from the prefill window (max_text_) to the token_step
+    // window (full_seq_ = max_text_ + max_generated) by zero-padding axis 4.
+    // Layout is [2 (K/V), layers, 1 (batch), kv_heads, seq, head_dim]; copy the
+    // first max_text_ seq slots and leave the remaining slots zeroed.
+    auto pad_cache = [pref_seq = max_text_, full_seq = full_seq_](
+                         const std::vector<float>& src, std::vector<float>& dst,
+                         int layers, int kv_heads, int head_dim) {
         std::fill(dst.begin(), dst.end(), 0.0f);
         const size_t per_kv  = static_cast<size_t>(layers) * kv_heads;
-        const size_t src_row = static_cast<size_t>(kPrefSeq) * head_dim;
-        const size_t dst_row = static_cast<size_t>(kFullSeq) * head_dim;
+        const size_t src_row = static_cast<size_t>(pref_seq) * head_dim;
+        const size_t dst_row = static_cast<size_t>(full_seq) * head_dim;
         for (int kv = 0; kv < 2; ++kv) {
             for (size_t i = 0; i < per_kv; ++i) {
                 const float* src_ptr = src.data() + (kv * per_kv + i) * src_row;
@@ -147,10 +342,10 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
             }
         }
     };
-    std::vector<float> base_cache    (kBaseCacheFloats);
-    std::vector<float> residual_cache(kResidualCacheFloats);
-    pad_cache(base_prefill,     base_cache,     28, 2, 128);
-    pad_cache(residual_prefill, residual_cache,  8, 2, 128);
+    std::vector<float> base_cache    (base_cache_floats_);
+    std::vector<float> residual_cache(residual_cache_floats_);
+    pad_cache(base_prefill,     base_cache,     kBaseLayers,     kKvHeads, kHeadDim);
+    pad_cache(residual_prefill, residual_cache, kResidualLayers, kKvHeads, kHeadDim);
     base_prefill    .clear(); base_prefill    .shrink_to_fit();
     residual_prefill.clear(); residual_prefill.shrink_to_fit();
 
@@ -172,8 +367,10 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
     auto t_lm     = make_type(kLiteRtElementTypeFloat32, {1, kHidden});
     auto t_resid  = make_type(kLiteRtElementTypeFloat32, {1, kHidden});
     auto t_pfc    = make_type(kLiteRtElementTypeFloat32, {1, kPatchSize, kFeatDim});
-    auto t_bcache = make_type(kLiteRtElementTypeFloat32, {2, 28, 1, 2, 2560, 128});
-    auto t_rcache = make_type(kLiteRtElementTypeFloat32, {2,  8, 1, 2, 2560, 128});
+    auto t_bcache = make_type(kLiteRtElementTypeFloat32,
+                              {2, kBaseLayers,     1, kKvHeads, full_seq_, kHeadDim});
+    auto t_rcache = make_type(kLiteRtElementTypeFloat32,
+                              {2, kResidualLayers, 1, kKvHeads, full_seq_, kHeadDim});
     auto t_pos    = make_type(kLiteRtElementTypeInt64,   {});
     auto t_noise  = make_type(kLiteRtElementTypeFloat32, {1, kFeatDim, kPatchSize});
     auto t_pred   = make_type(kLiteRtElementTypeFloat32, {1, kPatchSize, kFeatDim});
@@ -230,6 +427,7 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
     int  steps_done       = 0;
     int  steps_in_chunk   = 0;
     bool stopped_by_model = false;
+    const bool debug_steps = std::getenv("VOXCPM2_DEBUG") != nullptr;
 
     for (int step = 0; step < max_steps_; ++step) {
         if (cancelled_.load(std::memory_order_relaxed)) break;
@@ -284,6 +482,16 @@ void LiteRTVoxCPM2Tts::synthesize(const std::string& text,
         const bool stop_signal = stop_logits[1] > stop_logits[0]
                               && steps_done > min_stop_steps_;
         if (stop_signal) stopped_by_model = true;
+
+        if (debug_steps && (step < 6 || stop_signal)) {
+            float pmax = 0.0f; double sum = 0.0, sq = 0.0;
+            for (float v : pred_feat) { pmax = std::max(pmax, std::abs(v)); sum += v; sq += double(v) * v; }
+            const double mean = sum / pred_feat.size();
+            const double sd = std::sqrt(std::max(0.0, sq / pred_feat.size() - mean * mean));
+            LOGI("VoxCPM2 step %d: pred|max|=%.4f mean=%.4f std=%.4f stop=[%.2f,%.2f]%s",
+                 step, pmax, mean, sd, stop_logits[0], stop_logits[1],
+                 stop_signal ? " STOP" : "");
+        }
 
         if (steps_in_chunk == kFramesPerChunk) {
             flush_decoder(kFramesPerChunk, /*is_final=*/false);

--- a/src/models/litert/voxcpm2_c.cpp
+++ b/src/models/litert/voxcpm2_c.cpp
@@ -1,0 +1,103 @@
+// C ABI implementation for VoxCPM2 voice cloning — see speech_core/voxcpm2_c.h.
+// Thin wrapper over LiteRTVoxCPM2Tts; lives in speech_core_models_litert.
+
+#include "speech_core/voxcpm2_c.h"
+#include "speech_core/models/litert_voxcpm2_tts.h"
+
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <string>
+
+using speech_core::LiteRTVoxCPM2Tts;
+
+struct sc_voxcpm2_s {
+    std::unique_ptr<LiteRTVoxCPM2Tts> tts;
+    std::string last_error;
+};
+
+extern "C" {
+
+sc_voxcpm2_t sc_voxcpm2_create(const char* bundle_dir) {
+    if (!bundle_dir) return nullptr;
+    try {
+        const std::string b = bundle_dir;
+        auto* h = new sc_voxcpm2_s();
+        h->tts = std::make_unique<LiteRTVoxCPM2Tts>(
+            b + "/voxcpm2-text-prefill.tflite",
+            b + "/voxcpm2-token-step.tflite",
+            b + "/voxcpm2-audio-encoder.tflite",
+            b + "/voxcpm2-audio-decoder.tflite",
+            b + "/tokenizer.json",
+            /*hw_accel=*/false);
+        return h;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[speech ERROR] sc_voxcpm2_create: %s\n", e.what());
+        return nullptr;
+    }
+}
+
+void sc_voxcpm2_destroy(sc_voxcpm2_t s) { delete s; }
+
+void sc_voxcpm2_set_instruction(sc_voxcpm2_t s, const char* instruction) {
+    if (s && s->tts) s->tts->set_instruction(instruction ? instruction : "");
+}
+
+void sc_voxcpm2_set_max_steps(sc_voxcpm2_t s, int max_steps) {
+    if (s && s->tts) s->tts->set_max_steps(max_steps);
+}
+
+void sc_voxcpm2_set_min_steps_before_stop(sc_voxcpm2_t s, int min_steps) {
+    if (s && s->tts) s->tts->set_min_steps_before_stop(min_steps);
+}
+
+int sc_voxcpm2_set_reference(sc_voxcpm2_t s, const float* pcm,
+                             size_t length, int sample_rate) {
+    if (!s || !s->tts) return -1;
+    try {
+        s->tts->set_reference(pcm, length, sample_rate);
+        s->last_error.clear();
+        return 0;
+    } catch (const std::exception& e) {
+        s->last_error = e.what();
+        return -1;
+    }
+}
+
+void sc_voxcpm2_clear_reference(sc_voxcpm2_t s) {
+    if (s && s->tts) s->tts->clear_reference();
+}
+
+int sc_voxcpm2_output_sample_rate(sc_voxcpm2_t s) {
+    return (s && s->tts) ? s->tts->output_sample_rate() : 0;
+}
+
+int sc_voxcpm2_synthesize(sc_voxcpm2_t s, const char* text,
+                          sc_voxcpm2_chunk_fn on_chunk, void* context) {
+    if (!s || !s->tts) return -1;
+    if (!text || !on_chunk) {
+        if (s) s->last_error = "null text or callback";
+        return -1;
+    }
+    try {
+        s->tts->synthesize(text, "auto",
+            [on_chunk, context](const float* samples, size_t length, bool is_final) {
+                on_chunk(samples, length, is_final, context);
+            });
+        s->last_error.clear();
+        return 0;
+    } catch (const std::exception& e) {
+        s->last_error = e.what();
+        return -1;
+    }
+}
+
+void sc_voxcpm2_cancel(sc_voxcpm2_t s) {
+    if (s && s->tts) s->tts->cancel();
+}
+
+const char* sc_voxcpm2_last_error(sc_voxcpm2_t s) {
+    return s ? s->last_error.c_str() : "";
+}
+
+}  // extern "C"

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -18,6 +18,7 @@
 #include "speech_core/models/litert_voxcpm2_tts.h"
 #include "speech_core/models/voxcpm2_tokenizer.h"
 #include "speech_core/vad/streaming_vad.h"
+#include "speech_core/voxcpm2_c.h"
 
 #include <algorithm>
 #include <cctype>
@@ -586,6 +587,125 @@ void test_voxcpm2_tokenizer(const std::string& dir) {
     std::printf("ok\n");
 }
 
+// ---------------------------------------------------------------------------
+// VoxCPM2 voice cloning — conditions on the test fixture as a reference clip
+// and synthesizes a known phrase, asserting non-silent finite audio. The
+// fixture's silent lead-in is trimmed inside set_reference(). Dumps a WAV when
+// VOXCPM2_CLONE_WAV is set so CI can ASR round-trip it.
+// ---------------------------------------------------------------------------
+
+void dump_wav48k_mono(const char* path, const std::vector<float>& audio) {
+    std::ofstream w(path, std::ios::binary);
+    if (!w) return;
+    const uint32_t rate = 48000, n = static_cast<uint32_t>(audio.size());
+    const uint32_t data = n * 2, riff = 36 + data;
+    auto u32 = [&](uint32_t v) { w.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { w.write(reinterpret_cast<const char*>(&v), 2); };
+    w.write("RIFF", 4); u32(riff); w.write("WAVE", 4);
+    w.write("fmt ", 4); u32(16); u16(1); u16(1); u32(rate); u32(rate * 2); u16(2); u16(16);
+    w.write("data", 4); u32(data);
+    for (float s : audio) {
+        if (s < -1.0f) s = -1.0f; if (s > 1.0f) s = 1.0f;
+        u16(static_cast<uint16_t>(static_cast<int16_t>(s * 32767.0f)));
+    }
+}
+
+void check_voice_audio(const std::vector<float>& audio, const char* tag) {
+    REQUIRE(!audio.empty());
+    const size_t steps = audio.size() / 7680;
+    REQUIRE(steps >= 8);
+    double sum_sq = 0.0; float peak = 0.0f;
+    for (float s : audio) {
+        if (!std::isfinite(s)) { std::printf("\n    %s non-finite ", tag); REQUIRE(false); }
+        sum_sq += static_cast<double>(s) * s; peak = std::max(peak, std::abs(s));
+    }
+    const double rms = std::sqrt(sum_sq / audio.size());
+    std::printf("%s steps=%zu rms=%.4f peak=%.4f ", tag, steps, rms, peak);
+    REQUIRE(rms > 1e-3);     // cloned output must not be silent
+    REQUIRE(peak < 1.5f);
+}
+
+void test_litert_voxcpm2_clone(const std::string& dir) {
+    std::string pref = dir + "/voxcpm2-text-prefill.tflite";
+    std::string step = dir + "/voxcpm2-token-step.tflite";
+    std::string enc  = dir + "/voxcpm2-audio-encoder.tflite";
+    std::string dec  = dir + "/voxcpm2-audio-decoder.tflite";
+    std::string tok  = dir + "/tokenizer.json";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(pref) || !file_exists(step) || !file_exists(enc)
+        || !file_exists(dec) || !file_exists(tok)) {
+        std::printf("  [skip] voxcpm2 files not in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_voxcpm2_clone ... ");
+
+    speech_core::LiteRTVoxCPM2Tts tts(pref, step, enc, dec, tok, /*hw_accel=*/false);
+    tts.set_instruction("clear, natural delivery");
+    tts.set_max_steps(128);
+    tts.set_min_steps_before_stop(32);
+    tts.set_reference(wav.samples.data(), wav.samples.size(), wav.sample_rate);
+    REQUIRE(tts.has_reference());
+
+    std::vector<float> audio;
+    bool got_final = false;
+    tts.synthesize("The quick brown fox jumps over the lazy dog", "en",
+        [&](const float* s, size_t len, bool is_final) {
+            if (s && len) audio.insert(audio.end(), s, s + len);
+            if (is_final) got_final = true;
+        });
+    REQUIRE(got_final);
+    check_voice_audio(audio, "clone");
+
+    const char* wav_out = std::getenv("VOXCPM2_CLONE_WAV");
+    if (wav_out) { dump_wav48k_mono(wav_out, audio); std::printf("wav=%s ", wav_out); }
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// VoxCPM2 C ABI (sc_voxcpm2_*) — the surface speech-studio links via FFI. Drives
+// a clone through the C entry points and asserts non-silent audio.
+// ---------------------------------------------------------------------------
+
+void test_voxcpm2_c_api(const std::string& dir) {
+    std::string pref = dir + "/voxcpm2-text-prefill.tflite";
+    std::string tok  = dir + "/tokenizer.json";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(pref) || !file_exists(tok) || wav.samples.empty()) {
+        std::printf("  [skip] voxcpm2 files/fixture not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_voxcpm2_c_api ... ");
+
+    sc_voxcpm2_t v = sc_voxcpm2_create(dir.c_str());
+    REQUIRE(v != nullptr);
+    REQUIRE(sc_voxcpm2_output_sample_rate(v) == 48000);
+    sc_voxcpm2_set_instruction(v, "clear, natural delivery");
+    sc_voxcpm2_set_max_steps(v, 128);
+    sc_voxcpm2_set_min_steps_before_stop(v, 32);
+
+    int rc = sc_voxcpm2_set_reference(v, wav.samples.data(), wav.samples.size(),
+                                      wav.sample_rate);
+    if (rc != 0) std::printf("\n    set_reference: %s ", sc_voxcpm2_last_error(v));
+    REQUIRE(rc == 0);
+
+    std::vector<float> audio;
+    rc = sc_voxcpm2_synthesize(v, "The quick brown fox jumps over the lazy dog",
+        [](const float* s, size_t len, bool, void* ctx) {
+            auto* out = static_cast<std::vector<float>*>(ctx);
+            if (s && len) out->insert(out->end(), s, s + len);
+        }, &audio);
+    if (rc != 0) std::printf("\n    synthesize: %s ", sc_voxcpm2_last_error(v));
+    REQUIRE(rc == 0);
+    check_voice_audio(audio, "c_api");
+
+    sc_voxcpm2_destroy(v);
+    std::printf("ok\n");
+}
+
 }  // namespace
 
 int main() {
@@ -608,6 +728,8 @@ int main() {
     test_voxcpm2_tokenizer(dir);
     test_litert_voxcpm2_load(dir);
     test_litert_voxcpm2_synthesize(dir);
+    test_litert_voxcpm2_clone(dir);
+    test_voxcpm2_c_api(dir);
 
     if (failures > 0) {
         std::fprintf(stderr, "\n%d test(s) failed\n", failures);


### PR DESCRIPTION
## Why

The LiteRT VoxCPM2 wrapper loaded the `audio_encoder` graph but never used it — `synthesize()` always fed zero `audio_feats`, so the cross-platform backend could do plain TTS but not the **voice cloning** Studio's MVP is built around. Today only the macOS MLX sidecar can clone; this wires the conditioning end to end so Linux/Windows hosts can clone a speaker from a reference clip.

## What changed

- **Cloning**: `set_reference(pcm, len, sr)` resamples to 16 kHz, runs the `audio_encoder`, and caches the speaker latents. `synthesize()` builds the masked prefill sequence `[<|ref_audio_start|>, latents…, <|ref_audio_end|>, text…, <|audio_start|>]`, mirroring the MLX ICL clone path in `speech-swift`'s `VoxCPM2TTS.generateVoxCPM2` (`hasRef`).
- **Leading-silence trim**: the encoder window is a fixed 6.4 s taken from the front, so a quiet lead-in would fill it with silence and clone a *silent speaker* (observed as dead-silent output). `set_reference()` now trims leading silence with a peak-relative energy gate.
- **Adaptive context geometry**: query `max_text` from the prefill graph instead of hardcoding 512, so both the 256- and 512-token exports load.
- **Callable surfaces**: a `sc_voxcpm2_*` C ABI (`include/speech_core/voxcpm2_c.h`, for the speech-studio Rust FFI) and a `speech_voxcpm2_clone` CLI for standalone use/testing.
- **Tests/CI**: `test_litert_voxcpm2_clone` (C++) + `test_voxcpm2_c_api` (C ABI) in `test_litert_models`, plus a cloned-voice ASR round-trip in the weekly VoxCPM2 workflow.

## Test plan

- [x] `test_litert_models` passes against a local INT8 bundle — clone and C-ABI paths produce identical (deterministic) audible output (rms ~0.077).
- [x] ASR round-trip on the cloned output returns the input phrase ("The quick brown fox jumps over the lazy dog").
- [x] Cross-checked the recipe against the MLX reference (`speech speak --engine voxcpm2 --voxcpm2-ref-audio …`) — also ASR-exact.
- [x] Baseline (no-reference) TTS unchanged; builds clean with `-Wall -Wextra`.
- [ ] Weekly VoxCPM2 workflow confirms both round-trips on the deployed 512-context bundle.