### PR TITLE
models: upstream the server-side LiteRT wrappers + interfaces

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,10 +105,12 @@ jobs:
           test -f litert/libLiteRt.so
 
       - name: Download LiteRT models (if not cached)
-        # HF_TOKEN lets the (possibly private) soniqo/* repos resolve —
-        # including the diarization + omnilingual models for the upstreamed
-        # wrappers. Core models (silero/parakeet) are asserted below; the
-        # extra models are best-effort and their tests skip if absent.
+        # soniqo/* model repos are public — no token required; the diarization +
+        # omnilingual + nemotron models fetch anonymously alongside the core
+        # ones. HF_TOKEN is passed through if the secret happens to exist
+        # (harmless no-op otherwise, supports a future private mirror). Core
+        # models are asserted below; the extras are best-effort and their tests
+        # skip if absent.
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,12 +105,19 @@ jobs:
           test -f litert/libLiteRt.so
 
       - name: Download LiteRT models (if not cached)
+        # HF_TOKEN lets the (possibly private) soniqo/* repos resolve —
+        # including the diarization + omnilingual models for the upstreamed
+        # wrappers. Core models (silero/parakeet) are asserted below; the
+        # extra models are best-effort and their tests skip if absent.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           if [ ! -f scripts/models-litert/parakeet-encoder.tflite ]; then
               ./scripts/download_models_litert.sh
           fi
           test -f scripts/models-litert/silero-vad.tflite
           test -f scripts/models-litert/parakeet-encoder.tflite
+          echo "models present:" && ls -1 scripts/models-litert/
 
       - name: Configure
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@
 speech-core — voice agent pipeline engine in C++17. Provides:
 
 1. **Orchestration core** — state machine, turn detection, interruption handling, speech queue, conversation context, streaming VAD state machine, audio utilities. Zero ML dependencies, pure C++17.
-2. **Abstract interfaces** — `STTInterface`, `TTSInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`, `LLMInterface` in `include/speech_core/interfaces.h`. Consumers (speech-swift, speech-android, …) implement these with their own model backends.
+2. **Abstract interfaces** — `STTInterface`, `TTSInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`, `LLMInterface`, plus the batch diarization interfaces `SegmentationInterface`, `EmbeddingInterface`, `DiarizerInterface` (with `SegmentationWindow` / `DiarizedSegment` / `DiarizerConfig` types) in `include/speech_core/interfaces.h`. Consumers (speech-swift, speech-android, speech-cloud, …) implement these with their own model backends.
 3. **Optional ONNX reference implementations** — `SileroVad`, `ParakeetStt`, `KokoroTts`, `DeepFilterEnhancer` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_ONNX=ON`.
-4. **Optional LiteRT reference implementations** — `LiteRTSileroVad`, `LiteRTParakeetStt`, `LiteRTVoxCPM2Tts` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_LITERT=ON`. Backed by `libLiteRt` from Google's `ai-edge-litert` package (extracted from the PyPI wheel by `scripts/fetch_litert.sh`). Kokoro and DeepFilter LiteRT exports don't exist yet; wrappers will follow once `speech-models` ships them.
+4. **Optional LiteRT reference implementations** — `LiteRTSileroVad`, `LiteRTParakeetStt`, `LiteRTVoxCPM2Tts`, `LiteRTWeSpeakerEmbedding`, `LiteRTPyannoteSegmentation`, `LiteRTOmnilingualStt`, `LiteRTNemotronStreamingStt` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_LITERT=ON`. Backed by `libLiteRt` from Google's `ai-edge-litert` package (extracted from the PyPI wheel by `scripts/fetch_litert.sh`). Kokoro and DeepFilter LiteRT exports don't exist yet; wrappers will follow once `speech-models` ships them.
+5. **Diarization** — `DiarizationPipeline` (`DiarizerInterface`) in `include/speech_core/diarization/`. Pure C++17, no ML-runtime dependency, built into the **core** library; composes a `SegmentationInterface` + `EmbeddingInterface` with constrained agglomerative clustering.
 
 ## Structure
 
@@ -63,7 +64,7 @@ cmake --build build
 
 - **`speech_core`** — static library, orchestration + interfaces + audio utilities. No ORT. Always built.
 - **`speech_core_models`** — static library, ONNX Runtime reference implementations. Links `speech_core` + imported `onnxruntime`. Only built when `SPEECH_CORE_WITH_ONNX=ON`.
-- **`speech_core_models_litert`** — static library, LiteRT reference implementations (Silero VAD, Parakeet STT, VoxCPM2 TTS, VoxCPM2 tokenizer). Links `speech_core` + imported `litert` (`libLiteRt` from ai-edge-litert). Only built when `SPEECH_CORE_WITH_LITERT=ON`.
+- **`speech_core_models_litert`** — static library, LiteRT reference implementations (Silero VAD, Parakeet STT, VoxCPM2 TTS, WeSpeaker embedding, Pyannote segmentation, Omnilingual STT, Nemotron streaming STT, VoxCPM2 tokenizer). Links `speech_core` + imported `litert` (`libLiteRt` from ai-edge-litert). Only built when `SPEECH_CORE_WITH_LITERT=ON`. (`DiarizationPipeline` is pure C++ and lives in `speech_core` itself, not here.)
 
 Consumers link the targets they need:
 
@@ -77,7 +78,7 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + 
 
 | File | Purpose |
 |---|---|
-| `include/speech_core/interfaces.h` | Abstract STT / TTS / VAD / Enhancer / AEC / LLM interfaces |
+| `include/speech_core/interfaces.h` | Abstract STT / TTS / VAD / Enhancer / AEC / LLM + Segmentation / Embedding / Diarizer interfaces |
 | `include/speech_core/pipeline/voice_pipeline.h` | Main orchestrator |
 | `include/speech_core/pipeline/turn_detector.h` | VAD-driven turn boundaries + interruption logic |
 | `include/speech_core/pipeline/speech_queue.h` | Priority queue with cancel/resume |
@@ -91,8 +92,13 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + 
 | `include/speech_core/models/litert_silero_vad.h` | Silero VAD v5 (LiteRT) — implements `VADInterface` |
 | `include/speech_core/models/litert_parakeet_stt.h` | Parakeet TDT v3 (LiteRT, INT8 encoder) — implements `STTInterface` |
 | `include/speech_core/models/litert_voxcpm2_tts.h` | VoxCPM2 (LiteRT) — implements `TTSInterface` (4-graph pipeline) |
+| `include/speech_core/models/litert_wespeaker_embedding.h` | WeSpeaker ResNet34-LM (LiteRT) — implements `EmbeddingInterface` |
+| `include/speech_core/models/litert_pyannote_segmentation.h` | Pyannote Segmentation 3.0 (LiteRT) — implements `SegmentationInterface` |
+| `include/speech_core/models/litert_omnilingual_stt.h` | Omnilingual ASR CTC-300M (LiteRT) — implements `STTInterface` |
+| `include/speech_core/models/litert_nemotron_streaming_stt.h` | Nemotron Speech Streaming 0.6B (LiteRT) — streaming `STTInterface` |
 | `include/speech_core/models/voxcpm2_tokenizer.h` | Hand-rolled BPE tokenizer for VoxCPM2 (pure C++17, no deps) |
 | `include/speech_core/models/litert_engine.h` | LiteRT environment + CompiledModel + TensorBuffer RAII (CPU only) |
+| `include/speech_core/diarization/diarization_pipeline.h` | `DiarizationPipeline` (`DiarizerInterface`) — segmentation + embedding + clustering, core lib |
 | `third_party/litert/` | Vendored LiteRT C API headers (~44 files, ~408 KB) |
 
 ## Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(speech_core
     src/tools/tool_registry.cpp
     src/tools/intent_matcher.cpp
     src/tools/tool_executor.cpp
+    src/diarization/diarization_pipeline.cpp
     src/speech_core_c.cpp
 )
 
@@ -161,6 +162,9 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/litert_voxcpm2_tts.cpp
         src/models/litert/voxcpm2_c.cpp
         src/models/litert/voxcpm2_tokenizer.cpp
+        src/models/litert/litert_wespeaker_embedding.cpp
+        src/models/litert/litert_pyannote_segmentation.cpp
+        src/models/litert/litert_omnilingual_stt.cpp
     )
 
     target_include_directories(speech_core_models_litert

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/litert_wespeaker_embedding.cpp
         src/models/litert/litert_pyannote_segmentation.cpp
         src/models/litert/litert_omnilingual_stt.cpp
+        src/models/litert/litert_nemotron_streaming_stt.cpp
     )
 
     target_include_directories(speech_core_models_litert

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ Consumers can enable either, both, or neither — and can always bring their own
 | Kokoro 82M | TTS | ✓ | — |
 | DeepFilterNet3 | Enhancer | ✓ | — |
 | VoxCPM2 (2B) | TTS | — | ✓ |
+| WeSpeaker ResNet34-LM | Speaker embedding | — | ✓ |
+| Pyannote Segmentation 3.0 | Diarization | — | ✓ |
+| Omnilingual ASR CTC-300M | STT | — | ✓ |
+| Nemotron Speech Streaming 0.6B | Streaming STT | — | ✓ |
 
-(Kokoro / DeepFilterNet3 don't have LiteRT exports yet, and VoxCPM2 has no ONNX export — wrappers land as `speech-models` ships the artifacts.)
+(Kokoro / DeepFilterNet3 don't have LiteRT exports yet; VoxCPM2 and the diarization / streaming models have no ONNX export — wrappers land as `speech-models` ships the artifacts.)
 
 ## Backends & platforms
 
@@ -57,6 +61,13 @@ Both backends run CPU inference today; GPU / NNAPI / QNN delegate selection is a
 ```
 
 See [`docs/interfaces.md`](docs/interfaces.md) and [`docs/models.md`](docs/models.md) for details.
+
+The LiteRT backend additionally ships server-side meeting models —
+`LiteRTWeSpeakerEmbedding`, `LiteRTPyannoteSegmentation`, `LiteRTOmnilingualStt`,
+and the streaming `LiteRTNemotronStreamingStt` — plus a pure-C++
+`DiarizationPipeline` (in the always-built core) that composes a segmenter +
+embedder into speaker-labelled segments. These implement the batch diarization
+interfaces (`SegmentationInterface`, `EmbeddingInterface`, `DiarizerInterface`).
 
 ## Pipeline Modes
 
@@ -117,8 +128,14 @@ LiteRT wrappers (`SPEECH_CORE_WITH_LITERT`):
 | `litert_silero_vad.h` | `VADInterface` | Silero VAD v5 |
 | `litert_parakeet_stt.h` | `STTInterface` | Parakeet TDT v3, INT8 encoder |
 | `litert_voxcpm2_tts.h` | `TTSInterface` | VoxCPM2 (2B), 48 kHz, 4-graph pipeline |
+| `litert_wespeaker_embedding.h` | `EmbeddingInterface` | WeSpeaker ResNet34-LM, 256-dim, kaldi fbank |
+| `litert_pyannote_segmentation.h` | `SegmentationInterface` | Pyannote Segmentation 3.0, streaming 1-s chunks |
+| `litert_omnilingual_stt.h` | `STTInterface` | Omnilingual ASR CTC-300M + SentencePiece decode |
+| `litert_nemotron_streaming_stt.h` | `STTInterface` | Nemotron Speech Streaming 0.6B, true streaming RNN-T |
 | `voxcpm2_tokenizer.h` | (internal) | Hand-rolled BPE tokenizer, pure C++17 |
 | `litert_engine.h` | (internal) | LiteRT environment + CompiledModel + TensorBuffer RAII |
+
+Diarization (`include/speech_core/diarization/`, no ML-runtime dep): `diarization_pipeline.h` — `DiarizationPipeline` (`DiarizerInterface`) composes a `SegmentationInterface` + `EmbeddingInterface` with constrained clustering. Built into the core library.
 
 See [`docs/models.md`](docs/models.md) for usage.
 
@@ -130,7 +147,7 @@ See [`docs/models.md`](docs/models.md) for usage.
 
 ### Interfaces (`include/speech_core/interfaces.h`)
 
-Abstract classes any backend implements: `STTInterface`, `TTSInterface`, `LLMInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`. See the header for signatures.
+Abstract classes any backend implements: `STTInterface`, `TTSInterface`, `LLMInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`, plus the batch diarization interfaces `SegmentationInterface`, `EmbeddingInterface`, `DiarizerInterface`. See the header for signatures.
 
 ### Tools (`include/speech_core/tools/`)
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -155,6 +155,59 @@ public:
 
 Only needed for the `VoicePipeline` mode (full agent loop). Not needed for `Echo` or `TranscribeOnly` modes.
 
+## Diarization interfaces (batch, server-side)
+
+Three additional interfaces support multi-speaker meeting diarization. Unlike
+the real-time pipeline interfaces above they operate on a whole audio buffer and
+are **not** consumed by `VoicePipeline`; a `DiarizationPipeline` (in
+`speech_core/diarization/`) composes a segmenter + embedder + clustering. The
+shared types `SegmentationWindow`, `DiarizedSegment{start,end,speaker}`, and
+`DiarizerConfig` live in `interfaces.h` alongside them.
+
+### SegmentationInterface — local speaker activity per window
+
+```cpp
+class SegmentationInterface {
+public:
+    virtual ~SegmentationInterface() = default;
+    virtual std::vector<SegmentationWindow> segment(
+        const float* audio, size_t length, int sample_rate) = 0;
+    virtual int input_sample_rate() const = 0;
+    virtual int max_local_speakers() const = 0;
+};
+```
+
+**Reference implementation:** `LiteRTPyannoteSegmentation` (Pyannote Segmentation 3.0 via LiteRT, streaming 1-s chunks, powerset-decoded per-speaker activity).
+
+### EmbeddingInterface — speaker embedding
+
+```cpp
+class EmbeddingInterface {
+public:
+    virtual ~EmbeddingInterface() = default;
+    virtual std::vector<float> embed(
+        const float* audio, size_t length, int sample_rate) = 0;
+    virtual int embedding_dim() const = 0;
+    virtual int input_sample_rate() const = 0;
+};
+```
+
+**Reference implementation:** `LiteRTWeSpeakerEmbedding` (WeSpeaker ResNet34-LM via LiteRT, 256-dim L2-normalised vector).
+
+### DiarizerInterface — end-to-end diarization
+
+```cpp
+class DiarizerInterface {
+public:
+    virtual ~DiarizerInterface() = default;
+    virtual std::vector<DiarizedSegment> diarize(
+        const float* audio, size_t length, int sample_rate,
+        const DiarizerConfig& config) = 0;
+};
+```
+
+**Reference implementation:** `DiarizationPipeline` (`speech_core/diarization/diarization_pipeline.h`) — composes a `SegmentationInterface` + `EmbeddingInterface` with constrained agglomerative clustering. Pure C++, ships in the core library (no ML-runtime dependency).
+
 ## Design choices
 
 1. **Direct inheritance.** Models inherit interfaces directly (`class SileroVad : public VADInterface`) rather than going through adapter classes. speech-swift uses extension files to keep the same separation (Swift only — C++ has no equivalent). With only one consumer (speech-core itself), the indirection isn't worth its cost; revisit if a new caller wants the models without the orchestration.

--- a/docs/models.md
+++ b/docs/models.md
@@ -18,6 +18,12 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 | `LiteRTSileroVad` | `VADInterface` | `speech_core/models/litert_silero_vad.h` | full |
 | `LiteRTParakeetStt` | `STTInterface` | `speech_core/models/litert_parakeet_stt.h` | full |
 | `LiteRTVoxCPM2Tts` | `TTSInterface` | `speech_core/models/litert_voxcpm2_tts.h` | full (text-only) |
+| `LiteRTWeSpeakerEmbedding` | `EmbeddingInterface` | `speech_core/models/litert_wespeaker_embedding.h` | full |
+| `LiteRTPyannoteSegmentation` | `SegmentationInterface` | `speech_core/models/litert_pyannote_segmentation.h` | full |
+| `LiteRTOmnilingualStt` | `STTInterface` | `speech_core/models/litert_omnilingual_stt.h` | full |
+| `LiteRTNemotronStreamingStt` | `STTInterface` | `speech_core/models/litert_nemotron_streaming_stt.h` | full (streaming) |
+
+`DiarizationPipeline` (`speech_core/diarization/diarization_pipeline.h`, implements `DiarizerInterface`) composes a segmenter + embedder + constrained clustering. It is pure C++ and ships in the **core** library (built always, no LiteRT dependency); pair it with the LiteRT segmenter + embedder above.
 
 Kokoro 82M and DeepFilterNet3 do not yet have LiteRT exports — see `speech-models` for conversion status. When they land, wrappers will be added alongside the existing two.
 
@@ -163,6 +169,78 @@ tts.synthesize("Hello world", "en", [](const float* samples, size_t length, bool
 - Bundle is large (~4.6 GB total). Download with the dedicated script `scripts/download_voxcpm2_litert.sh`; we deliberately don't include it in `download_models_litert.sh` because the bundle blows the standard nightly's `actions/cache` budget.
 - Model files: [aufklarer/VoxCPM2-LiteRT](https://huggingface.co/aufklarer/VoxCPM2-LiteRT) — `voxcpm2-{text-prefill,token-step,audio-encoder,audio-decoder}.tflite`, `tokenizer.json`, `config.json`
 
+## LiteRTWeSpeakerEmbedding
+
+```cpp
+#include <speech_core/models/litert_wespeaker_embedding.h>
+
+speech_core::LiteRTWeSpeakerEmbedding emb("/models/wespeaker-resnet34.tflite");
+auto vec = emb.embed(audio, length, 16000);   // 256-float L2-normalised
+```
+
+- WeSpeaker ResNet34-LM. Computes a kaldi-style 80-bin log-mel fbank (25 ms / 10 ms, Hamming, per-frame DC removal) from raw 16 kHz audio internally; pads/tiles to the fixed 298-frame (~3 s) input.
+- Model files: [soniqo/WeSpeaker-ResNet34-LM-LiteRT](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) — `wespeaker-resnet34.tflite`
+
+## LiteRTPyannoteSegmentation
+
+```cpp
+#include <speech_core/models/litert_pyannote_segmentation.h>
+
+speech_core::LiteRTPyannoteSegmentation seg("/models/pyannote-segmentation.tflite");
+auto windows = seg.segment(audio, length, 16000);   // per-10 s window posteriors + speaker_activity
+```
+
+- Pyannote Segmentation 3.0, streaming mode: 1-s chunks with LSTM state carried across a 10-s window (reset per window, slide by 5 s). Powerset-decodes 7 classes → per-speaker activity for up to 3 local speakers.
+- Model files: [soniqo/Pyannote-Segmentation-LiteRT](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) — `pyannote-segmentation.tflite`
+
+## LiteRTOmnilingualStt
+
+```cpp
+#include <speech_core/models/litert_omnilingual_stt.h>
+
+speech_core::LiteRTOmnilingualStt stt("/models/omnilingual-ctc-300m.tflite",
+                                      "/models/tokenizer.model");
+auto result = stt.transcribe(audio, length, 16000);
+```
+
+- Meta Omnilingual ASR CTC-300M. Single-model CTC: z-score-normalised waveform → logits @ 50 Hz; greedy CTC decode (collapse repeats + blanks) with a minimal SentencePiece `.model` tokenizer. Fixed chunk length + vocab size are read from the model output layout at load.
+- Model files: [soniqo/Omnilingual-ASR-CTC-300M-LiteRT](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) — `omnilingual-ctc-300m.tflite`, `tokenizer.model`
+
+## LiteRTNemotronStreamingStt
+
+```cpp
+#include <speech_core/models/litert_nemotron_streaming_stt.h>
+
+speech_core::LiteRTNemotronStreamingStt stt(
+    "/models/nemotron-streaming-encoder.tflite",
+    "/models/nemotron-streaming-decoder.tflite",
+    "/models/nemotron-streaming-joint.tflite",
+    "/models/vocab.json");
+
+stt.begin_stream(16000);
+auto partial = stt.push_chunk(audio_chunk, chunk_len);   // partial.text grows as windows fill
+auto final   = stt.end_stream();
+```
+
+- Nemotron Speech Streaming 0.6B — **true** cache-aware streaming RNN-T (three graphs: encoder-with-cache, decoder LSTM, joint). `push_chunk` drains fixed ~80 ms windows, advancing the encoder cache + decoder state across calls and greedily decoding the first encoder frame. One instance == one stream.
+- Config defaults match the export; vocab size auto-derives from `vocab.json`.
+- Model files: [soniqo/Nemotron-Speech-Streaming-LiteRT](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) — `nemotron-streaming-{encoder,decoder,joint}.tflite`, `vocab.json`, `config.json`
+
+## DiarizationPipeline
+
+```cpp
+#include <speech_core/diarization/diarization_pipeline.h>
+
+speech_core::LiteRTPyannoteSegmentation seg("/models/pyannote-segmentation.tflite");
+speech_core::LiteRTWeSpeakerEmbedding   emb("/models/wespeaker-resnet34.tflite");
+speech_core::DiarizationPipeline        diar(seg, emb);
+
+speech_core::DiarizerConfig cfg;   // onset/offset/min_speech/clustering_threshold/min,max_speakers
+auto segments = diar.diarize(audio, length, 16000, cfg);  // [{start,end,speaker}, …]
+```
+
+- Pure-C++ orchestration (no LiteRT dependency): segmentation → per-speaker embedding → constrained agglomerative clustering (cosine distance, window-uniqueness constraint) → merged speaker-labelled segments. Lives in the **core** library; inject any `SegmentationInterface` + `EmbeddingInterface`.
+
 ## KokoroTts
 
 ```cpp
@@ -248,7 +326,7 @@ SPEECH_MODEL_DIR=scripts/models ctest --test-dir build --output-on-failure
 
 `test_models` skips cleanly with exit code 0 when `SPEECH_MODEL_DIR` is unset or model files are missing — CI without model artifacts stays green.
 
-A separate `test_litert_models` target is added when `SPEECH_CORE_WITH_LITERT=ON`, exercising the three LiteRT wrappers (Silero VAD, Parakeet STT, VoxCPM2 TTS) + the VoxCPM2 tokenizer against `.tflite` artifacts:
+A separate `test_litert_models` target is added when `SPEECH_CORE_WITH_LITERT=ON`, exercising the LiteRT wrappers (Silero VAD, Parakeet STT, VoxCPM2 TTS, WeSpeaker embedding, Pyannote segmentation, Omnilingual STT, Nemotron streaming STT) + the `DiarizationPipeline` + the VoxCPM2 tokenizer against `.tflite` artifacts:
 
 ```bash
 scripts/fetch_litert.sh build/litert        # extracts libLiteRt from ai-edge-litert wheel

--- a/include/speech_core/diarization/diarization_pipeline.h
+++ b/include/speech_core/diarization/diarization_pipeline.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <vector>
+
+namespace speech_core {
+
+/// Full diarization: segmentation → embedding → constrained agglomerative
+/// clustering. Composes a SegmentationInterface (per-window local speaker
+/// activity) with an EmbeddingInterface (per-speaker vectors). Backend-agnostic
+/// — pure orchestration, no ML runtime dependency.
+class DiarizationPipeline : public DiarizerInterface {
+public:
+    DiarizationPipeline(SegmentationInterface& seg,
+                        EmbeddingInterface& emb,
+                        float clustering_threshold = 0.715f);
+
+    std::vector<DiarizedSegment> diarize(
+        const float* audio, size_t length, int sample_rate,
+        const DiarizerConfig& config) override;
+
+private:
+    struct LocalSpeaker {
+        int   window_idx;
+        int   local_speaker;
+        float start;
+        float end;
+        std::vector<float> embedding;
+    };
+
+    std::vector<LocalSpeaker> extract_embeddings(
+        const float* audio, size_t length,
+        const std::vector<SegmentationWindow>& windows,
+        const DiarizerConfig& config);
+
+    std::vector<int> cluster(
+        const std::vector<LocalSpeaker>& speakers,
+        float threshold, int min_clusters, int max_clusters);
+
+    std::vector<DiarizedSegment> build_segments(
+        const std::vector<SegmentationWindow>& windows,
+        const std::vector<LocalSpeaker>& local_speakers,
+        const std::vector<int>& cluster_ids,
+        const DiarizerConfig& config);
+
+    SegmentationInterface& seg_;
+    EmbeddingInterface&    emb_;
+    float default_threshold_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/interfaces.h
+++ b/include/speech_core/interfaces.h
@@ -235,4 +235,81 @@ public:
     virtual void reset() = 0;
 };
 
+// ---------------------------------------------------------------------------
+// Diarization — speaker segmentation, embedding, and clustering
+// ---------------------------------------------------------------------------
+// These support multi-speaker meeting transcription (server-side). Unlike the
+// real-time conversational interfaces above, they operate on a whole audio
+// buffer. A Diarizer typically composes a SegmentationInterface (local speaker
+// activity per window) with an EmbeddingInterface (speaker vectors for
+// cross-window clustering).
+
+/// One speaker-labelled time span.
+struct DiarizedSegment {
+    float start   = 0.0f;  // seconds
+    float end     = 0.0f;  // seconds
+    int   speaker = -1;    // local speaker id; -1 = unassigned
+};
+
+/// One segmentation window's raw output.
+struct SegmentationWindow {
+    float start_time = 0.0f;
+    float end_time   = 0.0f;
+    std::vector<float> posteriors;        // [frames × powerset_classes]
+    std::vector<float> speaker_activity;  // [frames × max_local_speakers]
+};
+
+/// Tunables for end-to-end diarization.
+struct DiarizerConfig {
+    float onset                = 0.5f;
+    float offset               = 0.3f;
+    float min_speech_duration  = 0.3f;  // seconds
+    float clustering_threshold = 0.715f;
+    int   min_speakers         = 0;     // 0 = auto
+    int   max_speakers         = 0;     // 0 = auto
+};
+
+/// Local speaker-activity segmentation over fixed windows (e.g. Pyannote).
+class SegmentationInterface {
+public:
+    virtual ~SegmentationInterface() = default;
+
+    /// Run segmentation over the whole buffer, returning per-window posteriors.
+    virtual std::vector<SegmentationWindow> segment(
+        const float* audio, size_t length, int sample_rate) = 0;
+
+    /// Expected input sample rate in Hz.
+    virtual int input_sample_rate() const = 0;
+
+    /// Maximum simultaneous local speakers the model resolves per window.
+    virtual int max_local_speakers() const = 0;
+};
+
+/// Fixed-dimension speaker embedding (e.g. WeSpeaker ResNet34).
+class EmbeddingInterface {
+public:
+    virtual ~EmbeddingInterface() = default;
+
+    /// Embed an audio span into a speaker vector.
+    virtual std::vector<float> embed(
+        const float* audio, size_t length, int sample_rate) = 0;
+
+    /// Output embedding dimensionality.
+    virtual int embedding_dim() const = 0;
+
+    /// Expected input sample rate in Hz.
+    virtual int input_sample_rate() const = 0;
+};
+
+/// End-to-end diarization: audio in, speaker-labelled segments out.
+/// Typically composes a SegmentationInterface + an EmbeddingInterface.
+class DiarizerInterface {
+public:
+    virtual ~DiarizerInterface() = default;
+
+    virtual std::vector<DiarizedSegment> diarize(
+        const float* audio, size_t length, int sample_rate,
+        const DiarizerConfig& config) = 0;
+};
+
 }  // namespace speech_core

--- a/include/speech_core/models/litert_nemotron_streaming_stt.h
+++ b/include/speech_core/models/litert_nemotron_streaming_stt.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_engine.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Nemotron Speech Streaming 0.6B — cache-aware streaming RNN-T via LiteRT.
+///
+/// Three graphs (soniqo/Nemotron-Speech-Streaming-LiteRT):
+///   encoder  in:  mel[1,bins,frames], mel_len[1], pre_cache[1,bins,pre],
+///                 cache_last_channel[L,1,attn,H], cache_last_time[L,1,H,conv],
+///                 cache_last_channel_len[1]
+///            out: encoded[1,T_out,H], encoded_len[1], + the three rolled
+///                 caches + new cache_last_channel_len
+///   decoder  in:  token[1,1] i64, h[L,1,Hd], c[L,1,Hd]
+///            out: hidden[1,1,Hd], h_new, c_new
+///   joint    in:  enc_frame[1,1,H], dec_hidden[1,1,Hd]
+///            out: logits[1,1,vocab+1]
+///
+/// True chunkwise streaming: `push_chunk` drains fixed windows
+/// ((actual_mel_frames-1)*hop samples ≈ 80 ms), advancing the encoder cache +
+/// decoder LSTM state across calls and greedily decoding the first encoder
+/// frame (the second frame is right-context lookahead, re-settled next chunk).
+/// One instance == one stream. Not thread-safe.
+class LiteRTNemotronStreamingStt : public STTInterface {
+public:
+    struct Config {
+        int sample_rate       = 16000;
+        int mel_bins          = 128;
+        int n_fft             = 512;
+        int hop_length        = 160;
+        int win_length        = 400;
+        int encoder_layers    = 24;
+        int encoder_hidden    = 1024;
+        int decoder_layers    = 2;
+        int decoder_hidden    = 640;
+        int vocab_size        = 1024;  // refined from vocab.json
+        int blank_id          = 1024;  // = vocab_size
+        int pre_cache_size    = 16;
+        int actual_mel_frames = 9;     // 80 ms window
+        int attn_left_context = 70;    // cache_last_channel time dim
+        int conv_cache_size   = 8;     // cache_last_time conv dim (kernel-1)
+        int max_symbols       = 8;     // expansions per encoder frame
+    };
+
+    LiteRTNemotronStreamingStt(const std::string& encoder_path,
+                               const std::string& decoder_path,
+                               const std::string& joint_path,
+                               const std::string& vocab_path,
+                               bool hw_accel = true);
+    LiteRTNemotronStreamingStt(const std::string& encoder_path,
+                               const std::string& decoder_path,
+                               const std::string& joint_path,
+                               const std::string& vocab_path,
+                               const Config& config,
+                               bool hw_accel = true);
+    ~LiteRTNemotronStreamingStt() override;
+
+    // --- STTInterface (batch convenience = begin/push/end) ---
+    TranscriptionResult transcribe(const float* audio, size_t length, int sample_rate) override;
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+
+    // --- STTInterface (streaming — the real path) ---
+    bool supports_streaming() const override { return true; }
+    void begin_stream(int sample_rate) override;
+    PartialResult push_chunk(const float* audio, size_t length) override;
+    void flush_stream() override;
+    TranscriptionResult end_stream() override;
+    void cancel_stream() override;
+
+private:
+    bool load_vocab(const std::string& path);
+    void reset_stream_state();
+    void run_decoder_step(int64_t token_id);
+    std::string run_window();          // drain one window from pending_, return emitted text
+    std::string token_to_text(int id) const;
+    int chunk_samples() const { return (cfg_.actual_mel_frames - 1) * cfg_.hop_length; }
+
+    LiteRtModel         enc_model_    = nullptr;
+    LiteRtModel         dec_model_    = nullptr;
+    LiteRtModel         jnt_model_    = nullptr;
+    LiteRtCompiledModel enc_compiled_ = nullptr;
+    LiteRtCompiledModel dec_compiled_ = nullptr;
+    LiteRtCompiledModel jnt_compiled_ = nullptr;
+
+    Config cfg_;
+    int    enc_t_out_ = 2;  // encoder output frames per window (read at load)
+    std::vector<std::string> vocab_;
+
+    // ---- per-stream state ----
+    std::vector<float> pending_;             // accumulated PCM float32
+    std::vector<float> pre_cache_;           // [1, bins, pre_cache_size]
+    std::vector<float> cache_last_channel_;  // [L, 1, attn, H]
+    std::vector<float> cache_last_time_;     // [L, 1, H, conv]
+    int64_t            cache_last_channel_len_ = 0;
+    std::vector<float> dec_h_, dec_c_;       // [L, 1, Hd]
+    std::vector<float> dec_hidden_;          // [Hd] — joint input
+    std::string        accumulated_text_;
+    bool               stream_init_ = false;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/litert_omnilingual_stt.h
+++ b/include/speech_core/models/litert_omnilingual_stt.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_engine.h"
+
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Meta Omnilingual ASR CTC-300M via LiteRT.
+///
+/// Single-model CTC:
+///   Input:  raw waveform [1, S] f32, z-score normalised
+///   Output: logits [1, T, vocab] CTC logits at 50 Hz (320× downsample)
+/// Uses a SentencePiece (.model) tokenizer for decode. The fixed chunk length
+/// and vocab size are read from the model's output layout at construction.
+/// Not thread-safe — one per worker.
+class LiteRTOmnilingualStt : public STTInterface {
+public:
+    struct Config {
+        int sample_rate       = 16000;
+        int max_audio_samples = 160000;  // refined from the model at load
+        int frame_rate        = 50;      // 320× downsample
+        int vocab_size        = 10288;   // refined from the model at load
+        int blank_id          = 0;       // CTC blank is typically 0
+    };
+
+    LiteRTOmnilingualStt(const std::string& model_path,
+                         const std::string& tokenizer_path,
+                         bool hw_accel = true);
+    ~LiteRTOmnilingualStt() override;
+
+    TranscriptionResult transcribe(const float* audio, size_t length, int sample_rate) override;
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+
+private:
+    /// CTC greedy decode: per-frame argmax, collapse repeats, drop blanks.
+    std::string ctc_decode(const float* logits, int num_frames);
+
+    /// Minimal SentencePiece .model parse → id → piece table.
+    bool load_tokenizer(const std::string& path);
+
+    LiteRtModel         model_    = nullptr;
+    LiteRtCompiledModel compiled_ = nullptr;
+    Config cfg_;
+    int frames_per_chunk_ = 0;  // T from the model output layout
+
+    std::vector<std::string> id_to_piece_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/litert_parakeet_stt.h
+++ b/include/speech_core/models/litert_parakeet_stt.h
@@ -22,6 +22,7 @@ public:
         int hop_length      = 160;
         int win_length      = 400;
         float pre_emphasis  = 0.97f;
+        int enc_mel_frames  = 500;  // fixed encoder time dim — soniqo export is [1,128,500]
         int encoder_hidden  = 1024;
         int decoder_hidden  = 640;
         int decoder_layers  = 2;

--- a/include/speech_core/models/litert_pyannote_segmentation.h
+++ b/include/speech_core/models/litert_pyannote_segmentation.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_engine.h"
+
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Pyannote speaker segmentation 3.0 via LiteRT — streaming mode.
+///
+/// Matches soniqo/Pyannote-Segmentation-LiteRT:
+///   Input 0:  audio      [1, 1, 16000]   — one 1-second chunk at 16 kHz
+///   Input 1:  lstm_state [2, 8, 1, 128]  — carried across chunks
+///   Output 0: lstm_state [2, 8, 1, 128]
+///   Output 1: posteriors [1, 56, 7]
+///
+/// A 10-second window is 10 consecutive 1-s chunks with state carried between
+/// calls; state is reset at each window start, then the window slides by
+/// window_step. Not thread-safe — one per worker.
+class LiteRTPyannoteSegmentation : public SegmentationInterface {
+public:
+    struct Config {
+        int   sample_rate          = 16000;
+        int   chunk_samples        = 16000;  // 1 s @ 16 kHz
+        int   frames_per_chunk     = 56;     // per config.json
+        int   num_powerset_classes = 7;
+        int   max_local_speakers   = 3;
+        int   chunks_per_window    = 10;     // 10-s window
+        float window_duration      = 10.0f;
+        float window_step          = 5.0f;
+    };
+
+    static constexpr int kStateDim0 = 2;
+    static constexpr int kStateDim1 = 8;
+    static constexpr int kStateDim2 = 1;
+    static constexpr int kStateDim3 = 128;
+    static constexpr int kStateSize = kStateDim0 * kStateDim1 * kStateDim2 * kStateDim3;
+
+    explicit LiteRTPyannoteSegmentation(const std::string& model_path, bool hw_accel = true);
+    ~LiteRTPyannoteSegmentation() override;
+
+    std::vector<SegmentationWindow> segment(
+        const float* audio, size_t length, int sample_rate) override;
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+    int max_local_speakers() const override { return cfg_.max_local_speakers; }
+
+    const Config& config() const { return cfg_; }
+
+private:
+    /// Run one 1-s chunk: append its 56 frames of posteriors to
+    /// `window_posteriors` and advance state_. Caller resets state_ per window.
+    void process_chunk(const float* audio, size_t length,
+                       std::vector<float>& window_posteriors);
+
+    void decode_powerset(const float* posteriors, int num_frames,
+                         std::vector<float>& speaker_activity);
+
+    LiteRtModel         model_    = nullptr;
+    LiteRtCompiledModel compiled_ = nullptr;
+    Config cfg_;
+    std::vector<float> state_;
+    std::vector<float> chunk_buffer_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/litert_wespeaker_embedding.h
+++ b/include/speech_core/models/litert_wespeaker_embedding.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_engine.h"
+
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// WeSpeaker ResNet34-LM speaker embedding via LiteRT.
+///
+/// Matches soniqo/WeSpeaker-ResNet34-LM-LiteRT:
+///   Input 0:  fbank [1, 298, 80] f32 — precomputed kaldi-compatible log-mel
+///             fbank (80 bins, 25 ms / 10 ms, Hamming, no dither, per-frame
+///             DC removal). T=298 ≈ 3 s at 16 kHz.
+///   Output 0: embedding [1, 256]
+///
+/// The wrapper computes the fbank from raw 16 kHz audio internally (pads or
+/// tiles clips shorter than 3 s), so callers still pass raw float audio.
+/// L2-normalises the embedding. Not thread-safe — one per worker.
+class LiteRTWeSpeakerEmbedding : public EmbeddingInterface {
+public:
+    static constexpr int kEmbeddingDim = 256;
+    static constexpr int kNumMelBins   = 80;
+    static constexpr int kNumFrames    = 298;
+    static constexpr int kFrameLenSamp = 400;  // 25 ms @ 16 kHz
+    static constexpr int kHopSamp      = 160;  // 10 ms @ 16 kHz
+
+    explicit LiteRTWeSpeakerEmbedding(const std::string& model_path, bool hw_accel = true);
+    ~LiteRTWeSpeakerEmbedding() override;
+
+    std::vector<float> embed(const float* audio, size_t length, int sample_rate) override;
+    int embedding_dim() const override { return kEmbeddingDim; }
+    int input_sample_rate() const override { return 16000; }
+
+private:
+    /// kaldi-compatible log-mel fbank [kNumFrames, kNumMelBins], row-major
+    /// (frame-major). Pads or tiles the input to span kNumFrames.
+    std::vector<float> compute_fbank(const float* audio, size_t length);
+
+    LiteRtModel         model_    = nullptr;
+    LiteRtCompiledModel compiled_ = nullptr;
+};
+
+}  // namespace speech_core

--- a/scripts/download_models_litert.sh
+++ b/scripts/download_models_litert.sh
@@ -34,6 +34,12 @@ FILES=(
     "WeSpeaker-ResNet34-LM-LiteRT/wespeaker-resnet34.tflite"
     "Omnilingual-ASR-CTC-300M-LiteRT/omnilingual-ctc-300m.tflite"
     "Omnilingual-ASR-CTC-300M-LiteRT/tokenizer.model"
+    # Nemotron Speech Streaming — cache-aware streaming RNN-T (3 graphs).
+    "Nemotron-Speech-Streaming-LiteRT/nemotron-streaming-encoder.tflite"
+    "Nemotron-Speech-Streaming-LiteRT/nemotron-streaming-decoder.tflite"
+    "Nemotron-Speech-Streaming-LiteRT/nemotron-streaming-joint.tflite"
+    "Nemotron-Speech-Streaming-LiteRT/vocab.json"
+    "Nemotron-Speech-Streaming-LiteRT/config.json"
 )
 
 for entry in "${FILES[@]}"; do
@@ -49,6 +55,12 @@ for entry in "${FILES[@]}"; do
         Parakeet-TDT-0.6B-v3-LiteRT-INT8)
             dest="$OUT/parakeet-${rel}"
             [[ "$rel" == parakeet-* ]] && dest="$OUT/${rel}"
+            ;;
+        Nemotron-Speech-Streaming-LiteRT)
+            # .tflite are already nemotron-prefixed; vocab/config would collide
+            # with Parakeet's in the shared dir, so prefix those.
+            dest="$OUT/${rel}"
+            [[ "$rel" == "vocab.json" || "$rel" == "config.json" ]] && dest="$OUT/nemotron-${rel}"
             ;;
         *)
             dest="$OUT/${rel}"

--- a/scripts/download_models_litert.sh
+++ b/scripts/download_models_litert.sh
@@ -12,9 +12,9 @@ BASE_URL="https://huggingface.co/soniqo"
 OUT="${1:-$(dirname "$0")/models-litert}"
 mkdir -p "$OUT"
 
-# Optional HuggingFace auth — soniqo/* repos may be private. When HF_TOKEN is
-# set, send it as a bearer token; when unset, fetch anonymously. Backward
-# compatible with the previous (anonymous) behaviour.
+# The soniqo/* model repos are public — anonymous fetch works out of the box,
+# no token needed. HF_TOKEN is honoured if set (e.g. for a private mirror) but
+# is NOT required.
 AUTH=()
 if [[ -n "${HF_TOKEN:-}" ]]; then
     AUTH=(-H "Authorization: Bearer ${HF_TOKEN}")

--- a/scripts/download_models_litert.sh
+++ b/scripts/download_models_litert.sh
@@ -12,6 +12,14 @@ BASE_URL="https://huggingface.co/soniqo"
 OUT="${1:-$(dirname "$0")/models-litert}"
 mkdir -p "$OUT"
 
+# Optional HuggingFace auth — soniqo/* repos may be private. When HF_TOKEN is
+# set, send it as a bearer token; when unset, fetch anonymously. Backward
+# compatible with the previous (anonymous) behaviour.
+AUTH=()
+if [[ -n "${HF_TOKEN:-}" ]]; then
+    AUTH=(-H "Authorization: Bearer ${HF_TOKEN}")
+fi
+
 FILES=(
     "Silero-VAD-v5-LiteRT/silero-vad.tflite"
     "Silero-VAD-v5-LiteRT/config.json"
@@ -19,6 +27,13 @@ FILES=(
     "Parakeet-TDT-0.6B-v3-LiteRT-INT8/parakeet-decoder-joint.tflite"
     "Parakeet-TDT-0.6B-v3-LiteRT-INT8/vocab.json"
     "Parakeet-TDT-0.6B-v3-LiteRT-INT8/config.json"
+    # Diarization + multilingual ASR — fetched for the upstreamed cloud
+    # wrappers (WeSpeaker / Pyannote / Omnilingual). Best-effort: if a repo is
+    # private and HF_TOKEN is unset, the fetch warns and the gated test skips.
+    "Pyannote-Segmentation-LiteRT/pyannote-segmentation.tflite"
+    "WeSpeaker-ResNet34-LM-LiteRT/wespeaker-resnet34.tflite"
+    "Omnilingual-ASR-CTC-300M-LiteRT/omnilingual-ctc-300m.tflite"
+    "Omnilingual-ASR-CTC-300M-LiteRT/tokenizer.model"
 )
 
 for entry in "${FILES[@]}"; do
@@ -47,7 +62,14 @@ for entry in "${FILES[@]}"; do
 
     url="$BASE_URL/$repo/resolve/main/$rel"
     echo "[fetch] $rel"
-    curl -fL --retry 3 -o "$dest" "$url"
+    # Best-effort: a missing/forbidden file (e.g. a private repo with no
+    # HF_TOKEN) warns and continues so the rest still download. Gated tests
+    # skip cleanly when a model is absent. The ${AUTH[@]+...} form is
+    # nounset-safe for the empty-array (no-token) case on old bash.
+    if ! curl -fL --retry 3 ${AUTH[@]+"${AUTH[@]}"} -o "$dest" "$url"; then
+        echo "[warn] could not fetch $rel (set HF_TOKEN if the repo is private) — skipping"
+        rm -f "$dest"
+    fi
 done
 
 echo ""

--- a/src/diarization/diarization_pipeline.cpp
+++ b/src/diarization/diarization_pipeline.cpp
@@ -1,0 +1,244 @@
+#include "speech_core/diarization/diarization_pipeline.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <set>
+#include <unordered_map>
+
+namespace speech_core {
+
+namespace {
+/// Cosine similarity over two equal-length vectors. 0 if shapes mismatch or
+/// either side has ~zero norm.
+float cosine_similarity(const std::vector<float>& a, const std::vector<float>& b) {
+    if (a.size() != b.size()) return 0.0f;
+    float dot = 0.0f, na = 0.0f, nb = 0.0f;
+    for (size_t i = 0; i < a.size(); ++i) {
+        dot += a[i] * b[i];
+        na  += a[i] * a[i];
+        nb  += b[i] * b[i];
+    }
+    float denom = std::sqrt(na) * std::sqrt(nb);
+    return (denom > 1e-8f) ? dot / denom : 0.0f;
+}
+}  // namespace
+
+DiarizationPipeline::DiarizationPipeline(
+    SegmentationInterface& seg, EmbeddingInterface& emb, float clustering_threshold)
+    : seg_(seg), emb_(emb), default_threshold_(clustering_threshold) {}
+
+std::vector<DiarizedSegment> DiarizationPipeline::diarize(
+    const float* audio, size_t length, int sample_rate, const DiarizerConfig& config)
+{
+    auto windows = seg_.segment(audio, length, sample_rate);
+    if (windows.empty()) return {};
+
+    auto local_speakers = extract_embeddings(audio, length, windows, config);
+    if (local_speakers.empty()) return {};
+
+    float thresh = (config.clustering_threshold > 0)
+        ? config.clustering_threshold : default_threshold_;
+    auto cluster_ids = cluster(local_speakers, thresh,
+                               config.min_speakers, config.max_speakers);
+
+    return build_segments(windows, local_speakers, cluster_ids, config);
+}
+
+std::vector<DiarizationPipeline::LocalSpeaker>
+DiarizationPipeline::extract_embeddings(
+    const float* audio, size_t length,
+    const std::vector<SegmentationWindow>& windows,
+    const DiarizerConfig& config)
+{
+    std::vector<LocalSpeaker> speakers;
+    const int K  = seg_.max_local_speakers();
+    const int sr = seg_.input_sample_rate();
+
+    for (int w = 0; w < static_cast<int>(windows.size()); ++w) {
+        auto& win = windows[w];
+        int nf = static_cast<int>(win.speaker_activity.size()) / K;
+        if (nf <= 0) continue;
+        float frame_dur = (win.end_time - win.start_time) / static_cast<float>(nf);
+
+        for (int spk = 0; spk < K; ++spk) {
+            float best_start = 0, best_end = 0, best_dur = 0;
+            float cur_start = 0;
+            bool  active = false;
+
+            for (int f = 0; f < nf; ++f) {
+                float act = win.speaker_activity[f * K + spk];
+                float t   = win.start_time + f * frame_dur;
+                if (!active && act >= config.onset) {
+                    active = true;
+                    cur_start = t;
+                } else if (active && act < config.offset) {
+                    float dur = t - cur_start;
+                    if (dur > best_dur) { best_dur = dur; best_start = cur_start; best_end = t; }
+                    active = false;
+                }
+            }
+            if (active) {
+                float dur = win.end_time - cur_start;
+                if (dur > best_dur) { best_dur = dur; best_start = cur_start; best_end = win.end_time; }
+            }
+
+            if (best_dur < 0.5f) continue;
+
+            size_t s0 = static_cast<size_t>(best_start * sr);
+            size_t s1 = std::min(static_cast<size_t>(best_end * sr), length);
+            if (s1 <= s0) continue;
+
+            auto emb = emb_.embed(audio + s0, s1 - s0, sr);
+            if (emb.empty()) continue;
+
+            speakers.push_back({w, spk, best_start, best_end, std::move(emb)});
+        }
+    }
+
+    return speakers;
+}
+
+std::vector<int> DiarizationPipeline::cluster(
+    const std::vector<LocalSpeaker>& speakers,
+    float threshold, int min_clusters, int max_clusters)
+{
+    int n = static_cast<int>(speakers.size());
+    if (n == 0) return {};
+
+    std::vector<int> labels(n);
+    std::iota(labels.begin(), labels.end(), 0);
+
+    std::vector<std::vector<float>> dist(n, std::vector<float>(n, 0.0f));
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            float sim = cosine_similarity(speakers[i].embedding, speakers[j].embedding);
+            float d = 1.0f - sim;
+            dist[i][j] = d;
+            dist[j][i] = d;
+        }
+    }
+
+    auto get_cluster = [&](int idx) -> std::set<int> {
+        std::set<int> members;
+        int c = labels[idx];
+        for (int i = 0; i < n; ++i) if (labels[i] == c) members.insert(i);
+        return members;
+    };
+
+    while (true) {
+        int num_clusters = static_cast<int>(std::set<int>(labels.begin(), labels.end()).size());
+
+        if (max_clusters > 0 && num_clusters <= max_clusters &&
+            min_clusters > 0 && num_clusters <= min_clusters) break;
+
+        float best_dist = std::numeric_limits<float>::max();
+        int best_i = -1, best_j = -1;
+
+        for (int i = 0; i < n; ++i) {
+            for (int j = i + 1; j < n; ++j) {
+                if (labels[i] == labels[j]) continue;
+
+                auto ci = get_cluster(i);
+                auto cj = get_cluster(j);
+                bool same_window = false;
+                for (int a : ci) {
+                    for (int b : cj) {
+                        if (speakers[a].window_idx == speakers[b].window_idx) { same_window = true; break; }
+                    }
+                    if (same_window) break;
+                }
+                if (same_window) continue;
+
+                float avg_dist = 0;
+                int count = 0;
+                for (int a : ci) for (int b : cj) { avg_dist += dist[a][b]; ++count; }
+                avg_dist /= static_cast<float>(count);
+
+                if (avg_dist < best_dist) { best_dist = avg_dist; best_i = i; best_j = j; }
+            }
+        }
+
+        if (best_i < 0 || best_dist > threshold) break;
+
+        int old_label = labels[best_j];
+        int new_label = labels[best_i];
+        for (int i = 0; i < n; ++i) if (labels[i] == old_label) labels[i] = new_label;
+    }
+
+    std::set<int> unique(labels.begin(), labels.end());
+    std::unordered_map<int, int> remap;
+    int idx = 0;
+    for (int c : unique) remap[c] = idx++;
+    for (auto& l : labels) l = remap[l];
+
+    return labels;
+}
+
+std::vector<DiarizedSegment> DiarizationPipeline::build_segments(
+    const std::vector<SegmentationWindow>& windows,
+    const std::vector<LocalSpeaker>& local_speakers,
+    const std::vector<int>& cluster_ids,
+    const DiarizerConfig& config)
+{
+    std::map<std::pair<int, int>, int> speaker_map;
+    for (size_t i = 0; i < local_speakers.size(); ++i) {
+        speaker_map[{local_speakers[i].window_idx, local_speakers[i].local_speaker}] = cluster_ids[i];
+    }
+
+    std::vector<DiarizedSegment> segments;
+    const int K = seg_.max_local_speakers();
+
+    for (int w = 0; w < static_cast<int>(windows.size()); ++w) {
+        auto& win = windows[w];
+        int nf = static_cast<int>(win.speaker_activity.size()) / K;
+        if (nf <= 0) continue;
+        float frame_dur = (win.end_time - win.start_time) / static_cast<float>(nf);
+
+        for (int spk = 0; spk < K; ++spk) {
+            auto it = speaker_map.find({w, spk});
+            if (it == speaker_map.end()) continue;
+            int global_spk = it->second;
+
+            bool  active = false;
+            float seg_start = 0;
+
+            for (int f = 0; f < nf; ++f) {
+                float act = win.speaker_activity[f * K + spk];
+                float t   = win.start_time + f * frame_dur;
+                if (!active && act >= config.onset) {
+                    active = true;
+                    seg_start = t;
+                } else if (active && act < config.offset) {
+                    if (t - seg_start >= config.min_speech_duration)
+                        segments.push_back({seg_start, t, global_spk});
+                    active = false;
+                }
+            }
+            if (active) {
+                float t = win.end_time;
+                if (t - seg_start >= config.min_speech_duration)
+                    segments.push_back({seg_start, t, global_spk});
+            }
+        }
+    }
+
+    std::sort(segments.begin(), segments.end(),
+              [](const DiarizedSegment& a, const DiarizedSegment& b) { return a.start < b.start; });
+
+    std::vector<DiarizedSegment> merged;
+    for (auto& seg : segments) {
+        if (!merged.empty() && merged.back().speaker == seg.speaker &&
+            seg.start - merged.back().end < 0.5f) {
+            merged.back().end = seg.end;
+        } else {
+            merged.push_back(seg);
+        }
+    }
+
+    return merged;
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_nemotron_streaming_stt.cpp
+++ b/src/models/litert/litert_nemotron_streaming_stt.cpp
@@ -1,0 +1,296 @@
+#include "speech_core/models/litert_nemotron_streaming_stt.h"
+
+#include "speech_core/audio/mel.h"
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace speech_core {
+
+LiteRTNemotronStreamingStt::LiteRTNemotronStreamingStt(
+    const std::string& encoder_path, const std::string& decoder_path,
+    const std::string& joint_path, const std::string& vocab_path, bool hw_accel)
+    : LiteRTNemotronStreamingStt(encoder_path, decoder_path, joint_path,
+                                 vocab_path, Config{}, hw_accel) {}
+
+LiteRTNemotronStreamingStt::LiteRTNemotronStreamingStt(
+    const std::string& encoder_path, const std::string& decoder_path,
+    const std::string& joint_path, const std::string& vocab_path,
+    const Config& config, bool hw_accel)
+    : cfg_(config)
+{
+    auto& engine = LiteRTEngine::get();
+    engine.load(encoder_path, hw_accel, &enc_model_, &enc_compiled_);
+    engine.load(decoder_path, false,    &dec_model_, &dec_compiled_);
+    engine.load(joint_path,   false,    &jnt_model_, &jnt_compiled_);
+
+    load_vocab(vocab_path);
+
+    // Encoder output[0] = encoded [1, T_out, H]; read T_out for buffer sizing.
+    // The export is fixed-shape so the static layout is available without a
+    // resize. Tolerate failure — fall back to the default (2 @ 80 ms).
+    LiteRtLayout outs[6]{};
+    if (LiteRtGetCompiledModelOutputTensorLayouts(enc_compiled_, 0, 6, outs, false) == kLiteRtStatusOk
+        && outs[0].rank >= 3 && outs[0].dimensions[1] > 0) {
+        enc_t_out_ = static_cast<int>(outs[0].dimensions[1]);
+    }
+
+    LOGI("Nemotron streaming: vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d window=%d samples",
+         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_, chunk_samples());
+}
+
+LiteRTNemotronStreamingStt::~LiteRTNemotronStreamingStt() {
+    if (jnt_compiled_) LiteRtDestroyCompiledModel(jnt_compiled_);
+    if (jnt_model_)    LiteRtDestroyModel(jnt_model_);
+    if (dec_compiled_) LiteRtDestroyCompiledModel(dec_compiled_);
+    if (dec_model_)    LiteRtDestroyModel(dec_model_);
+    if (enc_compiled_) LiteRtDestroyCompiledModel(enc_compiled_);
+    if (enc_model_)    LiteRtDestroyModel(enc_model_);
+}
+
+bool LiteRTNemotronStreamingStt::load_vocab(const std::string& path) {
+    auto text = json::read_file(path);
+    if (text.empty()) return false;
+    auto flat = json::parse_flat_object(text);
+
+    int max_id = -1;
+    for (auto& [key, val] : flat) {
+        (void)val;
+        try { max_id = std::max(max_id, std::stoi(key)); } catch (...) {}
+    }
+    if (max_id < 0) return false;
+
+    vocab_.assign(static_cast<size_t>(max_id) + 1, std::string{});
+    for (auto& [key, val] : flat) {
+        try {
+            int id = std::stoi(key);
+            if (id >= 0 && id <= max_id) vocab_[id] = val;
+        } catch (...) {}
+    }
+    cfg_.vocab_size = static_cast<int>(vocab_.size());
+    cfg_.blank_id   = cfg_.vocab_size;
+    return true;
+}
+
+std::string LiteRTNemotronStreamingStt::token_to_text(int id) const {
+    if (id < 0 || id >= static_cast<int>(vocab_.size())) return {};
+    std::string piece = vocab_[id];
+    // SentencePiece ▁ (U+2581, UTF-8 E2 96 81) → leading space.
+    if (piece.size() >= 3 &&
+        static_cast<unsigned char>(piece[0]) == 0xE2 &&
+        static_cast<unsigned char>(piece[1]) == 0x96 &&
+        static_cast<unsigned char>(piece[2]) == 0x81) {
+        return " " + piece.substr(3);
+    }
+    return piece;
+}
+
+void LiteRTNemotronStreamingStt::reset_stream_state() {
+    pending_.clear();
+    pre_cache_.assign(static_cast<size_t>(cfg_.mel_bins) * cfg_.pre_cache_size, 0.0f);
+    cache_last_channel_.assign(
+        static_cast<size_t>(cfg_.encoder_layers) * cfg_.attn_left_context * cfg_.encoder_hidden, 0.0f);
+    cache_last_time_.assign(
+        static_cast<size_t>(cfg_.encoder_layers) * cfg_.encoder_hidden * cfg_.conv_cache_size, 0.0f);
+    cache_last_channel_len_ = 0;
+    dec_h_.assign(static_cast<size_t>(cfg_.decoder_layers) * cfg_.decoder_hidden, 0.0f);
+    dec_c_.assign(static_cast<size_t>(cfg_.decoder_layers) * cfg_.decoder_hidden, 0.0f);
+    dec_hidden_.assign(static_cast<size_t>(cfg_.decoder_hidden), 0.0f);
+    accumulated_text_.clear();
+    // Prime the decoder LSTM with the blank token so the first joint() call
+    // sees a meaningful hidden state (matches the reference validator).
+    run_decoder_step(cfg_.blank_id);
+}
+
+void LiteRTNemotronStreamingStt::run_decoder_step(int64_t token_id) {
+    auto env      = LiteRTEngine::get().env();
+    auto t_tok    = make_type(kLiteRtElementTypeInt64,   {1, 1});
+    auto t_state  = make_type(kLiteRtElementTypeFloat32, {cfg_.decoder_layers, 1, cfg_.decoder_hidden});
+    auto t_hidden = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.decoder_hidden});
+
+    int64_t tok = token_id;
+    LiteRtHostBuffer in_tok   (env, t_tok,    sizeof(int64_t),                 &tok);
+    LiteRtHostBuffer in_h     (env, t_state,  dec_h_.size() * sizeof(float),   dec_h_.data());
+    LiteRtHostBuffer in_c     (env, t_state,  dec_c_.size() * sizeof(float),   dec_c_.data());
+    LiteRtHostBuffer out_hid  (env, t_hidden, dec_hidden_.size() * sizeof(float));
+    LiteRtHostBuffer out_h    (env, t_state,  dec_h_.size() * sizeof(float));
+    LiteRtHostBuffer out_c    (env, t_state,  dec_c_.size() * sizeof(float));
+
+    // decoder I/O: in [token, h, c] -> out [hidden, h_new, c_new]
+    LiteRtTensorBuffer ins [3] = { in_tok.raw(), in_h.raw(), in_c.raw() };
+    LiteRtTensorBuffer outs[3] = { out_hid.raw(), out_h.raw(), out_c.raw() };
+    litert_check(LiteRtRunCompiledModel(dec_compiled_, 0, 3, ins, 3, outs), "Nemotron decoder Run");
+
+    out_hid.read(dec_hidden_.data(), dec_hidden_.size() * sizeof(float));
+    out_h  .read(dec_h_.data(),      dec_h_.size() * sizeof(float));
+    out_c  .read(dec_c_.data(),      dec_c_.size() * sizeof(float));
+}
+
+// Drain one window from pending_, run mel -> encoder (cache-aware) -> greedy
+// RNN-T over the first encoder frame, return the emitted text.
+std::string LiteRTNemotronStreamingStt::run_window() {
+    const int n_frames = cfg_.actual_mel_frames;
+    const int win      = chunk_samples();
+    if (static_cast<int>(pending_.size()) < win) return {};
+
+    std::vector<float> pcm(pending_.begin(), pending_.begin() + win);
+    pending_.erase(pending_.begin(), pending_.begin() + win);
+
+    constexpr float kLogFloor = 1.0f / static_cast<float>(1 << 24);  // 2^-24
+    auto mel = audio::mel_spectrogram(
+        pcm.data(), pcm.size(), cfg_.sample_rate,
+        cfg_.n_fft, cfg_.hop_length, cfg_.win_length, cfg_.mel_bins,
+        /*slaney=*/true, kLogFloor, /*center=*/true);
+
+    const int produced = static_cast<int>(mel.size()) / cfg_.mel_bins;
+    if (produced < n_frames) return {};
+    if (produced > n_frames) {  // trim trailing frames (centred padding overshoot)
+        std::vector<float> trimmed(static_cast<size_t>(cfg_.mel_bins) * n_frames);
+        for (int b = 0; b < cfg_.mel_bins; ++b) {
+            std::copy_n(&mel[static_cast<size_t>(b) * produced], n_frames,
+                        &trimmed[static_cast<size_t>(b) * n_frames]);
+        }
+        mel.swap(trimmed);
+    }
+
+    auto env = LiteRTEngine::get().env();
+    auto t_mel  = make_type(kLiteRtElementTypeFloat32, {1, cfg_.mel_bins, n_frames});
+    auto t_len  = make_type(kLiteRtElementTypeInt64,   {1});
+    auto t_pre  = make_type(kLiteRtElementTypeFloat32, {1, cfg_.mel_bins, cfg_.pre_cache_size});
+    auto t_clc  = make_type(kLiteRtElementTypeFloat32,
+                            {cfg_.encoder_layers, 1, cfg_.attn_left_context, cfg_.encoder_hidden});
+    auto t_clt  = make_type(kLiteRtElementTypeFloat32,
+                            {cfg_.encoder_layers, 1, cfg_.encoder_hidden, cfg_.conv_cache_size});
+    auto t_chl  = make_type(kLiteRtElementTypeInt64,   {1});
+    auto t_enc  = make_type(kLiteRtElementTypeFloat32, {1, enc_t_out_, cfg_.encoder_hidden});
+    auto t_i32  = make_type(kLiteRtElementTypeInt32,   {1});
+
+    int64_t mel_len = n_frames;
+    int64_t ch_len  = cache_last_channel_len_;
+
+    LiteRtHostBuffer in_mel (env, t_mel, mel.size() * sizeof(float),                mel.data());
+    LiteRtHostBuffer in_mlen(env, t_len, sizeof(int64_t),                           &mel_len);
+    LiteRtHostBuffer in_pre (env, t_pre, pre_cache_.size() * sizeof(float),         pre_cache_.data());
+    LiteRtHostBuffer in_clc (env, t_clc, cache_last_channel_.size() * sizeof(float), cache_last_channel_.data());
+    LiteRtHostBuffer in_clt (env, t_clt, cache_last_time_.size() * sizeof(float),   cache_last_time_.data());
+    LiteRtHostBuffer in_chl (env, t_chl, sizeof(int64_t),                           &ch_len);
+
+    LiteRtHostBuffer out_enc (env, t_enc, static_cast<size_t>(enc_t_out_) * cfg_.encoder_hidden * sizeof(float));
+    LiteRtHostBuffer out_elen(env, t_i32, sizeof(int32_t));
+    LiteRtHostBuffer out_pre (env, t_pre, pre_cache_.size() * sizeof(float));
+    LiteRtHostBuffer out_clc (env, t_clc, cache_last_channel_.size() * sizeof(float));
+    LiteRtHostBuffer out_clt (env, t_clt, cache_last_time_.size() * sizeof(float));
+    LiteRtHostBuffer out_chl (env, t_i32, sizeof(int32_t));
+
+    // encoder I/O order (traced export):
+    //   in:  mel, mel_len, pre_cache, cache_last_channel, cache_last_time, ch_len
+    //   out: encoded, encoded_len, pre_cache', cache_last_channel', cache_last_time', ch_len'
+    LiteRtTensorBuffer eins [6] = { in_mel.raw(), in_mlen.raw(), in_pre.raw(),
+                                    in_clc.raw(), in_clt.raw(), in_chl.raw() };
+    LiteRtTensorBuffer eouts[6] = { out_enc.raw(), out_elen.raw(), out_pre.raw(),
+                                    out_clc.raw(), out_clt.raw(), out_chl.raw() };
+    litert_check(LiteRtRunCompiledModel(enc_compiled_, 0, 6, eins, 6, eouts), "Nemotron encoder Run");
+
+    // Roll caches forward for the next window.
+    out_pre.read(pre_cache_.data(),          pre_cache_.size() * sizeof(float));
+    out_clc.read(cache_last_channel_.data(), cache_last_channel_.size() * sizeof(float));
+    out_clt.read(cache_last_time_.data(),    cache_last_time_.size() * sizeof(float));
+    int32_t chl_new = 0;
+    out_chl.read(&chl_new, sizeof(int32_t));
+    cache_last_channel_len_ = static_cast<int64_t>(chl_new);
+
+    std::vector<float> encoded(static_cast<size_t>(enc_t_out_) * cfg_.encoder_hidden);
+    out_enc.read(encoded.data(), encoded.size() * sizeof(float));
+
+    // Greedy RNN-T over the FIRST encoder frame only (frame 0 = first
+    // encoder_hidden floats). The second frame is right-context lookahead,
+    // re-settled on the next window — feeding it duplicates output.
+    auto t_encf   = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.encoder_hidden});
+    auto t_dechid = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.decoder_hidden});
+    auto t_logits = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.vocab_size + 1});
+    const size_t n_logits = static_cast<size_t>(cfg_.vocab_size) + 1;
+
+    std::string emitted;
+    for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
+        LiteRtHostBuffer in_encf  (env, t_encf,   static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float), encoded.data());
+        LiteRtHostBuffer in_dechid(env, t_dechid, dec_hidden_.size() * sizeof(float),                       dec_hidden_.data());
+        LiteRtHostBuffer out_log  (env, t_logits, n_logits * sizeof(float));
+
+        LiteRtTensorBuffer jins [2] = { in_encf.raw(), in_dechid.raw() };
+        LiteRtTensorBuffer jouts[1] = { out_log.raw() };
+        litert_check(LiteRtRunCompiledModel(jnt_compiled_, 0, 2, jins, 1, jouts), "Nemotron joint Run");
+
+        std::vector<float> logits(n_logits);
+        out_log.read(logits.data(), n_logits * sizeof(float));
+
+        int   best   = 0;
+        float best_v = logits[0];
+        for (size_t i = 1; i < n_logits; ++i) {
+            if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+        }
+        if (best == cfg_.blank_id) break;  // advance to the next encoder frame
+
+        emitted += token_to_text(best);
+        run_decoder_step(best);  // advance the predictor for the next expansion
+    }
+
+    return emitted;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming API
+// ---------------------------------------------------------------------------
+
+void LiteRTNemotronStreamingStt::begin_stream(int sample_rate) {
+    cfg_.sample_rate = sample_rate;
+    reset_stream_state();
+    stream_init_ = true;
+}
+
+PartialResult LiteRTNemotronStreamingStt::push_chunk(const float* audio, size_t length) {
+    if (!stream_init_) begin_stream(cfg_.sample_rate);
+    pending_.insert(pending_.end(), audio, audio + length);
+
+    std::string text;
+    while (static_cast<int>(pending_.size()) >= chunk_samples()) {
+        text += run_window();
+    }
+    accumulated_text_ += text;
+
+    PartialResult out;
+    out.text = std::move(text);
+    return out;
+}
+
+void LiteRTNemotronStreamingStt::flush_stream() {
+    // No-op: only full windows are decoded; a trailing partial window is held.
+}
+
+TranscriptionResult LiteRTNemotronStreamingStt::end_stream() {
+    TranscriptionResult out;
+    out.text = accumulated_text_;
+    stream_init_ = false;
+    return out;
+}
+
+void LiteRTNemotronStreamingStt::cancel_stream() {
+    pending_.clear();
+    accumulated_text_.clear();
+    stream_init_ = false;
+}
+
+// ---------------------------------------------------------------------------
+// Batch convenience: begin -> push everything -> end.
+// ---------------------------------------------------------------------------
+
+TranscriptionResult LiteRTNemotronStreamingStt::transcribe(
+    const float* audio, size_t length, int sample_rate)
+{
+    begin_stream(sample_rate);
+    push_chunk(audio, length);
+    return end_stream();
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_omnilingual_stt.cpp
+++ b/src/models/litert/litert_omnilingual_stt.cpp
@@ -1,0 +1,255 @@
+#include "speech_core/models/litert_omnilingual_stt.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+namespace speech_core {
+
+// ---------------------------------------------------------------------------
+// SentencePiece tokenizer — minimal protobuf parse (id → piece) for decode.
+// ModelProto { repeated SentencePiece pieces = 1; }
+// SentencePiece { string piece = 1; float score = 2; Type type = 3; }
+// ---------------------------------------------------------------------------
+
+bool LiteRTOmnilingualStt::load_tokenizer(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+
+    f.seekg(0, std::ios::end);
+    size_t file_size = static_cast<size_t>(f.tellg());
+    f.seekg(0, std::ios::beg);
+    std::vector<uint8_t> buf(file_size);
+    f.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(file_size));
+
+    id_to_piece_.clear();
+    size_t pos = 0;
+    while (pos < file_size) {
+        uint8_t tag = buf[pos++];
+        int field_num = tag >> 3;
+        int wire_type = tag & 0x7;
+
+        if (field_num == 1 && wire_type == 2) {
+            uint32_t len = 0;
+            int shift = 0;
+            while (pos < file_size && (buf[pos] & 0x80)) {
+                len |= (buf[pos++] & 0x7f) << shift;
+                shift += 7;
+            }
+            if (pos < file_size) len |= buf[pos++] << shift;
+
+            size_t end = pos + len;
+            if (end > file_size) break;
+
+            std::string piece;
+            size_t sub = pos;
+            while (sub < end) {
+                uint8_t stag = buf[sub++];
+                int sf = stag >> 3;
+                int sw = stag & 0x7;
+                if (sf == 1 && sw == 2) {
+                    uint32_t slen = 0;
+                    int sh = 0;
+                    while (sub < end && (buf[sub] & 0x80)) {
+                        slen |= (buf[sub++] & 0x7f) << sh;
+                        sh += 7;
+                    }
+                    if (sub < end) slen |= buf[sub++] << sh;
+                    if (sub + slen <= end) {
+                        piece = std::string(reinterpret_cast<const char*>(&buf[sub]), slen);
+                    }
+                    sub += slen;
+                } else if (sw == 0) {
+                    while (sub < end && (buf[sub] & 0x80)) sub++;
+                    if (sub < end) sub++;
+                } else if (sw == 2) {
+                    uint32_t slen = 0;
+                    int sh = 0;
+                    while (sub < end && (buf[sub] & 0x80)) {
+                        slen |= (buf[sub++] & 0x7f) << sh;
+                        sh += 7;
+                    }
+                    if (sub < end) slen |= buf[sub++] << sh;
+                    sub += slen;
+                } else if (sw == 5) {
+                    sub += 4;
+                } else if (sw == 1) {
+                    sub += 8;
+                } else {
+                    break;
+                }
+            }
+            id_to_piece_.push_back(piece);
+            pos = end;
+        } else if (wire_type == 0) {
+            while (pos < file_size && (buf[pos] & 0x80)) pos++;
+            if (pos < file_size) pos++;
+        } else if (wire_type == 2) {
+            uint32_t len = 0;
+            int shift = 0;
+            while (pos < file_size && (buf[pos] & 0x80)) {
+                len |= (buf[pos++] & 0x7f) << shift;
+                shift += 7;
+            }
+            if (pos < file_size) len |= buf[pos++] << shift;
+            pos += len;
+        } else if (wire_type == 5) {
+            pos += 4;
+        } else if (wire_type == 1) {
+            pos += 8;
+        } else {
+            break;
+        }
+    }
+
+    LOGI("Omnilingual: loaded %zu tokens from %s", id_to_piece_.size(), path.c_str());
+    return !id_to_piece_.empty();
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+LiteRTOmnilingualStt::LiteRTOmnilingualStt(const std::string& model_path,
+                                           const std::string& tokenizer_path,
+                                           bool hw_accel)
+{
+    LiteRTEngine::get().load(model_path, hw_accel, &model_, &compiled_);
+
+    if (!load_tokenizer(tokenizer_path)) {
+        throw std::runtime_error("Failed to load SentencePiece tokenizer: " + tokenizer_path);
+    }
+
+    // Read T (frames per chunk) + vocab from the static output layout
+    // [1, T, vocab]. The compiled-model API exposes output layouts only, so
+    // derive the input chunk length from T: max_audio = T * (sr / frame_rate).
+    LiteRtLayout out_layout[1]{};
+    litert_check(LiteRtGetCompiledModelOutputTensorLayouts(
+                     compiled_, 0, 1, out_layout, /*update_allocation=*/false),
+                 "Omnilingual GetOutputTensorLayouts");
+    if (out_layout[0].rank >= 3) {
+        frames_per_chunk_ = static_cast<int>(out_layout[0].dimensions[1]);
+        cfg_.vocab_size   = static_cast<int>(out_layout[0].dimensions[2]);
+    }
+    const int down = cfg_.sample_rate / cfg_.frame_rate;  // 320
+    if (frames_per_chunk_ > 0) {
+        cfg_.max_audio_samples = frames_per_chunk_ * down;
+    } else {
+        frames_per_chunk_ = cfg_.max_audio_samples / down;
+    }
+
+    LOGI("Omnilingual: input=[1,%d] output=[1,%d,%d] (%.1fs chunks)",
+         cfg_.max_audio_samples, frames_per_chunk_, cfg_.vocab_size,
+         static_cast<float>(cfg_.max_audio_samples) / cfg_.sample_rate);
+}
+
+LiteRTOmnilingualStt::~LiteRTOmnilingualStt() {
+    if (compiled_) LiteRtDestroyCompiledModel(compiled_);
+    if (model_)    LiteRtDestroyModel(model_);
+}
+
+// ---------------------------------------------------------------------------
+// Transcribe — chunk to max_audio_samples, z-score normalise, CTC decode.
+// ---------------------------------------------------------------------------
+
+TranscriptionResult LiteRTOmnilingualStt::transcribe(
+    const float* audio, size_t length, int sample_rate)
+{
+    if (sample_rate != cfg_.sample_rate) {
+        throw std::runtime_error("OmnilingualSTT expects " +
+                                 std::to_string(cfg_.sample_rate) + " Hz");
+    }
+
+    const int chunk_samples = cfg_.max_audio_samples;
+    const int down          = cfg_.sample_rate / cfg_.frame_rate;  // 320
+
+    auto env      = LiteRTEngine::get().env();
+    auto t_audio  = make_type(kLiteRtElementTypeFloat32, {1, chunk_samples});
+    auto t_logits = make_type(kLiteRtElementTypeFloat32, {1, frames_per_chunk_, cfg_.vocab_size});
+
+    std::vector<float> logits(static_cast<size_t>(frames_per_chunk_) * cfg_.vocab_size);
+    std::string full_text;
+
+    for (size_t offset = 0; offset < length; offset += chunk_samples) {
+        size_t chunk_len = std::min(static_cast<size_t>(chunk_samples), length - offset);
+
+        std::vector<float> normalized(static_cast<size_t>(chunk_samples), 0.0f);
+        double sum = 0.0, sum_sq = 0.0;
+        for (size_t i = 0; i < chunk_len; ++i) {
+            float v = audio[offset + i];
+            sum += v;
+            sum_sq += static_cast<double>(v) * v;
+        }
+        float mean    = static_cast<float>(sum / chunk_len);
+        float var     = static_cast<float>(sum_sq / chunk_len - static_cast<double>(mean) * mean);
+        float std_dev = std::sqrt(std::max(var, 1e-10f));
+        for (size_t i = 0; i < chunk_len; ++i) {
+            normalized[i] = (audio[offset + i] - mean) / std_dev;
+        }
+
+        LiteRtHostBuffer in_audio (env, t_audio,  static_cast<size_t>(chunk_samples) * sizeof(float), normalized.data());
+        LiteRtHostBuffer out_log  (env, t_logits, logits.size() * sizeof(float));
+
+        LiteRtTensorBuffer ins [1] = { in_audio.raw() };
+        LiteRtTensorBuffer outs[1] = { out_log.raw() };
+        litert_check(LiteRtRunCompiledModel(compiled_, 0, 1, ins, 1, outs), "Omnilingual Run");
+        out_log.read(logits.data(), logits.size() * sizeof(float));
+
+        int num_frames = static_cast<int>(chunk_len) / down;
+        if (num_frames <= 0) continue;
+
+        std::string chunk_text = ctc_decode(logits.data(), num_frames);
+        if (!chunk_text.empty()) {
+            if (!full_text.empty()) full_text += ' ';
+            full_text += chunk_text;
+        }
+    }
+
+    TranscriptionResult result;
+    result.text = std::move(full_text);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// CTC greedy decode
+// ---------------------------------------------------------------------------
+
+std::string LiteRTOmnilingualStt::ctc_decode(const float* logits, int num_frames) {
+    const int V     = cfg_.vocab_size;
+    const int blank = cfg_.blank_id;
+
+    std::vector<int> tokens;
+    int prev_token = -1;
+
+    for (int t = 0; t < num_frames; ++t) {
+        const float* frame = logits + static_cast<size_t>(t) * V;
+        int   best     = 0;
+        float best_val = frame[0];
+        for (int v = 1; v < V; ++v) {
+            if (frame[v] > best_val) { best_val = frame[v]; best = v; }
+        }
+        if (best != blank && best != prev_token) tokens.push_back(best);
+        prev_token = best;
+    }
+
+    std::string text;
+    for (int id : tokens) {
+        if (id < 0 || id >= static_cast<int>(id_to_piece_.size())) continue;
+        const std::string& piece = id_to_piece_[id];
+        if (piece.size() >= 3 &&
+            static_cast<unsigned char>(piece[0]) == 0xE2 &&
+            static_cast<unsigned char>(piece[1]) == 0x96 &&
+            static_cast<unsigned char>(piece[2]) == 0x81) {
+            if (!text.empty()) text += ' ';
+            text += piece.substr(3);
+        } else {
+            text += piece;
+        }
+    }
+    return text;
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_parakeet_stt.cpp
+++ b/src/models/litert/litert_parakeet_stt.cpp
@@ -5,22 +5,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
+#include <cstdint>
 
 namespace speech_core {
-
-// ---------------------------------------------------------------------------
-// SentencePiece U+2581 → space, then trim
-// ---------------------------------------------------------------------------
-
-static void replace_sp_marker(std::string& s) {
-    const std::string marker = "\xE2\x96\x81";
-    size_t pos = 0;
-    while ((pos = s.find(marker, pos)) != std::string::npos) {
-        s.replace(pos, marker.size(), " ");
-        pos += 1;
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -77,113 +64,165 @@ bool LiteRTParakeetStt::load_vocab(const std::string& path) {
     return !vocab_.empty();
 }
 
+// Decode token ids → text. SentencePiece ▁ (U+2581, UTF-8 E2 96 81) marks a
+// word boundary → space. Language tokens are skipped (detected separately).
 std::string LiteRTParakeetStt::decode_tokens(const std::vector<int>& token_ids) {
-    std::string pieces;
+    std::string text;
     for (int id : token_ids) {
+        if (lang_tokens_.count(id)) continue;
         auto it = vocab_.find(id);
-        if (it != vocab_.end()) pieces += it->second;
-    }
-    replace_sp_marker(pieces);
+        if (it == vocab_.end()) continue;
 
-    size_t start = pieces.find_first_not_of(' ');
-    if (start == std::string::npos) return "";
-    size_t end = pieces.find_last_not_of(' ');
-    return pieces.substr(start, end - start + 1);
+        const std::string& token = it->second;
+        if (!token.empty() && static_cast<unsigned char>(token[0]) == 0xE2) {
+            if (!text.empty()) text += ' ';
+            text += token.substr(3);  // skip the 3-byte ▁
+        } else {
+            text += token;
+        }
+    }
+    return text;
 }
 
 // ---------------------------------------------------------------------------
-// Mel spectrogram (per-utterance mean/var normalised, same as ORT wrapper)
+// Mel spectrogram — NeMo AudioToMelSpectrogramPreprocessor recipe (Parakeet
+// TDT v3): pre-emphasis → Slaney-mel STFT (center, log floor 2^-24) →
+// per-feature zero-mean unit-variance. Must match the cloud wrapper bit-for-bit
+// because the mel feeds the encoder; any drift changes the transcript.
 // ---------------------------------------------------------------------------
 
 std::vector<float> LiteRTParakeetStt::compute_mel(const float* audio, size_t length) {
-    std::vector<float> emphasized(length);
-    emphasized[0] = audio[0];
-    for (size_t i = 1; i < length; i++) {
-        emphasized[i] = audio[i] - cfg_.pre_emphasis * audio[i - 1];
+    if (length == 0) return {};
+
+    const float* mel_audio = audio;
+    std::vector<float> emphasized;
+    if (cfg_.pre_emphasis > 0.0f) {
+        emphasized.resize(length);
+        emphasized[0] = audio[0];
+        for (size_t i = 1; i < length; ++i)
+            emphasized[i] = audio[i] - cfg_.pre_emphasis * audio[i - 1];
+        mel_audio = emphasized.data();
     }
 
+    constexpr float kLogFloor = 5.960464477539063e-8f;  // 2^-24
     auto mel = audio::mel_spectrogram(
-        emphasized.data(), emphasized.size(),
-        cfg_.sample_rate, cfg_.n_fft, cfg_.hop_length,
-        cfg_.win_length, cfg_.num_mel_bins);
+        mel_audio, length,
+        cfg_.sample_rate, cfg_.n_fft, cfg_.hop_length, cfg_.win_length,
+        cfg_.num_mel_bins,
+        /*slaney_norm=*/true, /*log_floor=*/kLogFloor, /*center=*/true);
 
-    int num_frames = static_cast<int>(mel.size() / cfg_.num_mel_bins);
-    if (num_frames > 1) {
-        for (int m = 0; m < cfg_.num_mel_bins; m++) {
-            float sum = 0, sq_sum = 0;
-            for (int t = 0; t < num_frames; t++) {
-                float v = mel[m * num_frames + t];
-                sum    += v;
-                sq_sum += v * v;
-            }
-            float mean   = sum / num_frames;
-            float var    = sq_sum / num_frames - mean * mean;
-            float stddev = (var > 0) ? std::sqrt(var) : 1.0f;
-            for (int t = 0; t < num_frames; t++) {
-                mel[m * num_frames + t] = (mel[m * num_frames + t] - mean) / stddev;
-            }
-        }
+    const int n_mels = cfg_.num_mel_bins;
+    const int frames = (n_mels > 0) ? static_cast<int>(mel.size() / n_mels) : 0;
+    if (frames <= 0) return mel;
+
+    constexpr float eps = 1e-5f;
+    for (int m = 0; m < n_mels; ++m) {
+        float* row = mel.data() + static_cast<size_t>(m) * frames;
+        double sum = 0.0;
+        for (int t = 0; t < frames; ++t) sum += row[t];
+        float mean = static_cast<float>(sum / frames);
+        double var = 0.0;
+        for (int t = 0; t < frames; ++t) { float d = row[t] - mean; var += d * d; }
+        float sd = std::sqrt(static_cast<float>(var / frames) + eps);
+        for (int t = 0; t < frames; ++t) row[t] = (row[t] - mean) / sd;
     }
     return mel;
 }
 
 // ---------------------------------------------------------------------------
-// Encoder (dynamic T) + TDT decode
+// Encoder (fixed-shape [1, n_mels, enc_mel_frames], chunk + concat) + TDT decode
+//
+// The soniqo Parakeet-TDT-0.6B-v3-LiteRT-INT8 encoder is FIXED-shape: pad/chunk
+// the mel into enc_mel_frames-wide windows, encode each, and concatenate the
+// encoder outputs before decoding. Encoder I/O (prod-verified order):
+//   in:  [audio_signal float[1,n_mels,T], length int64[1]]
+//   out: [length int64[1], encoded float[1, hidden, enc_T]]
+// (Note: output order is [length, encoded] — opposite of an earlier
+// dynamic-shape export. This matches what the cloud runs in production.)
 // ---------------------------------------------------------------------------
 
 LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::decode(const float* audio, size_t length) {
     auto mel = compute_mel(audio, length);
-    const int64_t num_frames = static_cast<int64_t>(mel.size() / cfg_.num_mel_bins);
+    const int real_frames = static_cast<int>(mel.size() / cfg_.num_mel_bins);
+    if (real_frames <= 0) return {};
 
-    // Resize the encoder's dynamic time dim to match the current input.
-    const int enc_audio_dims[] = {1, cfg_.num_mel_bins, static_cast<int>(num_frames)};
-    litert_check(LiteRtCompiledModelResizeInputTensorNonStrict(
-                     enc_compiled_, 0, 0, enc_audio_dims, 3),
-                 "Encoder ResizeInputTensor(audio_signal)");
-    const int enc_len_dims[] = {1};
-    litert_check(LiteRtCompiledModelResizeInputTensorNonStrict(
-                     enc_compiled_, 0, 1, enc_len_dims, 1),
-                 "Encoder ResizeInputTensor(length)");
+    auto env = LiteRTEngine::get().env();
+    const int kT = cfg_.enc_mel_frames;
 
-    // Query the resized output layouts. update_allocation=true propagates the
-    // new dynamic shape from the resized inputs to the outputs (encoded[0]
-    // shape = [1, hidden, T']; encoded_lengths[1] shape = [1]).
+    // Query the encoder's static output layouts once: out[1] = encoded
+    // [1, hidden, enc_T]. update_allocation=false because the shape is static.
     LiteRtLayout enc_out_layouts[2]{};
     litert_check(LiteRtGetCompiledModelOutputTensorLayouts(
-                     enc_compiled_, 0, 2, enc_out_layouts, /*update_allocation=*/true),
+                     enc_compiled_, 0, 2, enc_out_layouts, /*update_allocation=*/false),
                  "GetOutputTensorLayouts(encoder)");
-    const int64_t hidden = enc_out_layouts[0].dimensions[1];
-    const int64_t enc_t  = enc_out_layouts[0].dimensions[2];
+    const int hidden = static_cast<int>(enc_out_layouts[1].dimensions[1]);
+    const int enc_T  = static_cast<int>(enc_out_layouts[1].dimensions[2]);
+    if (hidden <= 0 || enc_T <= 0) return {};
 
-    std::vector<float> encoded(static_cast<size_t>(hidden * enc_t));
-    int64_t mel_len = num_frames;
-    int64_t enc_len = 0;
+    auto t_audio   = make_type(kLiteRtElementTypeFloat32, {1, cfg_.num_mel_bins, kT});
+    auto t_length  = make_type(kLiteRtElementTypeInt64,   {1});
+    auto t_enc_len = make_type(kLiteRtElementTypeInt64,   {1});
+    auto t_encoded = make_type(kLiteRtElementTypeFloat32, {1, hidden, enc_T});
 
-    auto env       = LiteRTEngine::get().env();
-    auto t_audio   = make_type(kLiteRtElementTypeFloat32,
-                                {1, cfg_.num_mel_bins, static_cast<int32_t>(num_frames)});
-    auto t_length  = make_type(kLiteRtElementTypeInt64,  {1});
-    auto t_encoded = make_type(kLiteRtElementTypeFloat32,
-                                {1, static_cast<int32_t>(hidden), static_cast<int32_t>(enc_t)});
-    auto t_enc_len = make_type(kLiteRtElementTypeInt64,  {1});
+    std::vector<float> time_major;  // [total_enc_frames, hidden]
+    int total_enc_frames = 0;
 
-    LiteRtHostBuffer in_audio   (env, t_audio,   mel.size() * sizeof(float), mel.data());
-    LiteRtHostBuffer in_length  (env, t_length,  sizeof(int64_t),            &mel_len);
-    LiteRtHostBuffer out_encoded(env, t_encoded, encoded.size() * sizeof(float));
-    LiteRtHostBuffer out_enc_len(env, t_enc_len, sizeof(int64_t));
+    std::vector<float> padded(static_cast<size_t>(cfg_.num_mel_bins) * kT);
+    std::vector<float> enc_chunk(static_cast<size_t>(hidden) * enc_T);
 
-    LiteRtTensorBuffer enc_ins[2]  = { in_audio.raw(),    in_length.raw()  };
-    LiteRtTensorBuffer enc_outs[2] = { out_encoded.raw(), out_enc_len.raw() };
-    litert_check(LiteRtRunCompiledModel(enc_compiled_, 0, 2, enc_ins, 2, enc_outs),
-                 "Encoder Run");
+    for (int chunk_start = 0; chunk_start < real_frames; chunk_start += kT) {
+        const int chunk_frames = std::min(kT, real_frames - chunk_start);
 
-    out_encoded.read(encoded.data(), encoded.size() * sizeof(float));
-    out_enc_len.read(&enc_len,       sizeof(int64_t));
+        std::fill(padded.begin(), padded.end(), 0.0f);
+        for (int bin = 0; bin < cfg_.num_mel_bins; ++bin) {
+            const float* src = mel.data() + static_cast<size_t>(bin) * real_frames + chunk_start;
+            std::copy(src, src + chunk_frames,
+                      padded.begin() + static_cast<size_t>(bin) * kT);
+        }
 
-    LOGI("LiteRT STT: frames=%lld enc_len=%lld hidden=%lld audio=%zu",
-         (long long)num_frames, (long long)enc_len, (long long)hidden, length);
+        int64_t mel_len = chunk_frames;
+        int64_t out_len = 0;
 
-    auto result = tdt_decode(encoded.data(), enc_len, hidden);
+        LiteRtHostBuffer in_audio (env, t_audio,   padded.size() * sizeof(float), padded.data());
+        LiteRtHostBuffer in_length(env, t_length,  sizeof(int64_t),               &mel_len);
+        LiteRtHostBuffer out_lenb (env, t_enc_len, sizeof(int64_t));
+        LiteRtHostBuffer out_enc  (env, t_encoded, enc_chunk.size() * sizeof(float));
+
+        LiteRtTensorBuffer enc_ins [2] = { in_audio.raw(), in_length.raw() };
+        LiteRtTensorBuffer enc_outs[2] = { out_lenb.raw(),  out_enc.raw()  };
+        litert_check(LiteRtRunCompiledModel(enc_compiled_, 0, 2, enc_ins, 2, enc_outs),
+                     "Encoder Run");
+
+        out_lenb.read(&out_len,          sizeof(int64_t));
+        out_enc .read(enc_chunk.data(),  enc_chunk.size() * sizeof(float));
+
+        // enc_chunk is channels-first [hidden, enc_T]; keep only the valid
+        // frames the encoder reported, appended in time-major order.
+        const int enc_frames = std::min(static_cast<int>(out_len), enc_T);
+        for (int t = 0; t < enc_frames; ++t) {
+            for (int ch = 0; ch < hidden; ++ch) {
+                time_major.push_back(enc_chunk[static_cast<size_t>(ch) * enc_T + t]);
+            }
+        }
+        total_enc_frames += enc_frames;
+    }
+
+    if (total_enc_frames <= 0) return {};
+
+    // Transpose time-major [total, hidden] → channels-first [hidden, total]
+    // for tdt_decode (which gathers frame t at stride ch*total + t).
+    std::vector<float> encoded_chw(static_cast<size_t>(hidden) * total_enc_frames);
+    for (int t = 0; t < total_enc_frames; ++t) {
+        for (int ch = 0; ch < hidden; ++ch) {
+            encoded_chw[static_cast<size_t>(ch) * total_enc_frames + t] =
+                time_major[static_cast<size_t>(t) * hidden + ch];
+        }
+    }
+
+    LOGI("LiteRT STT: real_frames=%d enc_frames=%d hidden=%d audio=%zu",
+         real_frames, total_enc_frames, hidden, length);
+
+    auto result = tdt_decode(encoded_chw.data(), total_enc_frames, hidden);
     LOGI("LiteRT STT: text='%.60s' conf=%.4f", result.text.c_str(), result.confidence);
     return result;
 }
@@ -204,107 +243,112 @@ TranscriptionResult LiteRTParakeetStt::transcribe(
 }
 
 // ---------------------------------------------------------------------------
-// TDT greedy decoding with fused decoder_joint model
+// TDT greedy decode with the fused decoder-joint model.
+//
+// Decoder I/O (prod-verified soniqo export):
+//   in:  h[layers,1,hidden_dec]  c[layers,1,hidden_dec]  enc_frame[1,1,hidden]
+//        target[1,1] int64
+//   out: h_new[layers,1,hidden_dec]  logits[1,1,1,total_logits]
+//        c_new[layers,1,hidden_dec]
+//
+// TDT duration bins live at logits[blank+1 ..]. Duration 0 means "emit a token
+// and STAY on this frame" — the model may emit up to kMaxSymbols tokens at one
+// frame before we force-advance. This dur-0 handling is the fix that the older
+// speech-core decode lacked.
 // ---------------------------------------------------------------------------
 
 LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::tdt_decode(
     const float* encoded, int64_t enc_len, int64_t hidden)
 {
-    std::vector<int> token_ids;
-    std::string detected_language;
-    float log_prob_sum = 0.0f;
-    int   log_prob_count = 0;
+    const int kState = cfg_.decoder_layers * cfg_.decoder_hidden;  // [layers,1,hidden_dec]
+    const int kVocab = cfg_.vocab_size;
+    const int kBlank = cfg_.blank_id;
+    const int kDurs  = cfg_.num_dur_bins;
+    constexpr int kMaxSymbols = 10;  // matches NeMo greedy.max_symbols
 
-    const int64_t state_size = cfg_.decoder_layers * 1 * cfg_.decoder_hidden;
-    std::vector<float> h_state(state_size, 0.0f);
-    std::vector<float> c_state(state_size, 0.0f);
-
-    int64_t prev_token = static_cast<int64_t>(cfg_.blank_id);
-    int64_t t = 0;
-
-    std::vector<float> enc_frame(hidden);
-    std::vector<float> logits   (cfg_.total_logits);
-    std::vector<float> h_out    (state_size);
-    std::vector<float> c_out    (state_size);
-
-    // Decoder I/O tensor types are fixed across the loop.
     auto env      = LiteRTEngine::get().env();
-    auto t_enc    = make_type(kLiteRtElementTypeFloat32, {1, static_cast<int32_t>(hidden)});
-    auto t_target = make_type(kLiteRtElementTypeInt64,   {1});
-    auto t_state  = make_type(kLiteRtElementTypeFloat32, {cfg_.decoder_layers, 1, cfg_.decoder_hidden});
-    auto t_logits = make_type(kLiteRtElementTypeFloat32, {1, cfg_.total_logits});
+    auto t_state  = make_type(kLiteRtElementTypeFloat32,
+                              {cfg_.decoder_layers, 1, cfg_.decoder_hidden});
+    auto t_enc    = make_type(kLiteRtElementTypeFloat32, {1, 1, static_cast<int32_t>(hidden)});
+    auto t_target = make_type(kLiteRtElementTypeInt64,   {1, 1});
+    auto t_logits = make_type(kLiteRtElementTypeFloat32, {1, 1, 1, cfg_.total_logits});
 
+    std::vector<float> h(kState, 0.0f), c(kState, 0.0f);
+    std::vector<float> enc_frame(static_cast<size_t>(hidden));
+    std::vector<float> logits(static_cast<size_t>(cfg_.total_logits));
+    std::vector<float> h_out(kState), c_out(kState);
+
+    std::vector<int> tokens;
+    std::string detected_lang;
+    float total_log_prob = 0.0f;
+    int   total_tokens   = 0;
+    int   prev_token     = kBlank;
+    int   symbols_at_t   = 0;
+
+    int64_t t = 0;
     while (t < enc_len) {
-        // Encoder frame at time t: [1, 1, hidden] — note LiteRT decoder takes
-        // (B, T_enc=1, H) per convert_litert.py, vs ORT's (B, H, T_enc=1).
-        for (int64_t h = 0; h < hidden; h++) {
-            enc_frame[h] = encoded[h * enc_len + t];
+        for (int64_t ch = 0; ch < hidden; ++ch) {
+            enc_frame[ch] = encoded[ch * enc_len + t];
         }
+        int64_t target = prev_token;
 
-        LiteRtHostBuffer in_enc    (env, t_enc,    enc_frame.size() * sizeof(float), enc_frame.data());
-        LiteRtHostBuffer in_target (env, t_target, sizeof(int64_t),                  &prev_token);
-        LiteRtHostBuffer in_h      (env, t_state,  h_state.size() * sizeof(float),   h_state.data());
-        LiteRtHostBuffer in_c      (env, t_state,  c_state.size() * sizeof(float),   c_state.data());
-        LiteRtHostBuffer out_logits(env, t_logits, logits.size() * sizeof(float));
-        LiteRtHostBuffer out_h     (env, t_state,  h_out.size() * sizeof(float));
-        LiteRtHostBuffer out_c     (env, t_state,  c_out.size() * sizeof(float));
+        LiteRtHostBuffer in_h     (env, t_state,  h.size() * sizeof(float),         h.data());
+        LiteRtHostBuffer in_c     (env, t_state,  c.size() * sizeof(float),         c.data());
+        LiteRtHostBuffer in_enc   (env, t_enc,    enc_frame.size() * sizeof(float), enc_frame.data());
+        LiteRtHostBuffer in_target(env, t_target, sizeof(int64_t),                  &target);
+        LiteRtHostBuffer out_h    (env, t_state,  h_out.size() * sizeof(float));
+        LiteRtHostBuffer out_log  (env, t_logits, logits.size() * sizeof(float));
+        LiteRtHostBuffer out_c    (env, t_state,  c_out.size() * sizeof(float));
 
-        LiteRtTensorBuffer ins[4]  = { in_enc.raw(), in_target.raw(), in_h.raw(), in_c.raw() };
-        LiteRtTensorBuffer outs[3] = { out_logits.raw(), out_h.raw(), out_c.raw() };
+        LiteRtTensorBuffer ins [4] = { in_h.raw(), in_c.raw(), in_enc.raw(), in_target.raw() };
+        LiteRtTensorBuffer outs[3] = { out_h.raw(), out_log.raw(), out_c.raw() };
         litert_check(LiteRtRunCompiledModel(dec_compiled_, 0, 4, ins, 3, outs),
                      "Decoder Run");
-        out_logits.read(logits.data(), logits.size() * sizeof(float));
-        out_h     .read(h_out.data(),  h_out.size()  * sizeof(float));
-        out_c     .read(c_out.data(),  c_out.size()  * sizeof(float));
 
-        const int token_end = cfg_.vocab_size + 1;
+        out_h  .read(h_out.data(),  h_out.size()  * sizeof(float));
+        out_log.read(logits.data(), logits.size() * sizeof(float));
+        out_c  .read(c_out.data(),  c_out.size()  * sizeof(float));
+
+        // Commit decoder state every step (matches the prod-verified wrapper).
+        h = h_out;
+        c = c_out;
+
+        // argmax over tokens + blank (indices 0..kVocab inclusive).
         int   best_token = 0;
-        float best_score = logits[0];
-        for (int i = 1; i < token_end; i++) {
-            if (logits[i] > best_score) {
-                best_score = logits[i];
-                best_token = i;
-            }
+        float best_logit = logits[0];
+        for (int i = 1; i <= kVocab; ++i) {
+            if (logits[i] > best_logit) { best_logit = logits[i]; best_token = i; }
         }
 
-        if (best_token == cfg_.blank_id) {
-            t += 1;
-        } else {
-            if (best_token >= cfg_.first_text_token && best_token < cfg_.vocab_size) {
-                auto lang_it = lang_tokens_.find(best_token);
-                if (lang_it != lang_tokens_.end()) {
-                    if (detected_language.empty()) detected_language = lang_it->second;
-                } else {
-                    token_ids.push_back(best_token);
-                    log_prob_sum += best_score;
-                    log_prob_count++;
-                }
-            }
+        // argmax over the duration bins stored at [kBlank+1 ..].
+        int   best_dur       = 0;
+        float best_dur_logit = logits[kBlank + 1];
+        for (int d = 1; d < kDurs; ++d) {
+            float dl = logits[kBlank + 1 + d];
+            if (dl > best_dur_logit) { best_dur_logit = dl; best_dur = d; }
+        }
 
-            const float* dur_logits = logits.data() + token_end;
-            int   dur_idx = 0;
-            float best_dur = dur_logits[0];
-            for (int d = 1; d < cfg_.num_dur_bins; d++) {
-                if (dur_logits[d] > best_dur) {
-                    best_dur = dur_logits[d];
-                    dur_idx  = d;
-                }
-            }
-            t += std::max(cfg_.duration_bins[dur_idx], 1);
-
+        if (best_token != kBlank) {
+            tokens.push_back(best_token);
+            total_log_prob += best_logit;
+            ++total_tokens;
+            ++symbols_at_t;
             prev_token = best_token;
-            h_state = h_out;
-            c_state = c_out;
+            auto lang_it = lang_tokens_.find(best_token);
+            if (lang_it != lang_tokens_.end()) detected_lang = lang_it->second;
+        }
+
+        if (best_token == kBlank || best_dur > 0 || symbols_at_t >= kMaxSymbols) {
+            t += std::max(best_dur, 1);
+            symbols_at_t = 0;
         }
     }
 
     DecodeResult result;
-    result.text     = decode_tokens(token_ids);
-    result.language = detected_language;
-    if (log_prob_count > 0) {
-        float mean_logit  = log_prob_sum / static_cast<float>(log_prob_count);
-        result.confidence = 1.0f / (1.0f + std::exp(-mean_logit * 0.1f));
-    }
+    result.text     = decode_tokens(tokens);
+    result.language = detected_lang;
+    result.confidence = total_tokens > 0
+        ? std::exp(total_log_prob / static_cast<float>(total_tokens)) : 0.0f;
     if (!result.language.empty()) {
         LOGI("LiteRT STT: detected language=%s", result.language.c_str());
     }
@@ -312,7 +356,7 @@ LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::tdt_decode(
 }
 
 // ---------------------------------------------------------------------------
-// Streaming (same accumulate-and-re-transcribe shape as ORT)
+// Streaming (accumulate-and-re-transcribe; single-utterance sessions)
 // ---------------------------------------------------------------------------
 
 void LiteRTParakeetStt::begin_stream(int sample_rate) {

--- a/src/models/litert/litert_pyannote_segmentation.cpp
+++ b/src/models/litert/litert_pyannote_segmentation.cpp
@@ -1,0 +1,123 @@
+#include "speech_core/models/litert_pyannote_segmentation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace speech_core {
+
+LiteRTPyannoteSegmentation::LiteRTPyannoteSegmentation(const std::string& model_path, bool hw_accel)
+    : state_(kStateSize, 0.0f), chunk_buffer_(16000, 0.0f)
+{
+    LiteRTEngine::get().load(model_path, hw_accel, &model_, &compiled_);
+}
+
+LiteRTPyannoteSegmentation::~LiteRTPyannoteSegmentation() {
+    if (compiled_) LiteRtDestroyCompiledModel(compiled_);
+    if (model_)    LiteRtDestroyModel(model_);
+}
+
+void LiteRTPyannoteSegmentation::process_chunk(
+    const float* audio, size_t length, std::vector<float>& window_posteriors)
+{
+    const int chunk = cfg_.chunk_samples;
+    if (static_cast<int>(length) < chunk) {
+        std::copy(audio, audio + length, chunk_buffer_.begin());
+        std::fill(chunk_buffer_.begin() + length, chunk_buffer_.end(), 0.0f);
+        audio = chunk_buffer_.data();
+    }
+
+    auto env     = LiteRTEngine::get().env();
+    auto t_audio = make_type(kLiteRtElementTypeFloat32, {1, 1, chunk});
+    auto t_state = make_type(kLiteRtElementTypeFloat32,
+                             {kStateDim0, kStateDim1, kStateDim2, kStateDim3});
+    auto t_post  = make_type(kLiteRtElementTypeFloat32,
+                             {1, cfg_.frames_per_chunk, cfg_.num_powerset_classes});
+
+    LiteRtHostBuffer in_audio (env, t_audio, static_cast<size_t>(chunk) * sizeof(float), audio);
+    LiteRtHostBuffer in_state (env, t_state, kStateSize * sizeof(float), state_.data());
+    LiteRtHostBuffer out_state(env, t_state, kStateSize * sizeof(float));
+    LiteRtHostBuffer out_post (env, t_post,
+        static_cast<size_t>(cfg_.frames_per_chunk) * cfg_.num_powerset_classes * sizeof(float));
+
+    // Output order (prod-verified soniqo export): out[0]=lstm_state, out[1]=posteriors.
+    LiteRtTensorBuffer ins [2] = { in_audio.raw(),  in_state.raw() };
+    LiteRtTensorBuffer outs[2] = { out_state.raw(), out_post.raw() };
+    litert_check(LiteRtRunCompiledModel(compiled_, 0, 2, ins, 2, outs), "Pyannote Run");
+
+    const int n = cfg_.frames_per_chunk * cfg_.num_powerset_classes;
+    std::vector<float> post(static_cast<size_t>(n));
+    out_post .read(post.data(),   static_cast<size_t>(n) * sizeof(float));
+    out_state.read(state_.data(), kStateSize * sizeof(float));
+
+    window_posteriors.insert(window_posteriors.end(), post.begin(), post.end());
+}
+
+std::vector<SegmentationWindow>
+LiteRTPyannoteSegmentation::segment(const float* audio, size_t length, int sample_rate) {
+    if (sample_rate != cfg_.sample_rate)
+        throw std::runtime_error("PyannoteSegmentation expects 16kHz");
+
+    const int    chunk             = cfg_.chunk_samples;
+    const int    chunks_per_window = cfg_.chunks_per_window;
+    const size_t win_samples       = static_cast<size_t>(chunk) * chunks_per_window;
+    const size_t step_samples      = static_cast<size_t>(cfg_.window_step * cfg_.sample_rate);
+    const float  sr_f              = static_cast<float>(cfg_.sample_rate);
+
+    std::vector<SegmentationWindow> results;
+
+    // Reset LSTM state at each window start, run chunks_per_window chunks with
+    // carried state, collect the posteriors, then slide the window.
+    for (size_t off = 0; off + win_samples <= length; off += step_samples) {
+        std::fill(state_.begin(), state_.end(), 0.0f);
+
+        std::vector<float> window_posteriors;
+        window_posteriors.reserve(static_cast<size_t>(chunks_per_window) *
+                                  cfg_.frames_per_chunk * cfg_.num_powerset_classes);
+
+        for (int k = 0; k < chunks_per_window; ++k) {
+            size_t chunk_off = off + static_cast<size_t>(k) * chunk;
+            size_t chunk_len = std::min<size_t>(chunk, length - chunk_off);
+            process_chunk(audio + chunk_off, chunk_len, window_posteriors);
+        }
+
+        const int total_frames = chunks_per_window * cfg_.frames_per_chunk;
+
+        SegmentationWindow wr;
+        wr.start_time = static_cast<float>(off) / sr_f;
+        wr.end_time   = static_cast<float>(off + win_samples) / sr_f;
+        wr.posteriors = std::move(window_posteriors);
+        decode_powerset(wr.posteriors.data(), total_frames, wr.speaker_activity);
+
+        results.push_back(std::move(wr));
+    }
+
+    return results;
+}
+
+void LiteRTPyannoteSegmentation::decode_powerset(
+    const float* posteriors, int num_frames, std::vector<float>& speaker_activity)
+{
+    const int K = cfg_.max_local_speakers;
+    const int C = cfg_.num_powerset_classes;
+
+    speaker_activity.assign(static_cast<size_t>(num_frames) * K, 0.0f);
+
+    // Powerset over {∅, {1}, {2}, {3}, {1,2}, {1,3}, {2,3}} → per-speaker activity.
+    for (int f = 0; f < num_frames; ++f) {
+        const float* p = posteriors + static_cast<size_t>(f) * C;
+
+        float mx = *std::max_element(p, p + C);
+        float sum = 0.0f;
+        float probs[7];
+        for (int c = 0; c < C; ++c) { probs[c] = std::exp(p[c] - mx); sum += probs[c]; }
+        for (int c = 0; c < C; ++c) probs[c] /= sum;
+
+        float* a = speaker_activity.data() + static_cast<size_t>(f) * K;
+        a[0] = probs[1] + probs[4] + probs[5];
+        a[1] = probs[2] + probs[4] + probs[6];
+        a[2] = probs[3] + probs[5] + probs[6];
+    }
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_wespeaker_embedding.cpp
+++ b/src/models/litert/litert_wespeaker_embedding.cpp
@@ -1,0 +1,152 @@
+#include "speech_core/models/litert_wespeaker_embedding.h"
+
+#include "speech_core/audio/fft.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+namespace speech_core {
+
+namespace {
+
+// Kaldi-style mel frequency conversion (HTK formulation).
+float mel_of(float hz)  { return 1127.0f * std::log(1.0f + hz / 700.0f); }
+float hz_of(float mel)  { return 700.0f * (std::exp(mel / 1127.0f) - 1.0f); }
+
+// Triangular mel filterbank of `num_bins` filters over an `n_fft`-point STFT at
+// `sr` Hz, spanning [0, sr/2]. NOT area-normalised — kaldi's default fbank uses
+// raw triangles with unit peak.
+std::vector<float> kaldi_filterbank(int num_bins, int n_fft, int sr) {
+    int fft_bins = n_fft / 2 + 1;
+    float mel_low  = mel_of(0.0f);
+    float mel_high = mel_of(static_cast<float>(sr) / 2.0f);
+
+    std::vector<float> center_mel(num_bins + 2);
+    for (int i = 0; i < num_bins + 2; ++i)
+        center_mel[i] = mel_low + (mel_high - mel_low) * i / (num_bins + 1);
+
+    std::vector<float> center_hz(num_bins + 2);
+    for (int i = 0; i < num_bins + 2; ++i) center_hz[i] = hz_of(center_mel[i]);
+
+    std::vector<float> bin_hz(fft_bins);
+    for (int f = 0; f < fft_bins; ++f)
+        bin_hz[f] = static_cast<float>(f) * sr / static_cast<float>(n_fft);
+
+    std::vector<float> fb(static_cast<size_t>(num_bins) * fft_bins, 0.0f);
+    for (int m = 0; m < num_bins; ++m) {
+        float lo = center_hz[m], ce = center_hz[m + 1], hi = center_hz[m + 2];
+        for (int f = 0; f < fft_bins; ++f) {
+            float h = bin_hz[f];
+            if (h >= lo && h <= ce && ce > lo) {
+                fb[m * fft_bins + f] = (h - lo) / (ce - lo);
+            } else if (h > ce && h <= hi && hi > ce) {
+                fb[m * fft_bins + f] = (hi - h) / (hi - ce);
+            }
+        }
+    }
+    return fb;
+}
+
+}  // namespace
+
+LiteRTWeSpeakerEmbedding::LiteRTWeSpeakerEmbedding(const std::string& model_path, bool hw_accel) {
+    LiteRTEngine::get().load(model_path, hw_accel, &model_, &compiled_);
+}
+
+LiteRTWeSpeakerEmbedding::~LiteRTWeSpeakerEmbedding() {
+    if (compiled_) LiteRtDestroyCompiledModel(compiled_);
+    if (model_)    LiteRtDestroyModel(model_);
+}
+
+std::vector<float> LiteRTWeSpeakerEmbedding::compute_fbank(const float* audio, size_t length) {
+    // Fixed-shape kaldi-style log-mel fbank: kNumFrames × kNumMelBins (≈3 s at
+    // 10 ms hop). Shorter input is tiled; longer is truncated.
+    //   frame 25 ms (400) / hop 10 ms (160), Hamming, dither 0, no energy,
+    //   per-frame DC removal. n_fft = next pow2 of frame_length = 512.
+    const int n_fft    = 512;
+    const int fft_bins = n_fft / 2 + 1;
+    const int frames   = kNumFrames;
+    const int bins     = kNumMelBins;
+    const int win_len  = kFrameLenSamp;
+    const int hop      = kHopSamp;
+
+    const size_t required =
+        static_cast<size_t>(win_len) + static_cast<size_t>(frames - 1) * hop;
+
+    std::vector<float> padded(required, 0.0f);
+    if (length >= required) {
+        std::copy(audio, audio + required, padded.begin());
+    } else if (length > 0) {
+        for (size_t off = 0; off < required; off += length) {
+            size_t n = std::min(length, required - off);
+            std::copy(audio, audio + n, padded.begin() + off);
+        }
+    }
+
+    std::vector<float> window(win_len);
+    for (int i = 0; i < win_len; ++i)
+        window[i] = 0.54f - 0.46f * std::cos(2.0f * static_cast<float>(M_PI) * i / (win_len - 1));
+
+    static std::vector<float> fb;
+    if (fb.empty()) fb = kaldi_filterbank(bins, n_fft, 16000);
+
+    std::vector<float> fbank(static_cast<size_t>(frames) * bins, 0.0f);
+    std::vector<float> frame_buf(n_fft, 0.0f);
+    std::vector<float> spec_re(fft_bins), spec_im(fft_bins);
+
+    for (int t = 0; t < frames; ++t) {
+        std::fill(frame_buf.begin(), frame_buf.end(), 0.0f);
+
+        // kaldi "remove_dc_offset": subtract the per-frame mean before windowing.
+        float mean = 0.0f;
+        for (int i = 0; i < win_len; ++i) mean += padded[t * hop + i];
+        mean /= static_cast<float>(win_len);
+        for (int i = 0; i < win_len; ++i)
+            frame_buf[i] = (padded[t * hop + i] - mean) * window[i];
+
+        audio::fft_real(frame_buf.data(), n_fft, spec_re.data(), spec_im.data());
+
+        for (int m = 0; m < bins; ++m) {
+            float sum = 0.0f;
+            for (int f = 0; f < fft_bins; ++f) {
+                float power = spec_re[f] * spec_re[f] + spec_im[f] * spec_im[f];
+                sum += power * fb[m * fft_bins + f];
+            }
+            fbank[t * bins + m] = std::log(std::max(sum, 1e-10f));
+        }
+    }
+    return fbank;
+}
+
+std::vector<float> LiteRTWeSpeakerEmbedding::embed(
+    const float* audio, size_t length, int sample_rate)
+{
+    if (sample_rate != 16000) throw std::runtime_error("WeSpeaker expects 16kHz input");
+
+    auto fbank = compute_fbank(audio, length);  // [kNumFrames * kNumMelBins]
+
+    auto env     = LiteRTEngine::get().env();
+    auto t_fbank = make_type(kLiteRtElementTypeFloat32, {1, kNumFrames, kNumMelBins});
+    auto t_emb   = make_type(kLiteRtElementTypeFloat32, {1, kEmbeddingDim});
+
+    LiteRtHostBuffer in_fbank(env, t_fbank, fbank.size() * sizeof(float), fbank.data());
+    LiteRtHostBuffer out_emb (env, t_emb,   kEmbeddingDim * sizeof(float));
+
+    LiteRtTensorBuffer ins [1] = { in_fbank.raw() };
+    LiteRtTensorBuffer outs[1] = { out_emb.raw() };
+    litert_check(LiteRtRunCompiledModel(compiled_, 0, 1, ins, 1, outs), "WeSpeaker Run");
+
+    std::vector<float> embedding(kEmbeddingDim);
+    out_emb.read(embedding.data(), kEmbeddingDim * sizeof(float));
+
+    float norm = 0.0f;
+    for (float v : embedding) norm += v * v;
+    norm = std::sqrt(norm);
+    if (norm > 1e-8f) for (float& v : embedding) v /= norm;
+
+    return embedding;
+}
+
+}  // namespace speech_core

--- a/tests/test_diarization.cpp
+++ b/tests/test_diarization.cpp
@@ -1,0 +1,131 @@
+// Unit tests for DiarizationPipeline — runs in the default build (no LiteRT, no
+// model files). Drives the clustering + segment-building logic with mock
+// Segmentation/Embedding implementations so the algorithm is exercised in PR CI,
+// not only the model-gated nightly e2e.
+
+#include "speech_core/diarization/diarization_pipeline.h"
+#include "speech_core/interfaces.h"
+
+#include <cassert>
+#include <cstdio>
+#include <set>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+// Returns preset windows verbatim; ignores the audio.
+class MockSegmentation : public SegmentationInterface {
+public:
+    std::vector<SegmentationWindow> windows;
+    int max_spk = 2;
+
+    std::vector<SegmentationWindow> segment(const float*, size_t, int) override {
+        return windows;
+    }
+    int input_sample_rate() const override { return 16000; }
+    int max_local_speakers() const override { return max_spk; }
+};
+
+// Direction-distinct embedding keyed on the sign of the region's mean sample —
+// so the test can make two regions "the same speaker" (same sign) or "different
+// speakers" (opposite sign) by how it fills the audio buffer.
+class MockEmbedding : public EmbeddingInterface {
+public:
+    std::vector<float> embed(const float* audio, size_t len, int) override {
+        double s = 0.0;
+        for (size_t i = 0; i < len; ++i) s += audio[i];
+        float mean = len ? static_cast<float>(s / len) : 0.0f;
+        if (mean > 0.01f)  return {1.0f, 0.0f, 0.0f};
+        if (mean < -0.01f) return {0.0f, 1.0f, 0.0f};
+        return {0.0f, 0.0f, 1.0f};
+    }
+    int embedding_dim() const override { return 3; }
+    int input_sample_rate() const override { return 16000; }
+};
+
+// One window [start,end] where local speaker 0 is active across all frames.
+SegmentationWindow window_spk0(float start, float end, int K, int nf) {
+    SegmentationWindow w;
+    w.start_time = start;
+    w.end_time   = end;
+    w.speaker_activity.assign(static_cast<size_t>(nf) * K, 0.0f);
+    for (int f = 0; f < nf; ++f) w.speaker_activity[f * K + 0] = 1.0f;
+    return w;
+}
+
+void assert_well_formed(const std::vector<DiarizedSegment>& segs) {
+    for (size_t i = 0; i < segs.size(); ++i) {
+        assert(segs[i].speaker >= 0);
+        assert(segs[i].end > segs[i].start);
+        if (i > 0) assert(segs[i].start >= segs[i - 1].start);  // time-sorted
+    }
+}
+
+std::set<int> distinct_speakers(const std::vector<DiarizedSegment>& segs) {
+    std::set<int> s;
+    for (auto& g : segs) s.insert(g.speaker);
+    return s;
+}
+
+// Two windows, one active speaker each, with DIFFERENT embeddings → the
+// clusterer must keep them apart (cosine distance 1 > threshold 0.715).
+void test_distinct_speakers_stay_separate() {
+    MockSegmentation seg;
+    MockEmbedding    emb;
+    seg.windows = {window_spk0(0.0f, 1.0f, 2, 10), window_spk0(1.0f, 2.0f, 2, 10)};
+
+    std::vector<float> audio(32000, 0.0f);
+    for (int i = 0;     i < 16000; ++i) audio[i] =  0.5f;  // window 0 → [1,0,0]
+    for (int i = 16000; i < 32000; ++i) audio[i] = -0.5f;  // window 1 → [0,1,0]
+
+    DiarizationPipeline diar(seg, emb);
+    auto segs = diar.diarize(audio.data(), audio.size(), 16000, DiarizerConfig{});
+
+    assert(!segs.empty());
+    assert_well_formed(segs);
+    assert(distinct_speakers(segs).size() == 2);
+    printf("  PASS: distinct_speakers_stay_separate (%zu segments)\n", segs.size());
+}
+
+// Two windows, one active speaker each, with the SAME embedding → the clusterer
+// must merge them into one speaker (cosine distance 0 < threshold).
+void test_same_speaker_merges_across_windows() {
+    MockSegmentation seg;
+    MockEmbedding    emb;
+    seg.windows = {window_spk0(0.0f, 1.0f, 2, 10), window_spk0(1.0f, 2.0f, 2, 10)};
+
+    std::vector<float> audio(32000, 0.5f);  // both regions → [1,0,0]
+
+    DiarizationPipeline diar(seg, emb);
+    auto segs = diar.diarize(audio.data(), audio.size(), 16000, DiarizerConfig{});
+
+    assert(!segs.empty());
+    assert_well_formed(segs);
+    assert(distinct_speakers(segs).size() == 1);
+    printf("  PASS: same_speaker_merges_across_windows (%zu segments)\n", segs.size());
+}
+
+// Empty segmentation → empty result, no crash.
+void test_empty_segmentation() {
+    MockSegmentation seg;  // no windows
+    MockEmbedding    emb;
+    std::vector<float> audio(16000, 0.5f);
+
+    DiarizationPipeline diar(seg, emb);
+    auto segs = diar.diarize(audio.data(), audio.size(), 16000, DiarizerConfig{});
+    assert(segs.empty());
+    printf("  PASS: empty_segmentation\n");
+}
+
+}  // namespace
+
+int main() {
+    printf("test_diarization\n");
+    test_distinct_speakers_stay_separate();
+    test_same_speaker_merges_across_windows();
+    test_empty_segmentation();
+    printf("All diarization tests passed\n");
+    return 0;
+}

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -14,6 +14,7 @@
 #include "speech_core/audio/resampler.h"
 #include "speech_core/interfaces.h"
 #include "speech_core/diarization/diarization_pipeline.h"
+#include "speech_core/models/litert_nemotron_streaming_stt.h"
 #include "speech_core/models/litert_omnilingual_stt.h"
 #include "speech_core/models/litert_parakeet_stt.h"
 #include "speech_core/models/litert_pyannote_segmentation.h"
@@ -871,6 +872,54 @@ void test_litert_diarization(const std::string& dir) {
     std::printf("ok (segments=%zu speakers=%zu)\n", segments.size(), speakers.size());
 }
 
+// ---------------------------------------------------------------------------
+// Nemotron Speech Streaming — feeds the fixture in ~100 ms chunks through the
+// cache-aware streaming RNN-T (encoder+cache → decoder LSTM → joint) and runs
+// the full begin/push/end path. This exercises the per-stream cache rolling +
+// decoder-state advance + joint greedy loop end-to-end; reaching the end
+// without throwing means the encoder/decoder/joint tensor wiring is correct.
+// (Transcript content parity is a nightly concern against known audio.)
+// ---------------------------------------------------------------------------
+
+void test_litert_nemotron_streaming_stt(const std::string& dir) {
+    std::string enc = dir + "/nemotron-streaming-encoder.tflite";
+    std::string dec = dir + "/nemotron-streaming-decoder.tflite";
+    std::string jnt = dir + "/nemotron-streaming-joint.tflite";
+    std::string voc = dir + "/nemotron-vocab.json";
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(jnt) || !file_exists(voc)) {
+        std::printf("  [skip] nemotron-streaming files not in %s\n", dir.c_str());
+        return;
+    }
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_nemotron_streaming_stt ... ");
+
+    speech_core::LiteRTNemotronStreamingStt stt(enc, dec, jnt, voc, /*hw_accel=*/false);
+    REQUIRE(stt.input_sample_rate() == 16000);
+    REQUIRE(stt.supports_streaming());
+
+    auto audio = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    REQUIRE(!audio.empty());
+
+    stt.begin_stream(16000);
+    size_t partials = 0;
+    constexpr size_t kFeed = 1600;  // 100 ms @ 16 kHz
+    for (size_t off = 0; off < audio.size(); off += kFeed) {
+        size_t len = std::min(kFeed, audio.size() - off);
+        auto p = stt.push_chunk(audio.data() + off, len);
+        if (!p.text.empty()) ++partials;
+    }
+    auto result = stt.end_stream();
+
+    std::printf("partials=%zu final=\"%.50s\" ok\n", partials, result.text.c_str());
+}
+
 }  // namespace
 
 int main() {
@@ -894,6 +943,7 @@ int main() {
     test_litert_pyannote_segmentation(dir);
     test_litert_omnilingual_stt(dir);
     test_litert_diarization(dir);
+    test_litert_nemotron_streaming_stt(dir);
     test_voxcpm2_tokenizer(dir);
     test_litert_voxcpm2_load(dir);
     test_litert_voxcpm2_synthesize(dir);

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -13,9 +13,13 @@
 
 #include "speech_core/audio/resampler.h"
 #include "speech_core/interfaces.h"
+#include "speech_core/diarization/diarization_pipeline.h"
+#include "speech_core/models/litert_omnilingual_stt.h"
 #include "speech_core/models/litert_parakeet_stt.h"
+#include "speech_core/models/litert_pyannote_segmentation.h"
 #include "speech_core/models/litert_silero_vad.h"
 #include "speech_core/models/litert_voxcpm2_tts.h"
+#include "speech_core/models/litert_wespeaker_embedding.h"
 #include "speech_core/models/voxcpm2_tokenizer.h"
 #include "speech_core/vad/streaming_vad.h"
 #include "speech_core/voxcpm2_c.h"
@@ -28,6 +32,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -706,6 +711,166 @@ void test_voxcpm2_c_api(const std::string& dir) {
     std::printf("ok\n");
 }
 
+// ---------------------------------------------------------------------------
+// WeSpeaker embedding — embeds a tone, checks dim, L2-norm ≈ 1, finiteness,
+// and that identical input yields a self-similarity ≈ 1 (deterministic).
+// ---------------------------------------------------------------------------
+
+void test_litert_wespeaker_embedding(const std::string& dir) {
+    std::string model = dir + "/wespeaker-resnet34.tflite";
+    if (!file_exists(model)) {
+        std::printf("  [skip] wespeaker-resnet34.tflite not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_wespeaker_embedding ... ");
+
+    speech_core::LiteRTWeSpeakerEmbedding emb(model, /*hw_accel=*/false);
+    REQUIRE(emb.embedding_dim() == 256);
+    REQUIRE(emb.input_sample_rate() == 16000);
+
+    auto tone = generate_tone(16000, 220.0f, 2.0f, 0.4f);
+    auto v = emb.embed(tone.data(), tone.size(), 16000);
+    REQUIRE(static_cast<int>(v.size()) == emb.embedding_dim());
+
+    float norm = 0.0f;
+    for (float x : v) { REQUIRE(std::isfinite(x)); norm += x * x; }
+    norm = std::sqrt(norm);
+    REQUIRE(std::abs(norm - 1.0f) < 1e-2f);  // wrapper L2-normalises
+
+    auto v2 = emb.embed(tone.data(), tone.size(), 16000);
+    float self_sim = 0.0f;
+    for (size_t i = 0; i < v.size(); ++i) self_sim += v[i] * v2[i];
+    REQUIRE(self_sim > 0.99f);  // deterministic on identical input
+
+    std::printf("ok (dim=%zu norm=%.4f self_sim=%.4f)\n", v.size(), norm, self_sim);
+}
+
+// ---------------------------------------------------------------------------
+// Pyannote segmentation — runs ≥1 window over (padded) fixture audio and
+// checks window shape + that speaker_activity is finite and in [0, 1].
+// ---------------------------------------------------------------------------
+
+void test_litert_pyannote_segmentation(const std::string& dir) {
+    std::string model = dir + "/pyannote-segmentation.tflite";
+    if (!file_exists(model)) {
+        std::printf("  [skip] pyannote-segmentation.tflite not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_pyannote_segmentation ... ");
+
+    speech_core::LiteRTPyannoteSegmentation seg(model, /*hw_accel=*/false);
+    REQUIRE(seg.input_sample_rate() == 16000);
+    REQUIRE(seg.max_local_speakers() == 3);
+
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    std::vector<float> audio;
+    if (!wav.samples.empty()) {
+        audio = wav.sample_rate == 16000
+            ? wav.samples
+            : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                               wav.sample_rate, 16000);
+    }
+    if (audio.size() < static_cast<size_t>(16000) * 11) {
+        audio.resize(static_cast<size_t>(16000) * 11, 0.0f);  // guarantee ≥1 window
+    }
+
+    auto windows = seg.segment(audio.data(), audio.size(), 16000);
+    REQUIRE(!windows.empty());
+
+    const auto& w0 = windows.front();
+    REQUIRE(!w0.posteriors.empty());
+    REQUIRE(static_cast<int>(w0.speaker_activity.size()) % seg.max_local_speakers() == 0);
+    for (float a : w0.speaker_activity) {
+        REQUIRE(std::isfinite(a));
+        REQUIRE(a >= -0.01f && a <= 1.01f);
+    }
+
+    std::printf("ok (windows=%zu frames/win=%zu)\n",
+                windows.size(), w0.speaker_activity.size() / seg.max_local_speakers());
+}
+
+// ---------------------------------------------------------------------------
+// Omnilingual CTC STT (optional model) — transcribes the fixture; requires
+// non-empty text on real speech, otherwise just a clean run on silence.
+// ---------------------------------------------------------------------------
+
+void test_litert_omnilingual_stt(const std::string& dir) {
+    std::string model = dir + "/omnilingual-ctc-300m.tflite";
+    std::string tok   = dir + "/tokenizer.model";
+    if (!file_exists(model) || !file_exists(tok)) {
+        std::printf("  [skip] omnilingual files not in %s\n", dir.c_str());
+        return;
+    }
+    std::printf("  test_litert_omnilingual_stt ... ");
+
+    speech_core::LiteRTOmnilingualStt stt(model, tok, /*hw_accel=*/false);
+    REQUIRE(stt.input_sample_rate() == 16000);
+
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    bool real_speech = !wav.samples.empty();
+    std::vector<float> audio;
+    if (real_speech) {
+        audio = wav.sample_rate == 16000
+            ? wav.samples
+            : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                               wav.sample_rate, 16000);
+    } else {
+        audio.assign(16000, 0.0f);
+    }
+
+    auto result = stt.transcribe(audio.data(), audio.size(), 16000);
+    std::printf("text=\"%s\" ", result.text.c_str());
+    if (real_speech) REQUIRE(!result.text.empty());
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Diarization e2e — composes Pyannote (segmentation) + WeSpeaker (embedding)
+// through DiarizationPipeline on the fixture and checks the segments are
+// well-formed (speaker ≥ 0, end ≥ start, time-sorted) and non-empty.
+// ---------------------------------------------------------------------------
+
+void test_litert_diarization(const std::string& dir) {
+    std::string seg_model = dir + "/pyannote-segmentation.tflite";
+    std::string emb_model = dir + "/wespeaker-resnet34.tflite";
+    auto wav = load_wav_mono_pcm16(test_audio_path());
+    if (!file_exists(seg_model) || !file_exists(emb_model)) {
+        std::printf("  [skip] diarization needs pyannote + wespeaker in %s\n", dir.c_str());
+        return;
+    }
+    if (wav.samples.empty()) {
+        std::printf("  [skip] could not load %s\n", test_audio_path().c_str());
+        return;
+    }
+    std::printf("  test_litert_diarization ... ");
+
+    auto audio = wav.sample_rate == 16000
+        ? wav.samples
+        : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                           wav.sample_rate, 16000);
+    if (audio.size() < static_cast<size_t>(16000) * 11) {
+        audio.resize(static_cast<size_t>(16000) * 11, 0.0f);  // ≥1 segmentation window
+    }
+
+    speech_core::LiteRTPyannoteSegmentation seg(seg_model, /*hw_accel=*/false);
+    speech_core::LiteRTWeSpeakerEmbedding    emb(emb_model, /*hw_accel=*/false);
+    speech_core::DiarizationPipeline diar(seg, emb);
+
+    speech_core::DiarizerConfig cfg;  // defaults
+    auto segments = diar.diarize(audio.data(), audio.size(), 16000, cfg);
+    REQUIRE(!segments.empty());
+
+    std::set<int> speakers;
+    for (size_t i = 0; i < segments.size(); ++i) {
+        REQUIRE(segments[i].speaker >= 0);
+        REQUIRE(segments[i].end >= segments[i].start);
+        if (i > 0) REQUIRE(segments[i].start >= segments[i - 1].start);
+        speakers.insert(segments[i].speaker);
+    }
+
+    std::printf("ok (segments=%zu speakers=%zu)\n", segments.size(), speakers.size());
+}
+
 }  // namespace
 
 int main() {
@@ -725,6 +890,10 @@ int main() {
     test_litert_parakeet_real_speech(dir);
     test_litert_parakeet_streaming(dir);
     test_litert_vad_to_stt_pipeline(dir);
+    test_litert_wespeaker_embedding(dir);
+    test_litert_pyannote_segmentation(dir);
+    test_litert_omnilingual_stt(dir);
+    test_litert_diarization(dir);
     test_voxcpm2_tokenizer(dir);
     test_litert_voxcpm2_load(dir);
     test_litert_voxcpm2_synthesize(dir);


### PR DESCRIPTION
## Summary

Upstreams the server-side LiteRT inference wrappers that speech-cloud
maintained as a fork, making speech-core the single canonical home for the
LiteRT models. Part of converging the speech-cloud server onto speech-core.

- **New interfaces** (`interfaces.h`): `SegmentationInterface`,
  `EmbeddingInterface`, `DiarizerInterface` (+ `SegmentationWindow`,
  `DiarizedSegment`, `DiarizerConfig`).
- **New LiteRT wrappers**: `LiteRTWeSpeakerEmbedding`,
  `LiteRTPyannoteSegmentation`, `LiteRTOmnilingualStt`, and a backend-agnostic
  `DiarizationPipeline` (segmentation + embedding → constrained agglomerative
  clustering; pure C++, lives in the core lib).
- **`LiteRTParakeetStt`**: replaced the dynamic-shape decode with the
  production decode used against `soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8` —
  fixed `[1,128,500]` chunked encoder, `(h,c,enc,target)` decoder, TDT
  duration-0 multi-symbol handling, Slaney-mel preprocessing. Adds
  `enc_mel_frames` to `Config`; vocab size still auto-derives from
  `vocab.json`. Both decodes targeted the same export but only this one is
  verified in production.

## Test plan

- [x] `LITERT=ON` build links against libLiteRt (`speech_core_models_litert`, `test_litert_models`).
- [x] Default-config build + 9 unit tests green (the diarizer lives in the core lib).
- [x] e2e tests skip cleanly when model files are absent (PR CI unaffected).
- [ ] Nightly `litert-integration` runs the four new e2e tests against real models — the model-output parity gate.

**Requires** an `HF_TOKEN` repo secret with read access to the private
`soniqo/*` model repos for the nightly to fetch the diarization + omnilingual
models. Without it those fetches are skipped and the matching tests skip; the
core silero/parakeet lanes still run.