### PR TITLE
onnx: optional CUDA/TensorRT execution provider (gated) + export plan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Options
 option(SPEECH_CORE_BUILD_TESTS "Build tests" ON)
 option(SPEECH_CORE_WITH_ONNX "Build the speech_core_models target with ONNX Runtime reference implementations (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilter)" OFF)
+option(SPEECH_CORE_WITH_CUDA "Enable NVIDIA GPU execution providers (CUDA / TensorRT) in the ONNX engine. Requires SPEECH_CORE_WITH_ONNX=ON and ORT_DIR pointing at a GPU-enabled ONNX Runtime (onnxruntime-gpu). Selection is further gated at runtime by env SPEECH_CORE_ORT_PROVIDER and provider availability, with automatic CPU fallback." OFF)
 option(SPEECH_CORE_WITH_LITERT "Build the speech_core_models_litert target with LiteRT (TFLite) reference implementations (Silero VAD, Parakeet STT)" OFF)
 option(SPEECH_CORE_BUILD_EXAMPLES "Build examples/ (Linux C ABI lib, ALSA demo, CLI tools, integration tests). Requires SPEECH_CORE_WITH_ONNX=ON." OFF)
+
+if(SPEECH_CORE_WITH_CUDA AND NOT SPEECH_CORE_WITH_ONNX)
+    message(FATAL_ERROR "SPEECH_CORE_WITH_CUDA=ON requires SPEECH_CORE_WITH_ONNX=ON "
+                        "(CUDA / TensorRT EPs are ONNX-Runtime-only; LiteRT cannot use CUDA).")
+endif()
 
 # ---------------------------------------------------------------------------
 # speech_core — orchestration core (always built, no ML deps)
@@ -120,6 +126,21 @@ if(SPEECH_CORE_WITH_ONNX)
 
     # See speech_core above — same reason.
     set_target_properties(speech_core_models PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    # NVIDIA GPU execution providers (CUDA / TensorRT). Compile-time gate only:
+    # ORT_DIR must point at a GPU-enabled onnxruntime so the CUDA/TensorRT EP
+    # symbols are present in libonnxruntime at link/load time. The V2 provider
+    # API used in onnx_engine.h returns failure (not a crash) on a CPU-only
+    # runtime, so a binary built with this flag still runs on a CPU-only host;
+    # runtime selection is gated by env SPEECH_CORE_ORT_PROVIDER + provider
+    # availability. No extra link libs are needed — the EP lives inside the
+    # imported onnxruntime shared object (or its companion provider .so loaded
+    # at runtime by ORT itself).
+    if(SPEECH_CORE_WITH_CUDA)
+        target_compile_definitions(speech_core_models PUBLIC SPEECH_CORE_WITH_CUDA)
+        message(STATUS "speech_core_models: NVIDIA GPU EPs enabled (SPEECH_CORE_WITH_CUDA). "
+                       "Ensure ORT_DIR is a GPU-enabled ONNX Runtime.")
+    endif()
 
     target_link_libraries(speech_core_models PUBLIC speech_core onnxruntime)
 endif()

--- a/docs/onnx-cuda-export-plan.md
+++ b/docs/onnx-cuda-export-plan.md
@@ -1,0 +1,215 @@
+# CUDA inference for speech-core — ONNX export plan for the LiteRT-only models
+
+## Why this doc exists
+
+NVIDIA GPU inference in speech-core runs through the **ONNX Runtime backend**
+(`speech_core_models`, `SPEECH_CORE_WITH_ONNX`). The new `SPEECH_CORE_WITH_CUDA`
+build option wires `CUDAExecutionProvider` / `TensorrtExecutionProvider` into
+`onnx_engine.h`. LiteRT (`speech_core_models_litert`) **cannot** target CUDA —
+its runtime is edge-only (OpenCL / Metal / WebGPU / NNAPI). So "CUDA for all
+models" literally means **"every model needs an ONNX export"**.
+
+Four models already ship ONNX (Silero VAD, Parakeet STT, Kokoro TTS,
+DeepFilterNet3) and run on CUDA today via the engine change. The five below are
+LiteRT-only and need an ONNX export before they can use the GPU.
+
+All export tooling lives in the sibling **speech-models** repo under
+`models/{name}/export/`. The conversion engine is PyTorch → `torch.onnx.export`
+(opset 18 is the repo standard) → optional `onnxruntime.quantization.quantize_dynamic`
+INT8 on MatMul/Gemm. Two of the five already have a `convert_onnx.py`.
+
+## Ground truth found in speech-models
+
+| Model | ONNX script today? | Closest working ONNX precedent in-repo |
+|---|---|---|
+| Pyannote segmentation | **Yes** — `pyannote-vad/export/convert_onnx.py` (validated) | itself |
+| WeSpeaker embedding | **Yes** — `wespeaker/export/convert_onnx.py` (validated) | itself |
+| Nemotron streaming STT | No (LiteRT only) | `parakeet-asr/export/convert_onnx.py` — same RNN-T family |
+| Omnilingual STT | No (LiteRT only) | `wespeaker`/`pyannote` opset-18 single-graph pattern |
+| VoxCPM2 TTS | No (LiteRT only) | none — novel 4-graph AR loop |
+
+Key precedent: **Parakeet TDT already exports to ONNX** with a FastConformer
+encoder graph (INT8) + a *fused decoder-joint* graph carrying explicit LSTM
+state (`input_states_1/2` → `output_states_1/2`). Nemotron streaming is the same
+NeMo RNN-T machinery, so the encoder/decoder/joint → ONNX recipe is proven; only
+the cache tensors are new. Also notable: **Pyannote's LiteRT export already goes
+*through* ONNX** (`onnx2tf` + `sng4onnx` in its `pyproject.toml`), i.e. a valid
+Pyannote ONNX graph is produced as an intermediate today — the standalone
+`convert_onnx.py` just stops at that intermediate.
+
+---
+
+## Ranked path to "CUDA for all models"
+
+Ordered easiest/lowest-risk first. Rank = do-this-first ordering.
+
+### 1. WeSpeaker ResNet34-LM embedding — **TRIVIAL, already done**
+
+- **Export status:** `convert_onnx.py` exists and self-validates (runs a CPU
+  ORT session, checks embedding shape + L2 norm). Opset 18, single graph,
+  dynamic time axis (`dynamic_axes={"audio": {2: "samples"}}`).
+- **Architecture:** plain ResNet34 (Conv2d stack) → stats pooling → FC →
+  L2-normalized 256-d embedding. The one quirk — pyannote's fbank uses
+  `torch.vmap`, untraceable — is *already patched* (`_patch_wespeaker_vmap`
+  replaces it with a batch loop). Pure conv/matmul; no control flow, no state.
+- **ORT EP:** **TensorRT.** Static-ish CNN, fixed op set, the textbook TRT case;
+  builds one engine, runs fastest steady-state. CUDA EP is the safe fallback and
+  is plenty fast already. Dynamic length axis → set a TRT optimization profile
+  (min/opt/max samples) or pad to a fixed window.
+- **Effort:** ~0 (export) + ~0.5 day (verify on a real GPU, wire the C++
+  `WeSpeakerEmbedding` ONNX wrapper analogous to the existing Silero/Parakeet
+  ONNX wrappers). **Risk: very low.**
+
+### 2. Pyannote Segmentation 3.0 — **EASY, already done**
+
+- **Export status:** `convert_onnx.py` exists and self-validates (checks the
+  `[1,293,7]` powerset posteriors sum). Opset 18, single graph, **fully static**
+  shapes (fixed 10 s / 160000-sample window → 293 frames).
+- **Architecture:** SincNet/Conv frontend → **bi-LSTM** → linear → powerset
+  classifier. The LSTM is the only thing to watch: `torch.onnx.export` lowers
+  LSTM to the standard ONNX `LSTM` op, which both CUDA and TensorRT support, but
+  fixed-shape export sidesteps every dynamic-loop hazard.
+- **ORT EP:** **CUDA.** ONNX `LSTM` runs natively and reliably on the CUDA EP.
+  TensorRT *can* take LSTM but is fussier about recurrent ops; given the model is
+  tiny (~6 MB) the TRT engine-build cost isn't worth it — CUDA is the right call.
+  TensorRT remains available as a layered fallback (the engine appends CUDA
+  beneath TRT automatically).
+- **Effort:** ~0 (export) + ~0.5 day (GPU verify, C++ ONNX wrapper for the
+  segmentation model used by `diarization_pipeline`). **Risk: low** (LSTM-on-TRT
+  is the only thing to confirm; CUDA path is safe regardless).
+
+### 3. Omnilingual ASR CTC-300M — **EASY-MODERATE, new script needed**
+
+- **Export status:** LiteRT only, but the LiteRT path is the green light: the
+  `Wav2Vec2AsrTraceable` wrapper was explicitly written to be valid for **both
+  `torch.jit.trace` and `torch.export`**, rebuilding fairseq2's `BatchLayout`
+  from the tensor shape inside `forward`. `torch.onnx.export` (the dynamo=False
+  TorchScript path the repo uses everywhere) is exactly that trace path, so the
+  same wrapper drops straight into a new `convert_onnx.py`.
+- **Architecture:** Wav2Vec2 CNN frontend → Transformer encoder → CTC linear
+  head. Single forward pass, no autoregression, no recurrent state — the
+  simplest possible "audio in → logits out" shape. Output `T = ceil(S/320)`.
+- **The one quirk:** fairseq2's `BatchLayout` object. Already solved by the
+  traceable wrapper. Watch for fairseq2 custom ops that lack ONNX symbolics —
+  if any appear, they're isolated in the frontend and can be replaced with
+  stock ops (same class of fix as the WeSpeaker vmap patch).
+- **ORT EP:** **TensorRT** for the encoder (Transformer + Conv, static or
+  profiled dynamic length → ideal TRT workload, big steady-state win at 300M
+  params). CUDA fallback fine. Quantize INT8 (MatMul/Gemm only) as the LiteRT
+  path already does.
+- **Effort:** ~1–1.5 days (clone `convert_litert.py`, swap
+  `litert_torch.convert` → `torch.onnx.export` with the same wrapper + dynamic
+  length axis, add a CTC-decode validation like Parakeet's `test_onnx.py`).
+  **Risk: low-moderate** (only unknown is a stray fairseq2 op without a
+  symbolic; the traceable wrapper makes this unlikely).
+
+### 4. Nemotron Speech Streaming 0.6B (RNN-T) — **MODERATE, new script, strong precedent**
+
+- **Export status:** LiteRT only, but **Parakeet TDT already proves the recipe.**
+  Nemotron's `convert.py` wrappers (`StreamingEncoderWrapper`, `DecoderWrapper`,
+  `JointWrapper`) already produce clean static-shaped tensor I/O and already pass
+  `torch.jit.trace` (the CoreML path). `torch.onnx.export` consumes the same
+  traced modules.
+- **Architecture:** 3 graphs — cache-aware FastConformer encoder, RNN-T LSTM
+  prediction net, RNN-T joint. The streaming-specific complexity is the
+  **explicit cache I/O**: `cache_last_channel` `[24,1,70,H]`, `cache_last_time`
+  `[24,1,H,conv_cache]`, `cache_last_channel_len`, plus a rolling mel `pre_cache`.
+  These become additional ONNX graph inputs *and* outputs — mechanically the
+  same trick Parakeet's decoder-joint uses for `input_states_*`/`output_states_*`,
+  just more tensors. The C++ worker already owns this state (it does for LiteRT),
+  so the wire contract carries over.
+- **Per-graph EP split (mirror the quantization split):**
+  - **Encoder → CUDA** (not TensorRT initially). Cache-aware attention with
+    per-step changing cache shapes + the `cache_aware_stream_step` gather/scatter
+    is exactly what makes TRT engine-building painful (TRT wants stable shapes;
+    streaming caches fight that). CUDA EP runs it correctly out of the box. INT8
+    weight quantization as in the LiteRT export.
+  - **Decoder (LSTM) → CUDA.** ONNX `LSTM`, keep **FP32** (the LiteRT/CoreML
+    notes are explicit: the RNN-T LSTM hidden state drifts under INT8, corrupting
+    logits — same lesson as Parakeet). CUDA, not TRT, for the recurrent op.
+  - **Joint → CUDA or TensorRT.** Tiny FP32 MatMul; either works. Not worth a
+    separate TRT engine.
+  - Revisit TensorRT for the encoder *after* CUDA works, by fixing the chunk
+    shape (the 80 ms config is single-frame and most static) and adding a TRT
+    optimization profile. Treat as a perf follow-up, not a blocker.
+- **Effort:** ~2–3 days (new `convert_onnx.py` reusing the existing wrappers;
+  the work is declaring ~6 encoder inputs/outputs with correct `dynamic_axes`,
+  plus a streaming-decode validation harness like the existing
+  `_smoke_litert.py` / `_realtime_replay.py`). **Risk: moderate** — RNN-T export
+  itself is proven by Parakeet; the risk is purely getting the cache-tensor
+  input/output names + dynamic axes right and confirming the encoder's
+  gather/scatter lowers cleanly to ONNX (it does for TorchScript→CoreML, so the
+  ops exist).
+
+### 5. VoxCPM2 TTS — **HARD, new multi-graph script, real unknowns**
+
+- **Export status:** LiteRT only, and the **most complex model by far.** Not a
+  single graph: the runtime is `text/audio prefill → repeated token/acoustic
+  step → AudioVAE decode`, exported as **4 graphs** (`text_prefill`,
+  `token_step`, `audio_encoder`, `audio_decoder`) plus a manifest the C++ worker
+  uses to wire them. ONNX export must reproduce this same 4-graph split — ONNX is
+  a static dataflow graph and likewise cannot represent the AR loop; the loop
+  stays in C++.
+- **Architecture quirks, per graph:**
+  - **`text_prefill`** — MiniCPM base-LM + residual-LM over the full context;
+    emits packed KV caches `[2, L, B, KVH, T, D]`. **This is the >2 GB graph.**
+    FP32 it was ~10 GB / ~13 GiB RAM; the LiteRT export only fit by INT8-quantizing
+    it. **ONNX has a hard 2 GB protobuf limit** → this graph *must* be exported
+    with `torch.onnx.export(..., use_external_data_format=True)` so weights spill
+    to a sidecar `.onnx_data` file. This is the single biggest gotcha. INT8 it as
+    well (the recipe matches: weight-only INT8 / MatMul-Gemm).
+  - **`token_step`** — one acoustic step with **explicit in/out KV cache tensors**
+    and a hand-rolled functional attention (the converter already rewrote the
+    upstream `StaticKVCache` `copy_`/in-place path into a functional
+    write-mask + gather, precisely *because* the graph compilers reject in-place
+    cache mutation). That same functional rewrite is what makes it ONNX-able —
+    but it also contains `scaled_dot_product_attention` with `enable_gqa=True`,
+    a CFM Euler solver (`solve_euler` with `torch.linspace`/`cos`), and rotary
+    embeddings. SDPA + GQA need opset 18+ and a recent exporter; the Euler solve
+    is plain math and should trace. **Marked "experimental" even for LiteRT** —
+    expect ONNX to surface the same edges.
+  - **`audio_encoder` / `audio_decoder`** (AudioVAE) — Conv stacks, kept **FP32**
+    in LiteRT because the INT8 recipe rejected Conv ops. For ONNX, dynamic INT8
+    on MatMul/Gemm-only would skip Conv anyway, so keep them FP32. The decoder
+    has SR-conditioned conv layers (`sr_cond_model`) — straightforward conv,
+    should export.
+- **ORT EP:**
+  - `text_prefill` + `token_step` → **CUDA.** Transformer-with-KV-cache and SDPA
+    are well-supported on the CUDA EP; TensorRT struggles with the
+    external-data >2 GB graph and the per-step dynamic cache, so do **not** start
+    with TRT here. INT8 weights, FP32 activations.
+  - `audio_encoder` / `audio_decoder` → **TensorRT** candidate (pure conv, FP32,
+    static-friendly) once CUDA end-to-end works; CUDA fallback fine.
+- **Effort:** ~5–8 days. Sub-tasks: (a) external-data ONNX export for the >2 GB
+  prefill graph and confirm ORT loads the sidecar on GPU; (b) get `token_step`'s
+  functional-cache + SDPA-GQA + Euler-solver graph through the exporter (the
+  highest-risk item — may need an opset bump, an SDPA decomposition, or an
+  exporter patch); (c) AudioVAE encoder/decoder graphs; (d) a 4-graph
+  round-trip validation harness analogous to `smoke_litert_roundtrip.py`.
+  **Risk: high** — the >2 GB external-data path and the experimental
+  functional-KV-cache + GQA-SDPA lowering are both genuine unknowns until run on
+  a GPU box.
+
+---
+
+## Summary table
+
+| Rank | Model | ONNX script | Architecture | Primary EP | Effort | Risk |
+|---|---|---|---|---|---|---|
+| 1 | WeSpeaker ResNet34 | exists, validated | ResNet CNN + pool | **TensorRT** | ~0.5 d | very low |
+| 2 | Pyannote Seg 3.0 | exists, validated | Conv + bi-LSTM | **CUDA** | ~0.5 d | low |
+| 3 | Omnilingual CTC-300M | new (wrapper reusable) | Wav2Vec2 + CTC | **TensorRT** | ~1–1.5 d | low-mod |
+| 4 | Nemotron streaming | new (Parakeet precedent) | RNN-T + cache I/O | **CUDA** (per-graph) | ~2–3 d | moderate |
+| 5 | VoxCPM2 | new (4-graph, novel) | AR LM + AudioVAE | **CUDA** (per-graph) | ~5–8 d | high |
+
+**Recommended sequence:** ship 1+2 immediately (export already exists — only GPU
+verification + C++ ONNX wrappers remain), do 3 next (one reusable wrapper), then
+4 (lean on Parakeet's RNN-T ONNX recipe), and treat 5 as its own mini-project
+gated on the external-data + GQA-SDPA spikes.
+
+**Cross-cutting EP rule of thumb observed across all five:** TensorRT for static,
+conv-heavy, single-pass graphs (WeSpeaker, Omnilingual encoder, AudioVAE);
+CUDA for anything with recurrent state, per-step dynamic KV caches, or >2 GB
+external-data (Pyannote LSTM, every RNN-T/LM graph). The engine layers CUDA
+beneath TensorRT automatically, and falls back to CPU if neither EP is in the
+linked ORT build — so a wrong EP guess degrades, never crashes.

--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -234,9 +234,19 @@ private:
             OrtStatus* cs = api_->CreateTensorRTProviderOptions(&trt);
             if (cs == nullptr && trt != nullptr) {
                 // Cache built TensorRT engines on disk so the (expensive) engine
-                // build only happens on first run, not every cold start.
+                // build only happens on first run, not every cold start. Pick the
+                // OS temp dir from env (TMPDIR on Unix, TEMP on Windows) so the
+                // path is valid on both platforms; fall back to a sane default.
+                const char* tmp = std::getenv("TMPDIR");
+                if (tmp == nullptr) tmp = std::getenv("TEMP");
+                if (tmp == nullptr) tmp = std::getenv("TMP");
+#ifdef _WIN32
+                std::string cache = std::string(tmp ? tmp : ".") + "\\speech_core_trt_cache";
+#else
+                std::string cache = std::string(tmp ? tmp : "/tmp") + "/speech_core_trt_cache";
+#endif
                 const char* keys[] = {"trt_engine_cache_enable", "trt_engine_cache_path"};
-                const char* vals[] = {"1", "/tmp/speech_core_trt_cache"};
+                const char* vals[] = {"1", cache.c_str()};
                 OrtStatus* us = api_->UpdateTensorRTProviderOptions(trt, keys, vals, 2);
                 if (us != nullptr) api_->ReleaseStatus(us);  // non-fatal: keep defaults
                 OrtStatus* as = api_->SessionOptionsAppendExecutionProvider_TensorRT_V2(opts, trt);

--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <onnxruntime_c_api.h>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 
@@ -24,6 +27,17 @@ inline void ort_check(const OrtApi* api, OrtStatus* status) {
     }
 }
 
+/// NVIDIA GPU execution providers, selected on desktop/server (Linux/Windows)
+/// builds. Has no effect on Android (which uses NNAPI/QNN) or on a CPU-only ORT
+/// runtime — both fall back to CPU at runtime. CUDA is the general-purpose GPU
+/// path; TensorRT additionally fuses + builds an optimized engine (slower first
+/// inference, faster steady-state), with CUDA + CPU layered beneath it.
+enum class OrtGpuProvider {
+    None,       ///< CPU (or Android NNAPI/QNN). Default.
+    Cuda,       ///< CUDAExecutionProvider.
+    TensorRT,   ///< TensorrtExecutionProvider (with CUDA + CPU fallback beneath).
+};
+
 /// Singleton ONNX Runtime environment shared across all models.
 class OnnxEngine {
 public:
@@ -39,13 +53,32 @@ public:
     bool had_nnapi_fallback() const { return nnapi_fallback_; }
     const std::string& nnapi_fallback_reason() const { return nnapi_fallback_reason_; }
 
+    /// The GPU provider actually in use after the resolve step (build option +
+    /// env var + runtime availability). OrtGpuProvider::None when running on
+    /// CPU/NNAPI/QNN. Lets callers log / emit telemetry for the effective backend.
+    OrtGpuProvider gpu_provider() const { return gpu_provider_; }
+
+    /// True if a model requested a GPU EP but session creation fell back to CPU.
+    bool had_gpu_fallback() const { return gpu_fallback_; }
+    const std::string& gpu_fallback_reason() const { return gpu_fallback_reason_; }
+
     OrtSession* load(const std::string& path, bool nnapi = true) {
         OrtSessionOptions* opts = nullptr;
         ort_check(api_, api_->CreateSessionOptions(&opts));
         api_->SetSessionGraphOptimizationLevel(opts, ORT_ENABLE_ALL);
         api_->SetIntraOpNumThreads(opts, 2);
 
-        if (nnapi) {
+        // A GPU EP (CUDA / TensorRT), when resolved on a desktop/server build,
+        // takes priority over NNAPI/QNN. The `nnapi` argument is the model
+        // wrapper's "use hardware acceleration" flag — when it is false (e.g.
+        // Parakeet's FP32 decoder-joint, which must stay numerically exact) we
+        // honour it and keep the session on CPU, GPU present or not.
+        bool gpu_attempted = false;
+        if (nnapi && gpu_provider_ != OrtGpuProvider::None) {
+            gpu_attempted = try_append_gpu(opts, path);
+        }
+
+        if (nnapi && !gpu_attempted) {
             LOGI("Loading model with hardware acceleration: %s",
                  path.substr(path.find_last_of('/') + 1).c_str());
 #ifdef __ANDROID__
@@ -68,12 +101,17 @@ public:
         OrtSession* session = nullptr;
         OrtStatus* create_status = api_->CreateSession(env_, path.c_str(), opts, &session);
 
-        // If session creation fails with NNAPI, retry CPU-only
+        // If session creation fails with a hardware EP (NNAPI/QNN/GPU), retry CPU-only.
         if (create_status != nullptr && nnapi) {
             const char* msg = api_->GetErrorMessage(create_status);
-            LOGI("NNAPI session failed (%s), retrying CPU-only", msg);
-            nnapi_fallback_ = true;
-            nnapi_fallback_reason_ = msg;
+            LOGI("Hardware-EP session failed (%s), retrying CPU-only", msg);
+            if (gpu_attempted) {
+                gpu_fallback_ = true;
+                gpu_fallback_reason_ = msg;
+            } else {
+                nnapi_fallback_ = true;
+                nnapi_fallback_reason_ = msg;
+            }
             api_->ReleaseStatus(create_status);
             api_->ReleaseSessionOptions(opts);
 
@@ -109,14 +147,143 @@ private:
         ort_check(api_, api_->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "speech", &env_));
         ort_check(api_, api_->CreateCpuMemoryInfo(
             OrtArenaAllocator, OrtMemTypeDefault, &mem_));
+        gpu_provider_ = resolve_gpu_provider();
     }
 
     OnnxEngine(const OnnxEngine&) = delete;
     OnnxEngine& operator=(const OnnxEngine&) = delete;
+
+    /// Resolve which (if any) GPU EP to use. Three gates, all must pass:
+    ///   1. Build: SPEECH_CORE_WITH_CUDA must be defined (the CMake option that
+    ///      links a CUDA-enabled ORT). Without it we never touch GPU symbols.
+    ///   2. Request: env SPEECH_CORE_ORT_PROVIDER in {cuda,tensorrt,trt,gpu}.
+    ///      "cpu"/"none" → CPU. Unset defaults to CUDA *because* the build is
+    ///      already GPU-capable; availability (gate 3) still protects the
+    ///      no-GPU-present case, so the same binary degrades to CPU cleanly.
+    ///   3. Availability: the requested EP is listed by GetAvailableProviders()
+    ///      — i.e. the linked libonnxruntime was actually built with it. A
+    ///      CPU-only runtime reports neither, so we degrade to CPU silently.
+    /// On Android the whole thing is compiled out (NNAPI/QNN own acceleration).
+    OrtGpuProvider resolve_gpu_provider() {
+#if defined(SPEECH_CORE_WITH_CUDA) && !defined(__ANDROID__)
+        OrtGpuProvider requested = OrtGpuProvider::Cuda;  // default on a GPU build
+        const char* env = std::getenv("SPEECH_CORE_ORT_PROVIDER");
+        if (env != nullptr && env[0] != '\0') {
+            std::string v(env);
+            for (auto& ch : v) ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+            if (v == "cpu" || v == "none") return OrtGpuProvider::None;
+            else if (v == "tensorrt" || v == "trt") requested = OrtGpuProvider::TensorRT;
+            else if (v == "cuda" || v == "gpu") requested = OrtGpuProvider::Cuda;
+            else {
+                LOGI("Unknown SPEECH_CORE_ORT_PROVIDER='%s', using CPU", env);
+                return OrtGpuProvider::None;
+            }
+        }
+
+        const bool cuda_avail = provider_available("CUDAExecutionProvider");
+        const bool trt_avail = provider_available("TensorrtExecutionProvider");
+
+        if (requested == OrtGpuProvider::TensorRT) {
+            if (trt_avail) { LOGI("ORT GPU provider: TensorRT"); return OrtGpuProvider::TensorRT; }
+            if (cuda_avail) { LOGI("TensorRT EP not built into ORT, using CUDA"); return OrtGpuProvider::Cuda; }
+            LOGI("No GPU EP available in this ORT build, using CPU");
+            return OrtGpuProvider::None;
+        }
+        if (cuda_avail) { LOGI("ORT GPU provider: CUDA"); return OrtGpuProvider::Cuda; }
+        LOGI("CUDA EP not available in this ORT build, using CPU");
+        return OrtGpuProvider::None;
+#else
+        return OrtGpuProvider::None;
+#endif
+    }
+
+    /// Query GetAvailableProviders() for an EP name. Works on every ORT build
+    /// (the API itself is always present); a CPU-only runtime simply won't list
+    /// CUDA/TensorRT, which is how the CPU-fallback path stays automatic.
+    bool provider_available(const char* name) {
+        char** providers = nullptr;
+        int count = 0;
+        OrtStatus* s = api_->GetAvailableProviders(&providers, &count);
+        if (s != nullptr) {
+            api_->ReleaseStatus(s);
+            return false;
+        }
+        bool found = false;
+        for (int i = 0; i < count; ++i) {
+            if (std::strcmp(providers[i], name) == 0) { found = true; break; }
+        }
+        OrtStatus* rs = api_->ReleaseAvailableProviders(providers, count);
+        if (rs != nullptr) api_->ReleaseStatus(rs);  // documented to never fail
+        return found;
+    }
+
+    /// Append the resolved GPU EP to `opts`. Returns true if a GPU EP was
+    /// appended (so the caller skips NNAPI/QNN). A single failure here is
+    /// non-fatal: CreateSession's own fallback in load() re-tries CPU-only.
+    /// We use the V2 opaque-options API (CreateCUDAProviderOptions /
+    /// SessionOptionsAppendExecutionProvider_CUDA_V2), which the header
+    /// documents as *returning failure* on a non-CUDA-enabled build rather
+    /// than crashing — the basis of the silent CPU fallback.
+    bool try_append_gpu(OrtSessionOptions* opts, const std::string& path) {
+#if defined(SPEECH_CORE_WITH_CUDA) && !defined(__ANDROID__)
+        const char* fname = path.c_str() + path.find_last_of('/') + 1;
+        bool appended = false;
+
+        if (gpu_provider_ == OrtGpuProvider::TensorRT) {
+            OrtTensorRTProviderOptionsV2* trt = nullptr;
+            OrtStatus* cs = api_->CreateTensorRTProviderOptions(&trt);
+            if (cs == nullptr && trt != nullptr) {
+                // Cache built TensorRT engines on disk so the (expensive) engine
+                // build only happens on first run, not every cold start.
+                const char* keys[] = {"trt_engine_cache_enable", "trt_engine_cache_path"};
+                const char* vals[] = {"1", "/tmp/speech_core_trt_cache"};
+                OrtStatus* us = api_->UpdateTensorRTProviderOptions(trt, keys, vals, 2);
+                if (us != nullptr) api_->ReleaseStatus(us);  // non-fatal: keep defaults
+                OrtStatus* as = api_->SessionOptionsAppendExecutionProvider_TensorRT_V2(opts, trt);
+                api_->ReleaseTensorRTProviderOptions(trt);
+                if (as != nullptr) {
+                    LOGI("TensorRT EP append failed (%s), trying CUDA beneath",
+                         api_->GetErrorMessage(as));
+                    api_->ReleaseStatus(as);
+                } else {
+                    LOGI("Appended TensorRT EP: %s", fname);
+                    appended = true;
+                }
+            } else if (cs != nullptr) {
+                api_->ReleaseStatus(cs);
+            }
+            // Layer CUDA beneath TensorRT so any op TensorRT can't take still
+            // runs on GPU rather than dropping all the way to CPU.
+        }
+
+        OrtCUDAProviderOptionsV2* cuda = nullptr;
+        OrtStatus* cs = api_->CreateCUDAProviderOptions(&cuda);
+        if (cs != nullptr) {
+            // Build is not actually CUDA-enabled (or OOM) — bail.
+            api_->ReleaseStatus(cs);
+            return appended;  // TRT may already have appended above
+        }
+        OrtStatus* as = api_->SessionOptionsAppendExecutionProvider_CUDA_V2(opts, cuda);
+        api_->ReleaseCUDAProviderOptions(cuda);
+        if (as != nullptr) {
+            LOGI("CUDA EP append failed (%s)", api_->GetErrorMessage(as));
+            api_->ReleaseStatus(as);
+            return appended;
+        }
+        LOGI("Appended CUDA EP: %s", fname);
+        return true;
+#else
+        (void)opts; (void)path;
+        return false;
+#endif
+    }
 
     const OrtApi* api_ = nullptr;
     OrtEnv* env_ = nullptr;
     OrtMemoryInfo* mem_ = nullptr;
     bool nnapi_fallback_ = false;
     std::string nnapi_fallback_reason_;
+    OrtGpuProvider gpu_provider_ = OrtGpuProvider::None;
+    bool gpu_fallback_ = false;
+    std::string gpu_fallback_reason_;
 };


### PR DESCRIPTION
## Summary (DRAFT — GPU execution not yet validated)
Enables NVIDIA GPU inference on the ONNX Runtime backend, **gated off by default**. LiteRT can't do CUDA (edge runtime), so the ONNX backend is the CUDA path.

- `onnx_engine`: `OrtGpuProvider {None, Cuda, TensorRT}`, resolved by **build flag** `SPEECH_CORE_WITH_CUDA` + **env** `SPEECH_CORE_ORT_PROVIDER` + a **runtime** `GetAvailableProviders()` probe; V2 opaque-options API; TensorRT engine caching; CPU fallback on any EP failure. `gpu_provider()` / `had_gpu_fallback()` for telemetry.
- CPU build and Android NNAPI/QNN selection are **byte-for-byte unchanged** (the GPU block is `#if defined(SPEECH_CORE_WITH_CUDA) && !defined(__ANDROID__)`).
- `docs/onnx-cuda-export-plan.md`: ranked path to "CUDA for all models" — WeSpeaker + Pyannote already have ONNX export scripts (near-free); Nemotron RNN-T is the same arch Parakeet already exports; VoxCPM2 (4-graph AR, >2 GB graph) is the hard one. New ONNX repos should be born under **`soniqo/*-ONNX`** per the org decision.

## Why draft
- Compiled with `SPEECH_CORE_WITH_CUDA=ON` against ORT 1.26.0 by the author; resolver + CPU fallback runtime-tested on CPU.
- **GPU execution is unverified** — needs an NVIDIA box / a CUDA CI lane. Gated off by default, so merging changes no current behavior, but don't flip it on in prod until validated on real hardware.

## Test plan
- [x] CUDA=ON build links against ORT; CUDA=OFF unchanged; CMake guard rejects CUDA-without-ONNX.
- [x] Provider resolver degrades to CPU on a non-GPU host (all env values).
- [ ] Real CUDA / TensorRT execution on an NVIDIA box.