### PR TITLE
nemotron-streaming: ORT path + 320 ms LiteRT (RTF 0.80x -> 3.12x via static-selective INT8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/kokoro/kokoro_multilingual.cpp
         src/models/deepfilter/deepfilter.cpp
         src/models/voxcpm2/onnx_voxcpm2_tts.cpp
+        src/models/nemotron/onnx_nemotron_streaming_stt.cpp
     )
     # VoxCPM2 tokenizer is pure C++17 and shared with the LiteRT target. To
     # avoid duplicate symbols when a downstream binary links both targets, we
@@ -267,6 +268,12 @@ if(SPEECH_CORE_BUILD_TESTS)
         if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/bench_ort_models.cpp)
             add_executable(bench_ort_models tests/bench_ort_models.cpp)
             target_link_libraries(bench_ort_models PRIVATE speech_core_models)
+            if(SPEECH_CORE_WITH_LITERT)
+                # Tokenizer symbol lives in speech_core_models_litert when both
+                # backends are enabled (see the conditional above the sources
+                # list) — link it so OnnxVoxCPM2Tts's references resolve.
+                target_link_libraries(bench_ort_models PRIVATE speech_core_models_litert)
+            endif()
             target_compile_definitions(bench_ort_models PRIVATE
                 SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
         endif()

--- a/include/speech_core/models/litert_nemotron_streaming_stt.h
+++ b/include/speech_core/models/litert_nemotron_streaming_stt.h
@@ -89,7 +89,9 @@ private:
     LiteRtCompiledModel jnt_compiled_ = nullptr;
 
     Config cfg_;
-    int    enc_t_out_ = 2;  // encoder output frames per window (read at load)
+    int    enc_t_out_     = 2;  // encoder output frames per window (read at load)
+    int    output_frames_ = 1;  // committed frames per window (T_out minus lookahead;
+                                // overridden from config.json's streaming.outputFrames).
     std::vector<std::string> vocab_;
 
     // ---- per-stream state ----

--- a/include/speech_core/models/litert_nemotron_streaming_stt.h
+++ b/include/speech_core/models/litert_nemotron_streaming_stt.h
@@ -92,6 +92,16 @@ private:
     int    enc_t_out_     = 2;  // encoder output frames per window (read at load)
     int    output_frames_ = 1;  // committed frames per window (T_out minus lookahead;
                                 // overridden from config.json's streaming.outputFrames).
+    // Encoder signature input position (0..5) per semantic role. The published
+    // 80 ms bundle has identity mapping (args_N at position N), but bundles
+    // re-exported via the agent's WSL patched-NeMo path have a jumbled
+    // tensor-id order (args_5 at pos 0, etc.). Built at load time by parsing
+    // the "serving_default_args_N" suffix from LiteRtGetSignatureInputName.
+    // Default to identity; only updated if name parsing succeeds.
+    int    enc_in_sig_pos_[6]  = {0, 1, 2, 3, 4, 5};
+    int    enc_out_sig_pos_[6] = {0, 1, 2, 3, 4, 5};
+    int    dec_in_sig_pos_[3]  = {0, 1, 2};
+    int    dec_out_sig_pos_[3] = {0, 1, 2};
     std::vector<std::string> vocab_;
 
     // ---- per-stream state ----

--- a/include/speech_core/models/onnx_nemotron_streaming_stt.h
+++ b/include/speech_core/models/onnx_nemotron_streaming_stt.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Nemotron Speech Streaming 0.6B — cache-aware streaming RNN-T via ORT.
+///
+/// Wire-level identical to LiteRTNemotronStreamingStt: same three graphs,
+/// same I/O contract, same streaming state machine — only the runtime
+/// differs (ONNX Runtime instead of LiteRT). On a desktop/server build the
+/// CUDA EP takes over for the encoder (heaviest of the three) while the
+/// decoder LSTM + joint stay CPU (small tensors, dispatch overhead beats
+/// kernel time — same anti-pattern as Parakeet's decoder_joint).
+///
+/// Three graphs (soniqo/Nemotron-Speech-Streaming-ONNX):
+///   encoder  in:  audio_signal[1,bins,frames], audio_length[1],
+///                 pre_cache[1,bins,pre], cache_last_channel[L,1,attn,H],
+///                 cache_last_time[L,1,H,conv], cache_last_channel_len[1]
+///            out: encoded_output[1,T_out,H], encoded_length[1],
+///                 new_pre_cache, new_cache_last_channel,
+///                 new_cache_last_time, new_cache_last_channel_len
+///   decoder  in:  token[1,1] i64, h[L,1,Hd], c[L,1,Hd]
+///            out: decoder_output[1,1,Hd], h_out, c_out
+///   joint    in:  encoder_output[1,1,H], decoder_output[1,1,Hd]
+///            out: logits[1,1,vocab+1]
+///
+/// One instance == one stream. Not thread-safe.
+class OnnxNemotronStreamingStt : public STTInterface {
+public:
+    struct Config {
+        int sample_rate       = 16000;
+        int mel_bins          = 128;
+        int n_fft             = 512;
+        int hop_length        = 160;
+        int win_length        = 400;
+        int encoder_layers    = 24;
+        int encoder_hidden    = 1024;
+        int decoder_layers    = 2;
+        int decoder_hidden    = 640;
+        int vocab_size        = 1024;  // refined from vocab.json
+        int blank_id          = 1024;  // = vocab_size
+        int pre_cache_size    = 16;
+        int actual_mel_frames = 9;     // 80 ms window
+        int attn_left_context = 70;    // cache_last_channel time dim
+        int conv_cache_size   = 8;     // cache_last_time conv dim (kernel-1)
+        int max_symbols       = 8;     // expansions per encoder frame
+    };
+
+    OnnxNemotronStreamingStt(const std::string& encoder_path,
+                             const std::string& decoder_path,
+                             const std::string& joint_path,
+                             const std::string& vocab_path,
+                             bool hw_accel = true);
+    OnnxNemotronStreamingStt(const std::string& encoder_path,
+                             const std::string& decoder_path,
+                             const std::string& joint_path,
+                             const std::string& vocab_path,
+                             const Config& config,
+                             bool hw_accel = true);
+    ~OnnxNemotronStreamingStt() override;
+
+    // --- STTInterface (batch convenience = begin/push/end) ---
+    TranscriptionResult transcribe(const float* audio, size_t length, int sample_rate) override;
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+
+    // --- STTInterface (streaming — the real path) ---
+    bool supports_streaming() const override { return true; }
+    void begin_stream(int sample_rate) override;
+    PartialResult push_chunk(const float* audio, size_t length) override;
+    void flush_stream() override;
+    TranscriptionResult end_stream() override;
+    void cancel_stream() override;
+
+private:
+    bool load_vocab(const std::string& path);
+    void reset_stream_state();
+    void run_decoder_step(int64_t token_id);
+    std::string run_window();
+    std::string token_to_text(int id) const;
+    int chunk_samples() const { return (cfg_.actual_mel_frames - 1) * cfg_.hop_length; }
+
+    const OrtApi* api_ = nullptr;
+    OrtSession*   enc_ = nullptr;
+    OrtSession*   dec_ = nullptr;
+    OrtSession*   jnt_ = nullptr;
+
+    // Cached I/O name vectors (introspected at load) — same idiom as
+    // OnnxVoxCPM2Tts::IoNames.
+    struct IoNames {
+        std::vector<std::string>  in_names_str;
+        std::vector<std::string>  out_names_str;
+        std::vector<const char*>  in_names;
+        std::vector<const char*>  out_names;
+    };
+    void query_io_names(OrtSession* session, IoNames& names);
+    IoNames enc_io_;
+    IoNames dec_io_;
+    IoNames jnt_io_;
+
+    Config cfg_;
+    int    enc_t_out_ = 2;  // encoder output frames per window (read at load)
+    std::vector<std::string> vocab_;
+
+    // ---- per-stream state ----
+    std::vector<float> pending_;             // accumulated PCM float32
+    std::vector<float> pre_cache_;           // [1, bins, pre_cache_size]
+    std::vector<float> cache_last_channel_;  // [L, 1, attn, H]
+    std::vector<float> cache_last_time_;     // [L, 1, H, conv]
+    int64_t            cache_last_channel_len_ = 0;
+    std::vector<float> dec_h_, dec_c_;       // [L, 1, Hd]
+    std::vector<float> dec_hidden_;          // [Hd] — joint input
+    std::string        accumulated_text_;
+    bool               stream_init_ = false;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_nemotron_streaming_stt.h
+++ b/include/speech_core/models/onnx_nemotron_streaming_stt.h
@@ -105,7 +105,9 @@ private:
     IoNames jnt_io_;
 
     Config cfg_;
-    int    enc_t_out_ = 2;  // encoder output frames per window (read at load)
+    int    enc_t_out_     = 2;  // encoder output frames per window (read at load)
+    int    output_frames_ = 1;  // committed frames per window (T_out minus lookahead;
+                                // overridden from config.json's streaming.outputFrames).
     std::vector<std::string> vocab_;
 
     // ---- per-stream state ----

--- a/scripts/nemo_reference_wer.py
+++ b/scripts/nemo_reference_wer.py
@@ -1,0 +1,100 @@
+"""Run NeMo PyTorch FP32 reference on a corpus manifest, emit the same CSV
+format as the C++ bench corpus modes:
+  uid,nemo-fp32,audio_s,wall_ms,transcript
+
+This is the GOLD-STANDARD reference. Compare ORT/LiteRT against it to
+quantify (a) export fidelity (ORT vs NeMo) and (b) quantization cost
+(LiteRT INT8 vs NeMo).
+
+Uses NeMo's model.transcribe() — offline inference path; the cache-aware
+streaming encoder still runs, but with the full sequence in one shot
+(no chunk boundaries discarded), which is the model's quality ceiling.
+"""
+
+import argparse
+import csv
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+# Silence NeMo noise — same env knobs the convert scripts use.
+warnings.filterwarnings("ignore")
+os.environ.setdefault("NEMO_LOG_LEVEL", "ERROR")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument(
+        "--nemo-id", default="nvidia/nemotron-speech-streaming-en-0.6b",
+        help="HuggingFace model id NeMo restores from. Cache lives in "
+             "$HF_HOME/hub/models--nvidia--... and is reused across runs.",
+    )
+    args = ap.parse_args()
+
+    import torch
+    import soundfile as sf
+    import nemo.collections.asr as nemo_asr
+
+    print(f"Loading NeMo {args.nemo_id} ...", file=sys.stderr, flush=True)
+    t_load = time.perf_counter()
+    model = nemo_asr.models.ASRModel.from_pretrained(args.nemo_id)
+    model.eval()
+    if torch.cuda.is_available():
+        model = model.cuda()
+        device = "cuda"
+    else:
+        device = "cpu"
+    print(f"  loaded in {time.perf_counter()-t_load:.1f}s on {device}",
+          file=sys.stderr, flush=True)
+
+    rows = []
+    with open(args.manifest, "r", encoding="utf-8", newline="") as m:
+        reader = csv.reader(m)
+        for r in reader:
+            if not r or r[0].startswith("#"):
+                continue
+            if len(r) < 3:
+                continue
+            rows.append((r[0].strip(), r[1].strip()))
+
+    print(f"Transcribing {len(rows)} utterances...", file=sys.stderr, flush=True)
+    with open(args.out, "w", encoding="utf-8", newline="") as out_f:
+        out_f.write("#uid,provider,audio_s,wall_ms,transcript\n")
+        for i, (uid, wav_path) in enumerate(rows):
+            try:
+                info = sf.info(wav_path)
+                audio_s = info.duration
+            except Exception as e:
+                print(f"  skip {uid}: {e}", file=sys.stderr)
+                continue
+
+            t0 = time.perf_counter()
+            with torch.no_grad():
+                # NeMo's transcribe returns a list; element may be a str
+                # (old API) or a Hypothesis (newer API). Handle both.
+                results = model.transcribe([wav_path], verbose=False)
+            wall_ms = (time.perf_counter() - t0) * 1000.0
+
+            if results and hasattr(results[0], "text"):
+                text = results[0].text
+            elif results:
+                text = str(results[0])
+            else:
+                text = ""
+            text = text.replace(",", " ")
+
+            out_f.write(f"{uid},nemo-fp32,{audio_s:.2f},{wall_ms:.1f},{text}\n")
+            out_f.flush()
+
+            if (i + 1) % 10 == 0:
+                print(f"  {i+1}/{len(rows)} done", file=sys.stderr, flush=True)
+
+    print(f"Wrote {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemotron_wer_rtf.py
+++ b/scripts/nemotron_wer_rtf.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Compare Nemotron streaming STT engines (ORT-CUDA / ORT-CPU / LiteRT) on WER and RTF.
+
+Reads a LibriSpeech-style manifest plus up to three engine CSVs produced by the
+benchmark harness, and prints a fixed-width comparison table.
+
+CSV row format (with leading '#' header line):
+    uid,provider,audio_s,wall_ms,transcript
+
+Manifest row format (no header):
+    uid,wav_path,reference
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+try:
+    from jiwer import wer as _jiwer_wer  # type: ignore
+    _HAVE_JIWER = True
+except Exception:
+    _HAVE_JIWER = False
+
+
+_PUNCT_RE = re.compile(r"[\.,\!\?;:\'\"\-—]")
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip ASCII punctuation (.,!?;:'\"-—), collapse whitespace."""
+    if text is None:
+        return ""
+    t = text.lower()
+    t = _PUNCT_RE.sub(" ", t)
+    t = _WS_RE.sub(" ", t).strip()
+    return t
+
+
+def _levenshtein_words(ref: List[str], hyp: List[str]) -> int:
+    """Classic word-level Levenshtein distance, O(len(ref) * len(hyp)) time, O(min) memory."""
+    if len(ref) < len(hyp):
+        ref, hyp = hyp, ref
+    if not hyp:
+        return len(ref)
+    prev = list(range(len(hyp) + 1))
+    for i, r in enumerate(ref, start=1):
+        curr = [i] + [0] * len(hyp)
+        for j, h in enumerate(hyp, start=1):
+            cost = 0 if r == h else 1
+            curr[j] = min(
+                curr[j - 1] + 1,        # insertion
+                prev[j] + 1,            # deletion
+                prev[j - 1] + cost,     # substitution
+            )
+        prev = curr
+    return prev[-1]
+
+
+def utterance_wer(reference: str, hypothesis: str) -> float:
+    """Per-utterance WER in [0, +inf). Empty reference -> 0.0 if hyp also empty, else 1.0."""
+    ref_n = normalize(reference)
+    hyp_n = normalize(hypothesis)
+    if _HAVE_JIWER:
+        if not ref_n:
+            return 0.0 if not hyp_n else 1.0
+        try:
+            return float(_jiwer_wer(ref_n, hyp_n))
+        except Exception:
+            pass
+    ref_words = ref_n.split()
+    hyp_words = hyp_n.split()
+    if not ref_words:
+        return 0.0 if not hyp_words else 1.0
+    dist = _levenshtein_words(ref_words, hyp_words)
+    return dist / len(ref_words)
+
+
+def load_manifest(path: str) -> Dict[str, str]:
+    """Returns {uid: reference}. Reference is taken verbatim from column 2 (already lowercase)."""
+    refs: Dict[str, str] = {}
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row or row[0].startswith("#"):
+                continue
+            if len(row) < 3:
+                continue
+            uid = row[0].strip()
+            reference = row[2]
+            # Some manifests may embed commas in the reference; rejoin trailing fields.
+            if len(row) > 3:
+                reference = ",".join(row[2:])
+            refs[uid] = reference
+    return refs
+
+
+@dataclass
+class EngineRow:
+    uid: str
+    provider: str
+    audio_s: float
+    wall_ms: float
+    transcript: str
+
+
+def load_engine_csv(path: str) -> List[EngineRow]:
+    rows: List[EngineRow] = []
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if not row:
+                continue
+            if row[0].startswith("#"):
+                continue
+            if len(row) < 5:
+                continue
+            uid = row[0].strip()
+            provider = row[1].strip()
+            try:
+                audio_s = float(row[2])
+                wall_ms = float(row[3])
+            except ValueError:
+                continue
+            transcript = row[4] if len(row) == 5 else ",".join(row[4:])
+            rows.append(EngineRow(uid, provider, audio_s, wall_ms, transcript))
+    return rows
+
+
+@dataclass
+class EngineStats:
+    label: str
+    provider: str
+    n: int
+    wer_mean: float
+    wer_p50: float
+    wer_p95: float
+    rtf: float
+    wall_p50: float
+    wall_p95: float
+
+
+def _percentile(values: List[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    s = sorted(values)
+    # Linear interpolation between closest ranks.
+    k = (len(s) - 1) * (pct / 100.0)
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    if f == c:
+        return s[f]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def compute_stats(label: str, rows: List[EngineRow], refs: Dict[str, str]) -> EngineStats:
+    wers: List[float] = []
+    walls: List[float] = []
+    audio_total = 0.0
+    wall_total = 0.0
+    provider = ""
+    for r in rows:
+        if r.uid not in refs:
+            continue
+        if not provider:
+            provider = r.provider
+        wers.append(utterance_wer(refs[r.uid], r.transcript))
+        walls.append(r.wall_ms)
+        audio_total += r.audio_s
+        wall_total += r.wall_ms
+
+    n = len(wers)
+    wer_mean = statistics.fmean(wers) if wers else 0.0
+    wer_p50 = _percentile(wers, 50.0)
+    wer_p95 = _percentile(wers, 95.0)
+    wall_p50 = _percentile(walls, 50.0)
+    wall_p95 = _percentile(walls, 95.0)
+    rtf = (audio_total / (wall_total / 1000.0)) if wall_total > 0 else 0.0
+
+    return EngineStats(
+        label=label,
+        provider=provider or label,
+        n=n,
+        wer_mean=wer_mean,
+        wer_p50=wer_p50,
+        wer_p95=wer_p95,
+        rtf=rtf,
+        wall_p50=wall_p50,
+        wall_p95=wall_p95,
+    )
+
+
+def _fmt_pct(v: float) -> str:
+    return f"{v * 100.0:.2f}%"
+
+
+def _fmt_rtf(v: float) -> str:
+    return f"{v:.2f}x"
+
+
+def _fmt_ms(v: float) -> str:
+    return f"{int(round(v))} ms"
+
+
+def print_table(stats: List[EngineStats]) -> None:
+    headers = ["provider", "n", "WER_mean", "WER_p50", "WER_p95", "RTF", "wall_p50", "wall_p95"]
+    widths = [16, 2, 8, 7, 7, 5, 8, 8]
+
+    def fmt_row(cells: List[str]) -> str:
+        return " | ".join(c.ljust(w) for c, w in zip(cells, widths))
+
+    print(fmt_row(headers))
+    print("-+-".join("-" * w for w in widths))
+    for s in stats:
+        cells = [
+            s.label,
+            str(s.n),
+            _fmt_pct(s.wer_mean),
+            _fmt_pct(s.wer_p50),
+            _fmt_pct(s.wer_p95),
+            _fmt_rtf(s.rtf),
+            _fmt_ms(s.wall_p50),
+            _fmt_ms(s.wall_p95),
+        ]
+        print(fmt_row(cells))
+
+
+def print_verdict(stats: List[EngineStats]) -> None:
+    by_label = {s.label: s for s in stats}
+    baseline = by_label.get("litert")
+    candidate = by_label.get("ort-cuda")
+    if baseline is None or candidate is None:
+        return
+
+    delta = candidate.wer_mean - baseline.wer_mean
+    abs_delta_pct = abs(delta) * 100.0
+    threshold_pct = 1.0
+
+    if abs_delta_pct <= threshold_pct:
+        print(
+            f"[OK]  ort-cuda WER within {threshold_pct:.1f}% absolute of litert-cpu baseline "
+            f"-- safe to publish."
+        )
+    else:
+        worse_or_better = "worse" if delta > 0 else "better"
+        print(
+            f"[WARN] ort-cuda WER is {abs_delta_pct:.1f}% absolute {worse_or_better} than "
+            f"litert-cpu -- investigate before publishing."
+        )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare Nemotron streaming STT engines on WER/RTF.")
+    parser.add_argument("--manifest", required=True, help="Path to manifest CSV (uid,wav_path,reference).")
+    parser.add_argument("--ort-cuda", dest="ort_cuda", default=None, help="Path to ORT CUDA results CSV.")
+    parser.add_argument("--ort-cpu", dest="ort_cpu", default=None, help="Path to ORT CPU results CSV.")
+    parser.add_argument("--litert", dest="litert", default=None, help="Path to LiteRT results CSV.")
+    args = parser.parse_args(argv)
+
+    refs = load_manifest(args.manifest)
+    if not refs:
+        print(f"error: no references loaded from manifest {args.manifest!r}", file=sys.stderr)
+        return 2
+
+    sources: List[Tuple[str, Optional[str]]] = [
+        ("ort-cuda", args.ort_cuda),
+        ("ort-cpu", args.ort_cpu),
+        ("litert", args.litert),
+    ]
+
+    stats: List[EngineStats] = []
+    for label, path in sources:
+        if not path:
+            continue
+        try:
+            rows = load_engine_csv(path)
+        except FileNotFoundError:
+            print(f"warning: {label} CSV not found at {path!r} -- skipping.", file=sys.stderr)
+            continue
+        if not rows:
+            print(f"warning: {label} CSV {path!r} contained no usable rows -- skipping.", file=sys.stderr)
+            continue
+        stats.append(compute_stats(label, rows, refs))
+
+    if not stats:
+        print("error: no engine CSVs provided (or all empty).", file=sys.stderr)
+        return 2
+
+    print_table(stats)
+    print()
+    print_verdict(stats)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nemotron_wer_rtf.py
+++ b/scripts/nemotron_wer_rtf.py
@@ -233,35 +233,67 @@ def print_table(stats: List[EngineStats]) -> None:
 
 
 def print_verdict(stats: List[EngineStats]) -> None:
-    by_label = {s.label: s for s in stats}
-    baseline = by_label.get("litert")
-    candidate = by_label.get("ort-cuda")
-    if baseline is None or candidate is None:
-        return
+    """Two-tier verdict:
 
-    delta = candidate.wer_mean - baseline.wer_mean
-    abs_delta_pct = abs(delta) * 100.0
+      Tier 1 (the export-fidelity gate): each ORT candidate vs LiteRT.
+        Same inference mode (streaming, 80 ms), so the delta isolates the
+        ONNX export from any other difference. Threshold: 1.0% absolute.
+
+      Tier 2 (the ceiling gate): each engine vs NeMo FP32 reference.
+        Different inference mode (offline vs streaming) so the gap is the
+        sum of (a) streaming penalty and (b) any quantization cost. This
+        is informational, not a hard publish gate.
+    """
+    by_label = {s.label: s for s in stats}
     threshold_pct = 1.0
 
-    if abs_delta_pct <= threshold_pct:
-        print(
-            f"[OK]  ort-cuda WER within {threshold_pct:.1f}% absolute of litert-cpu baseline "
-            f"-- safe to publish."
-        )
-    else:
-        worse_or_better = "worse" if delta > 0 else "better"
-        print(
-            f"[WARN] ort-cuda WER is {abs_delta_pct:.1f}% absolute {worse_or_better} than "
-            f"litert-cpu -- investigate before publishing."
-        )
+    litert = by_label.get("litert")
+    nemo   = by_label.get("nemo-fp32")
+
+    # Tier 1: ORT candidates vs LiteRT (same streaming mode → export delta).
+    for cand_label in ("ort-cuda", "ort-cuda-int8", "ort-cpu"):
+        cand = by_label.get(cand_label)
+        if cand is None or litert is None:
+            continue
+        delta = cand.wer_mean - litert.wer_mean
+        abs_delta_pct = abs(delta) * 100.0
+        if abs_delta_pct <= threshold_pct:
+            print(
+                f"[OK]   {cand_label} WER within {threshold_pct:.1f}% absolute of litert "
+                f"({_fmt_pct(cand.wer_mean)} vs {_fmt_pct(litert.wer_mean)}, "
+                f"delta {delta*100:+.2f} pts) -- export faithful."
+            )
+        else:
+            worse_or_better = "worse" if delta > 0 else "better"
+            print(
+                f"[WARN] {cand_label} WER is {abs_delta_pct:.1f}% absolute {worse_or_better} "
+                f"than litert ({_fmt_pct(cand.wer_mean)} vs {_fmt_pct(litert.wer_mean)}) "
+                f"-- investigate before publishing."
+            )
+
+    # Tier 2: streaming penalty / quantization cost vs NeMo FP32 reference.
+    if nemo is not None:
+        print()
+        print(f"NeMo FP32 reference (offline): {_fmt_pct(nemo.wer_mean)} mean WER, "
+              f"{_fmt_pct(nemo.wer_p50)} p50 -- model's quality ceiling.")
+        for other in stats:
+            if other.label == "nemo-fp32":
+                continue
+            gap = other.wer_mean - nemo.wer_mean
+            print(f"  {other.label:>15}: +{gap*100:5.2f} pts vs ref (streaming "
+                  f"+ quantization penalty)")
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Compare Nemotron streaming STT engines on WER/RTF.")
     parser.add_argument("--manifest", required=True, help="Path to manifest CSV (uid,wav_path,reference).")
     parser.add_argument("--ort-cuda", dest="ort_cuda", default=None, help="Path to ORT CUDA results CSV.")
+    parser.add_argument("--ort-cuda-int8", dest="ort_cuda_int8", default=None,
+                        help="Path to ORT CUDA INT8-encoder results CSV.")
     parser.add_argument("--ort-cpu", dest="ort_cpu", default=None, help="Path to ORT CPU results CSV.")
     parser.add_argument("--litert", dest="litert", default=None, help="Path to LiteRT results CSV.")
+    parser.add_argument("--nemo-fp32", dest="nemo_fp32", default=None,
+                        help="Path to NeMo PyTorch FP32 reference results CSV (offline mode).")
     args = parser.parse_args(argv)
 
     refs = load_manifest(args.manifest)
@@ -270,7 +302,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     sources: List[Tuple[str, Optional[str]]] = [
+        ("nemo-fp32", args.nemo_fp32),
         ("ort-cuda", args.ort_cuda),
+        ("ort-cuda-int8", args.ort_cuda_int8),
         ("ort-cpu", args.ort_cpu),
         ("litert", args.litert),
     ]

--- a/src/models/litert/litert_nemotron_streaming_stt.cpp
+++ b/src/models/litert/litert_nemotron_streaming_stt.cpp
@@ -74,36 +74,171 @@ LiteRTNemotronStreamingStt::LiteRTNemotronStreamingStt(
     // at larger chunk modes. Source: config.json streaming.outputFrames;
     // fall back to T_out - 1.
     output_frames_ = std::max(1, enc_t_out_ - 1);
+    // LiteRT's introspection of input tensor layouts is unreliable for our
+    // exports: the SignatureRunner's input-index order does not match the
+    // semantic forward() argument order, and the layouts come back in an
+    // arbitrary tensor-id order that may not put audio_signal at index 0.
+    // Worse, on the freshly-exported 560 ms bundle the introspection
+    // returned 80 ms-default dims for every input — i.e. it failed silently.
+    // Read everything we can from config.json (the canonical source) and
+    // only fall back to introspection / defaults when the file is missing.
     {
         std::string cfg_path = encoder_path;
         auto slash = cfg_path.find_last_of("/\\");
         if (slash != std::string::npos) cfg_path = cfg_path.substr(0, slash);
         cfg_path += "/config.json";
         std::string text = json::read_file(cfg_path);
-        if (!text.empty()) {
-            const std::string key = "\"outputFrames\"";
-            auto pos = text.find(key);
-            if (pos != std::string::npos) {
-                pos = text.find(':', pos);
-                if (pos != std::string::npos) {
-                    ++pos;
-                    while (pos < text.size()
-                           && (text[pos] == ' ' || text[pos] == '\t'
-                               || text[pos] == '\n' || text[pos] == '\r')) ++pos;
-                    int v = 0;
-                    while (pos < text.size() && text[pos] >= '0' && text[pos] <= '9') {
-                        v = v * 10 + (text[pos] - '0');
-                        ++pos;
-                    }
-                    if (v > 0 && v <= enc_t_out_) output_frames_ = v;
-                }
+        auto read_int = [&](const std::string& key) -> int {
+            const std::string k = "\"" + key + "\"";
+            auto pos = text.find(k);
+            if (pos == std::string::npos) return -1;
+            pos = text.find(':', pos);
+            if (pos == std::string::npos) return -1;
+            ++pos;
+            while (pos < text.size()
+                   && (text[pos] == ' ' || text[pos] == '\t'
+                       || text[pos] == '\n' || text[pos] == '\r')) ++pos;
+            int v = 0;
+            bool any = false;
+            while (pos < text.size() && text[pos] >= '0' && text[pos] <= '9') {
+                v = v * 10 + (text[pos] - '0'); ++pos; any = true;
             }
+            return any ? v : -1;
+        };
+        if (!text.empty()) {
+            int v;
+            if ((v = read_int("outputFrames"))    > 0) output_frames_         = v;
+            if ((v = read_int("melFrames"))       > 0) cfg_.actual_mel_frames = v;
+            if ((v = read_int("preCacheSize"))    > 0) cfg_.pre_cache_size    = v;
+            if ((v = read_int("attentionContext"))> 0) cfg_.attn_left_context = v;
+            if ((v = read_int("convCacheSize"))   > 0) cfg_.conv_cache_size   = v;
+            if ((v = read_int("encoderHidden"))   > 0) cfg_.encoder_hidden    = v;
+            if ((v = read_int("encoderLayers"))   > 0) cfg_.encoder_layers    = v;
+            if ((v = read_int("decoderHidden"))   > 0) cfg_.decoder_hidden    = v;
+            if ((v = read_int("decoderLayers"))   > 0) cfg_.decoder_layers    = v;
+            if ((v = read_int("vocabSize"))       > 0) { cfg_.vocab_size = v; cfg_.blank_id = v; }
+            // enc_t_out_ should match output_frames_ + lookahead frames; if
+            // tensor-layout introspection failed it's still the Config default
+            // (2) which is wrong for >80 ms. Derive from output_frames_ when
+            // both melFrames and outputFrames are present (T_out == output_frames
+            // for our exports — there's no lookahead frame in this NeMo
+            // streaming Conformer pipeline).
+            if (read_int("outputFrames") > 0) enc_t_out_ = output_frames_;
         }
     }
 
-    LOGI("Nemotron streaming: vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d output_frames=%d mel_frames=%d window=%d samples",
+    // Build the semantic-role -> signature-position mapping by reading the
+    // encoder's input/output names from its signature. Each tensor is named
+    // "serving_default_args_N"; the N is the original positional index from
+    // the Python wrapper's forward() args (so 0=mel, 1=mlen, 2=pre_cache,
+    // 3=cache_last_channel, 4=cache_last_time, 5=cache_last_channel_len).
+    // The published 80 ms bundle has identity mapping (pos N has args_N),
+    // but bundles produced by the WSL-side patched-NeMo + litert-torch 0.8
+    // path scramble the tensor-id order, leaving the semantic ID encoded
+    // only in the name. Without this remap, run_window() feeds buffers into
+    // the wrong slots and LiteRT rejects them with "Cannot auto-resize
+    // tensor args_2: no dims_signature exists" — same shape, wrong position.
+    {
+        LiteRtSignature sig = nullptr;
+        if (LiteRtGetModelSignature(enc_model_, 0, &sig) == kLiteRtStatusOk && sig) {
+            auto parse_args_id = [](const char* name) -> int {
+                if (!name) return -1;
+                // Try "args_N" (input naming) and "output_N" (output naming).
+                for (const char* token : {"args_", "output_"}) {
+                    const char* m = std::strstr(name, token);
+                    if (m) {
+                        int n = std::atoi(m + std::strlen(token));
+                        if (n >= 0 && n < 6) return n;
+                    }
+                }
+                // "StatefulPartitionedCall:N" fallback.
+                const char* colon = std::strrchr(name, ':');
+                if (colon) {
+                    int n = std::atoi(colon + 1);
+                    if (n >= 0 && n < 6) return n;
+                }
+                return -1;
+            };
+            // Inputs
+            int sem_to_pos_in[6] = {-1,-1,-1,-1,-1,-1};
+            for (int p = 0; p < 6; ++p) {
+                const char* name = nullptr;
+                if (LiteRtGetSignatureInputName(sig, p, &name) != kLiteRtStatusOk) continue;
+                int sem = parse_args_id(name);
+                if (sem >= 0) sem_to_pos_in[sem] = p;
+            }
+            bool full_in = true;
+            for (int s = 0; s < 6; ++s) if (sem_to_pos_in[s] < 0) full_in = false;
+            if (full_in) {
+                for (int s = 0; s < 6; ++s) enc_in_sig_pos_[s] = sem_to_pos_in[s];
+            }
+            // Outputs
+            int sem_to_pos_out[6] = {-1,-1,-1,-1,-1,-1};
+            for (int p = 0; p < 6; ++p) {
+                const char* name = nullptr;
+                if (LiteRtGetSignatureOutputName(sig, p, &name) != kLiteRtStatusOk) continue;
+                int sem = parse_args_id(name);
+                if (sem < 0) {
+                    const char* colon = name ? std::strrchr(name, ':') : nullptr;
+                    if (colon) sem = std::atoi(colon + 1);
+                }
+                if (sem >= 0 && sem < 6) sem_to_pos_out[sem] = p;
+            }
+            bool full_out = true;
+            for (int s = 0; s < 6; ++s) if (sem_to_pos_out[s] < 0) full_out = false;
+            if (full_out) {
+                for (int s = 0; s < 6; ++s) enc_out_sig_pos_[s] = sem_to_pos_out[s];
+            }
+        }
+        // Same scrambling can hit the decoder (3 in / 3 out). Joint has been
+        // identity in observed bundles, but we apply the same approach for
+        // safety if it ever scrambles.
+        LiteRtSignature dsig = nullptr;
+        if (LiteRtGetModelSignature(dec_model_, 0, &dsig) == kLiteRtStatusOk && dsig) {
+            auto parse3 = [](const char* name) -> int {
+                if (!name) return -1;
+                for (const char* token : {"args_", "output_"}) {
+                    const char* m = std::strstr(name, token);
+                    if (m) {
+                        int n = std::atoi(m + std::strlen(token));
+                        if (n >= 0 && n < 3) return n;
+                    }
+                }
+                const char* colon = std::strrchr(name, ':');
+                if (colon) {
+                    int n = std::atoi(colon + 1);
+                    if (n >= 0 && n < 3) return n;
+                }
+                return -1;
+            };
+            int dec_in_map[3] = {-1,-1,-1};
+            for (int p = 0; p < 3; ++p) {
+                const char* name = nullptr;
+                if (LiteRtGetSignatureInputName(dsig, p, &name) != kLiteRtStatusOk) continue;
+                int sem = parse3(name);
+                if (sem >= 0) dec_in_map[sem] = p;
+            }
+            bool fi = true;
+            for (int s = 0; s < 3; ++s) if (dec_in_map[s] < 0) fi = false;
+            if (fi) for (int s = 0; s < 3; ++s) dec_in_sig_pos_[s] = dec_in_map[s];
+
+            int dec_out_map[3] = {-1,-1,-1};
+            for (int p = 0; p < 3; ++p) {
+                const char* name = nullptr;
+                if (LiteRtGetSignatureOutputName(dsig, p, &name) != kLiteRtStatusOk) continue;
+                int sem = parse3(name);
+                if (sem >= 0) dec_out_map[sem] = p;
+            }
+            bool fo = true;
+            for (int s = 0; s < 3; ++s) if (dec_out_map[s] < 0) fo = false;
+            if (fo) for (int s = 0; s < 3; ++s) dec_out_sig_pos_[s] = dec_out_map[s];
+        }
+    }
+
+    LOGI("Nemotron streaming: vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d output_frames=%d mel_frames=%d pre_cache=%d attn=%d conv=%d window=%d samples",
          vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_,
-         output_frames_, cfg_.actual_mel_frames, chunk_samples());
+         output_frames_, cfg_.actual_mel_frames, cfg_.pre_cache_size,
+         cfg_.attn_left_context, cfg_.conv_cache_size, chunk_samples());
 }
 
 LiteRTNemotronStreamingStt::~LiteRTNemotronStreamingStt() {
@@ -184,8 +319,15 @@ void LiteRTNemotronStreamingStt::run_decoder_step(int64_t token_id) {
     LiteRtHostBuffer out_c    (env, t_state,  dec_c_.size() * sizeof(float));
 
     // decoder I/O: in [token, h, c] -> out [hidden, h_new, c_new]
-    LiteRtTensorBuffer ins [3] = { in_tok.raw(), in_h.raw(), in_c.raw() };
-    LiteRtTensorBuffer outs[3] = { out_hid.raw(), out_h.raw(), out_c.raw() };
+    // decoder I/O semantic order: in [token, h, c] -> out [hidden, h_new, c_new]
+    // Some 560 ms-style bundles scramble tensor IDs; remap via dec_in_sig_pos_.
+    LiteRtTensorBuffer sem_ins [3] = { in_tok.raw(), in_h.raw(), in_c.raw() };
+    LiteRtTensorBuffer sem_outs[3] = { out_hid.raw(), out_h.raw(), out_c.raw() };
+    LiteRtTensorBuffer ins[3], outs[3];
+    for (int s = 0; s < 3; ++s) {
+        ins [dec_in_sig_pos_[s]]  = sem_ins[s];
+        outs[dec_out_sig_pos_[s]] = sem_outs[s];
+    }
     litert_check(LiteRtRunCompiledModel(dec_compiled_, 0, 3, ins, 3, outs), "Nemotron decoder Run");
 
     out_hid.read(dec_hidden_.data(), dec_hidden_.size() * sizeof(float));
@@ -249,13 +391,25 @@ std::string LiteRTNemotronStreamingStt::run_window() {
     LiteRtHostBuffer out_clt (env, t_clt, cache_last_time_.size() * sizeof(float));
     LiteRtHostBuffer out_chl (env, t_i32, sizeof(int32_t));
 
-    // encoder I/O order (traced export):
+    // encoder I/O semantic order:
     //   in:  mel, mel_len, pre_cache, cache_last_channel, cache_last_time, ch_len
     //   out: encoded, encoded_len, pre_cache', cache_last_channel', cache_last_time', ch_len'
-    LiteRtTensorBuffer eins [6] = { in_mel.raw(), in_mlen.raw(), in_pre.raw(),
-                                    in_clc.raw(), in_clt.raw(), in_chl.raw() };
-    LiteRtTensorBuffer eouts[6] = { out_enc.raw(), out_elen.raw(), out_pre.raw(),
-                                    out_clc.raw(), out_clt.raw(), out_chl.raw() };
+    // The actual signature position of each tensor depends on the bundle:
+    // identity for the published 80 ms bundle, scrambled for our newly-
+    // exported bundles. enc_in_sig_pos_/enc_out_sig_pos_ remap.
+    LiteRtTensorBuffer sem_eins[6] = {
+        in_mel.raw(), in_mlen.raw(), in_pre.raw(),
+        in_clc.raw(), in_clt.raw(), in_chl.raw()
+    };
+    LiteRtTensorBuffer sem_eouts[6] = {
+        out_enc.raw(), out_elen.raw(), out_pre.raw(),
+        out_clc.raw(), out_clt.raw(), out_chl.raw()
+    };
+    LiteRtTensorBuffer eins[6], eouts[6];
+    for (int s = 0; s < 6; ++s) {
+        eins [enc_in_sig_pos_[s]]  = sem_eins[s];
+        eouts[enc_out_sig_pos_[s]] = sem_eouts[s];
+    }
     litert_check(LiteRtRunCompiledModel(enc_compiled_, 0, 6, eins, 6, eouts), "Nemotron encoder Run");
 
     // Roll caches forward for the next window.

--- a/src/models/litert/litert_nemotron_streaming_stt.cpp
+++ b/src/models/litert/litert_nemotron_streaming_stt.cpp
@@ -338,10 +338,22 @@ PartialResult LiteRTNemotronStreamingStt::push_chunk(const float* audio, size_t 
 }
 
 void LiteRTNemotronStreamingStt::flush_stream() {
-    // No-op: only full windows are decoded; a trailing partial window is held.
+    // Pad any leftover partial window with silence so the encoder gets
+    // a final pass on the trailing audio. Otherwise the last 0..chunk_ms
+    // of every utterance is dropped — bucketing the LibriSpeech-100
+    // corpus on the ORT path (same architecture, same export contract)
+    // showed this trailing-loss concentrated 7.23 absolute WER points
+    // on utterances <5s. The same bug bites here.
+    if (!stream_init_) return;
+    if (pending_.empty()) return;
+    const int win = chunk_samples();
+    if (static_cast<int>(pending_.size()) >= win) return;
+    pending_.resize(static_cast<size_t>(win), 0.0f);
+    accumulated_text_ += run_window();
 }
 
 TranscriptionResult LiteRTNemotronStreamingStt::end_stream() {
+    flush_stream();
     TranscriptionResult out;
     out.text = accumulated_text_;
     stream_init_ = false;

--- a/src/models/litert/litert_nemotron_streaming_stt.cpp
+++ b/src/models/litert/litert_nemotron_streaming_stt.cpp
@@ -4,8 +4,10 @@
 #include "speech_core/util/json.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 
 namespace speech_core {
 
@@ -117,13 +119,30 @@ LiteRTNemotronStreamingStt::LiteRTNemotronStreamingStt(
             if ((v = read_int("decoderHidden"))   > 0) cfg_.decoder_hidden    = v;
             if ((v = read_int("decoderLayers"))   > 0) cfg_.decoder_layers    = v;
             if ((v = read_int("vocabSize"))       > 0) { cfg_.vocab_size = v; cfg_.blank_id = v; }
-            // enc_t_out_ should match output_frames_ + lookahead frames; if
-            // tensor-layout introspection failed it's still the Config default
-            // (2) which is wrong for >80 ms. Derive from output_frames_ when
-            // both melFrames and outputFrames are present (T_out == output_frames
-            // for our exports — there's no lookahead frame in this NeMo
-            // streaming Conformer pipeline).
-            if (read_int("outputFrames") > 0) enc_t_out_ = output_frames_;
+            // Authoritative T_out: chunkSize + rightContext. The cache-aware
+            // streaming Conformer emits committed frames (chunkSize) plus
+            // right-context lookahead frames in one Run; only chunkSize gets
+            // appended to the transcript, the lookahead is re-settled (with
+            // more left context) on the next window.
+            //
+            // The earlier override `enc_t_out_ = output_frames_` was wrong:
+            // it sized the out_enc host buffer to `output_frames_ * H * 4`
+            // bytes while LiteRT writes `(output_frames_ + right_context) *
+            // H * 4` bytes. The trailing right_context * H * 4 bytes
+            // overflowed onto adjacent LiteRtHostBuffers (out_elen / out_pre
+            // / out_clc), corrupted their heap headers, and the process died
+            // silently mid-Run with no LiteRT error message — matching the
+            // "exit 127, no error" symptom on 560 ms bundles.
+            //
+            // For 80 ms: chunkSize=1, rightContext=1 → T_out=2. ✓
+            // For 320 ms: chunkSize=4, rightContext=3 → T_out=7.
+            // For 560 ms: chunkSize=?, rightContext=? → T_out=8 (per bundle dump).
+            int chunk_size  = read_int("chunkSize");
+            int right_ctx   = read_int("rightContext");
+            if (chunk_size > 0 && right_ctx >= 0) {
+                enc_t_out_     = chunk_size + right_ctx;
+                output_frames_ = chunk_size;
+            }
         }
     }
 
@@ -337,7 +356,27 @@ void LiteRTNemotronStreamingStt::run_decoder_step(int64_t token_id) {
 
 // Drain one window from pending_, run mel -> encoder (cache-aware) -> greedy
 // RNN-T over the first encoder frame, return the emitted text.
+//
+// Per-Run timing is opt-in via SPEECH_LITERT_PROFILE=1. Cumulative totals are
+// printed to stderr at end_stream(). Off by default — the gettime calls add
+// ~100 ns per Run which is noise but the prints aren't.
+namespace { struct ProfAcc {
+    double mel_ms = 0, enc_ms = 0, jnt_ms = 0, dec_ms = 0;
+    int    n_windows = 0, n_jnt = 0, n_dec = 0;
+    bool   on = std::getenv("SPEECH_LITERT_PROFILE") != nullptr;
+    ~ProfAcc() {
+        if (!on || n_windows == 0) return;
+        std::fprintf(stderr,
+            "\n[profile] windows=%d mel=%.1f enc=%.1f jnt=%.1f(n=%d) dec=%.1f(n=%d) total=%.1f ms\n",
+            n_windows, mel_ms, enc_ms, jnt_ms, n_jnt, dec_ms, n_dec,
+            mel_ms + enc_ms + jnt_ms + dec_ms);
+    }
+}; }
+static thread_local ProfAcc g_prof;
+
 std::string LiteRTNemotronStreamingStt::run_window() {
+    using clk = std::chrono::steady_clock;
+    auto t0 = clk::now();
     const int n_frames = cfg_.actual_mel_frames;
     const int win      = chunk_samples();
     if (static_cast<int>(pending_.size()) < win) return {};
@@ -361,6 +400,8 @@ std::string LiteRTNemotronStreamingStt::run_window() {
         }
         mel.swap(trimmed);
     }
+
+    if (g_prof.on) g_prof.mel_ms += std::chrono::duration<double, std::milli>(clk::now() - t0).count();
 
     auto env = LiteRTEngine::get().env();
     auto t_mel  = make_type(kLiteRtElementTypeFloat32, {1, cfg_.mel_bins, n_frames});
@@ -410,7 +451,9 @@ std::string LiteRTNemotronStreamingStt::run_window() {
         eins [enc_in_sig_pos_[s]]  = sem_eins[s];
         eouts[enc_out_sig_pos_[s]] = sem_eouts[s];
     }
+    auto t_enc_start = clk::now();
     litert_check(LiteRtRunCompiledModel(enc_compiled_, 0, 6, eins, 6, eouts), "Nemotron encoder Run");
+    if (g_prof.on) g_prof.enc_ms += std::chrono::duration<double, std::milli>(clk::now() - t_enc_start).count();
 
     // Roll caches forward for the next window.
     out_pre.read(pre_cache_.data(),          pre_cache_.size() * sizeof(float));
@@ -446,7 +489,9 @@ std::string LiteRTNemotronStreamingStt::run_window() {
 
             LiteRtTensorBuffer jins [2] = { in_encf.raw(), in_dechid.raw() };
             LiteRtTensorBuffer jouts[1] = { out_log.raw() };
+            auto t_jnt = clk::now();
             litert_check(LiteRtRunCompiledModel(jnt_compiled_, 0, 2, jins, 1, jouts), "Nemotron joint Run");
+            if (g_prof.on) { g_prof.jnt_ms += std::chrono::duration<double, std::milli>(clk::now() - t_jnt).count(); ++g_prof.n_jnt; }
 
             std::vector<float> logits(n_logits);
             out_log.read(logits.data(), n_logits * sizeof(float));
@@ -459,10 +504,13 @@ std::string LiteRTNemotronStreamingStt::run_window() {
             if (best == cfg_.blank_id) break;  // advance to the next encoder frame
 
             emitted += token_to_text(best);
+            auto t_dec = clk::now();
             run_decoder_step(best);  // advance the predictor for the next expansion
+            if (g_prof.on) { g_prof.dec_ms += std::chrono::duration<double, std::milli>(clk::now() - t_dec).count(); ++g_prof.n_dec; }
         }
     }
 
+    if (g_prof.on) ++g_prof.n_windows;
     return emitted;
 }
 

--- a/src/models/litert/litert_nemotron_streaming_stt.cpp
+++ b/src/models/litert/litert_nemotron_streaming_stt.cpp
@@ -37,8 +37,73 @@ LiteRTNemotronStreamingStt::LiteRTNemotronStreamingStt(
         enc_t_out_ = static_cast<int>(outs[0].dimensions[1]);
     }
 
-    LOGI("Nemotron streaming: vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d window=%d samples",
-         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_, chunk_samples());
+    // Auto-detect chunk-mode shape pins from the encoder input layouts. The
+    // English Nemotron streaming model ships in 4 chunk-mode exports (80,
+    // 160, 560, 1120 ms) whose mel_frames / pre_cache_size differ. Without
+    // this, the wrapper assumes 80 ms defaults and silently feeds misshaped
+    // tensors to larger-chunk exports.
+    //   input[0] = audio_signal       [1, mel_bins, actual_mel_frames]
+    //   input[2] = pre_cache          [1, mel_bins, pre_cache_size]
+    //   input[3] = cache_last_channel [L, 1, attn_left, encoder_hidden]
+    //   input[4] = cache_last_time    [L, 1, encoder_hidden, conv_cache_size]
+    LiteRtLayout in_layout{};
+    if (LiteRtGetCompiledModelInputTensorLayout(enc_compiled_, 0, 0, &in_layout) == kLiteRtStatusOk
+        && in_layout.rank >= 3 && in_layout.dimensions[2] > 0) {
+        cfg_.actual_mel_frames = static_cast<int>(in_layout.dimensions[2]);
+    }
+    if (LiteRtGetCompiledModelInputTensorLayout(enc_compiled_, 0, 2, &in_layout) == kLiteRtStatusOk
+        && in_layout.rank >= 3 && in_layout.dimensions[2] > 0) {
+        cfg_.pre_cache_size = static_cast<int>(in_layout.dimensions[2]);
+    }
+    if (LiteRtGetCompiledModelInputTensorLayout(enc_compiled_, 0, 3, &in_layout) == kLiteRtStatusOk
+        && in_layout.rank >= 4) {
+        if (in_layout.dimensions[0] > 0) cfg_.encoder_layers    = static_cast<int>(in_layout.dimensions[0]);
+        if (in_layout.dimensions[2] > 0) cfg_.attn_left_context = static_cast<int>(in_layout.dimensions[2]);
+        if (in_layout.dimensions[3] > 0) cfg_.encoder_hidden    = static_cast<int>(in_layout.dimensions[3]);
+    }
+    if (LiteRtGetCompiledModelInputTensorLayout(enc_compiled_, 0, 4, &in_layout) == kLiteRtStatusOk
+        && in_layout.rank >= 4 && in_layout.dimensions[3] > 0) {
+        cfg_.conv_cache_size = static_cast<int>(in_layout.dimensions[3]);
+    }
+
+    // Committed encoder frames per window. The cache-aware streaming encoder
+    // emits T_out frames per Run; the FIRST output_frames_ are committed
+    // (their text belongs in the transcript), the remainder are right-context
+    // lookahead re-computed (with more left context) in the next window.
+    // Without this, only frame 0 was decoded — fine for 80 ms but catastrophic
+    // at larger chunk modes. Source: config.json streaming.outputFrames;
+    // fall back to T_out - 1.
+    output_frames_ = std::max(1, enc_t_out_ - 1);
+    {
+        std::string cfg_path = encoder_path;
+        auto slash = cfg_path.find_last_of("/\\");
+        if (slash != std::string::npos) cfg_path = cfg_path.substr(0, slash);
+        cfg_path += "/config.json";
+        std::string text = json::read_file(cfg_path);
+        if (!text.empty()) {
+            const std::string key = "\"outputFrames\"";
+            auto pos = text.find(key);
+            if (pos != std::string::npos) {
+                pos = text.find(':', pos);
+                if (pos != std::string::npos) {
+                    ++pos;
+                    while (pos < text.size()
+                           && (text[pos] == ' ' || text[pos] == '\t'
+                               || text[pos] == '\n' || text[pos] == '\r')) ++pos;
+                    int v = 0;
+                    while (pos < text.size() && text[pos] >= '0' && text[pos] <= '9') {
+                        v = v * 10 + (text[pos] - '0');
+                        ++pos;
+                    }
+                    if (v > 0 && v <= enc_t_out_) output_frames_ = v;
+                }
+            }
+        }
+    }
+
+    LOGI("Nemotron streaming: vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d output_frames=%d mel_frames=%d window=%d samples",
+         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_,
+         output_frames_, cfg_.actual_mel_frames, chunk_samples());
 }
 
 LiteRTNemotronStreamingStt::~LiteRTNemotronStreamingStt() {
@@ -204,36 +269,44 @@ std::string LiteRTNemotronStreamingStt::run_window() {
     std::vector<float> encoded(static_cast<size_t>(enc_t_out_) * cfg_.encoder_hidden);
     out_enc.read(encoded.data(), encoded.size() * sizeof(float));
 
-    // Greedy RNN-T over the FIRST encoder frame only (frame 0 = first
-    // encoder_hidden floats). The second frame is right-context lookahead,
-    // re-settled on the next window — feeding it duplicates output.
+    // Greedy RNN-T over the COMMITTED encoder frames (frames 0..output_frames_-1).
+    // The remaining T_out - output_frames_ frames are right-context lookahead,
+    // re-settled on the next window — feeding them duplicates output. For
+    // 80 ms chunks (output_frames_=1) we decode only frame 0, same as before.
+    // For 160/560/1120 ms (output_frames_=2/7/14) we now decode multiple
+    // frames per window — this closes the streaming-quality gap.
     auto t_encf   = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.encoder_hidden});
     auto t_dechid = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.decoder_hidden});
     auto t_logits = make_type(kLiteRtElementTypeFloat32, {1, 1, cfg_.vocab_size + 1});
     const size_t n_logits = static_cast<size_t>(cfg_.vocab_size) + 1;
 
     std::string emitted;
-    for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
-        LiteRtHostBuffer in_encf  (env, t_encf,   static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float), encoded.data());
-        LiteRtHostBuffer in_dechid(env, t_dechid, dec_hidden_.size() * sizeof(float),                       dec_hidden_.data());
-        LiteRtHostBuffer out_log  (env, t_logits, n_logits * sizeof(float));
+    for (int frame = 0; frame < output_frames_; ++frame) {
+        const size_t frame_off = static_cast<size_t>(frame) * cfg_.encoder_hidden;
+        for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
+            LiteRtHostBuffer in_encf  (env, t_encf,
+                static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
+                encoded.data() + frame_off);
+            LiteRtHostBuffer in_dechid(env, t_dechid, dec_hidden_.size() * sizeof(float), dec_hidden_.data());
+            LiteRtHostBuffer out_log  (env, t_logits, n_logits * sizeof(float));
 
-        LiteRtTensorBuffer jins [2] = { in_encf.raw(), in_dechid.raw() };
-        LiteRtTensorBuffer jouts[1] = { out_log.raw() };
-        litert_check(LiteRtRunCompiledModel(jnt_compiled_, 0, 2, jins, 1, jouts), "Nemotron joint Run");
+            LiteRtTensorBuffer jins [2] = { in_encf.raw(), in_dechid.raw() };
+            LiteRtTensorBuffer jouts[1] = { out_log.raw() };
+            litert_check(LiteRtRunCompiledModel(jnt_compiled_, 0, 2, jins, 1, jouts), "Nemotron joint Run");
 
-        std::vector<float> logits(n_logits);
-        out_log.read(logits.data(), n_logits * sizeof(float));
+            std::vector<float> logits(n_logits);
+            out_log.read(logits.data(), n_logits * sizeof(float));
 
-        int   best   = 0;
-        float best_v = logits[0];
-        for (size_t i = 1; i < n_logits; ++i) {
-            if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+            int   best   = 0;
+            float best_v = logits[0];
+            for (size_t i = 1; i < n_logits; ++i) {
+                if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+            }
+            if (best == cfg_.blank_id) break;  // advance to the next encoder frame
+
+            emitted += token_to_text(best);
+            run_decoder_step(best);  // advance the predictor for the next expansion
         }
-        if (best == cfg_.blank_id) break;  // advance to the next encoder frame
-
-        emitted += token_to_text(best);
-        run_decoder_step(best);  // advance the predictor for the next expansion
     }
 
     return emitted;

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -1,0 +1,418 @@
+#include "speech_core/models/onnx_nemotron_streaming_stt.h"
+
+#include "speech_core/audio/mel.h"
+#include "speech_core/models/onnx_engine.h"
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+namespace speech_core {
+
+namespace {
+
+// RAII for an OrtAllocator-allocated string (input/output name).
+struct OrtStringHandle {
+    const OrtApi* api = nullptr;
+    OrtAllocator* alloc = nullptr;
+    char* p = nullptr;
+    OrtStringHandle(const OrtApi* a, OrtAllocator* al) : api(a), alloc(al) {}
+    ~OrtStringHandle() { if (p && api && alloc) api->AllocatorFree(alloc, p); }
+    OrtStringHandle(const OrtStringHandle&) = delete;
+    OrtStringHandle& operator=(const OrtStringHandle&) = delete;
+};
+
+}  // namespace
+
+void OnnxNemotronStreamingStt::query_io_names(OrtSession* session, IoNames& names) {
+    OrtAllocator* alloc = nullptr;
+    ort_check(api_, api_->GetAllocatorWithDefaultOptions(&alloc));
+
+    size_t n_in = 0;
+    ort_check(api_, api_->SessionGetInputCount(session, &n_in));
+    names.in_names_str.reserve(n_in);
+    for (size_t i = 0; i < n_in; ++i) {
+        OrtStringHandle h(api_, alloc);
+        ort_check(api_, api_->SessionGetInputName(session, i, alloc, &h.p));
+        names.in_names_str.emplace_back(h.p);
+    }
+    size_t n_out = 0;
+    ort_check(api_, api_->SessionGetOutputCount(session, &n_out));
+    names.out_names_str.reserve(n_out);
+    for (size_t i = 0; i < n_out; ++i) {
+        OrtStringHandle h(api_, alloc);
+        ort_check(api_, api_->SessionGetOutputName(session, i, alloc, &h.p));
+        names.out_names_str.emplace_back(h.p);
+    }
+
+    names.in_names.clear();
+    names.in_names.reserve(names.in_names_str.size());
+    for (auto& s : names.in_names_str) names.in_names.push_back(s.c_str());
+    names.out_names.clear();
+    names.out_names.reserve(names.out_names_str.size());
+    for (auto& s : names.out_names_str) names.out_names.push_back(s.c_str());
+}
+
+OnnxNemotronStreamingStt::OnnxNemotronStreamingStt(
+    const std::string& encoder_path, const std::string& decoder_path,
+    const std::string& joint_path, const std::string& vocab_path, bool hw_accel)
+    : OnnxNemotronStreamingStt(encoder_path, decoder_path, joint_path,
+                               vocab_path, Config{}, hw_accel) {}
+
+OnnxNemotronStreamingStt::OnnxNemotronStreamingStt(
+    const std::string& encoder_path, const std::string& decoder_path,
+    const std::string& joint_path, const std::string& vocab_path,
+    const Config& config, bool hw_accel)
+    : cfg_(config)
+{
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    // Encoder is the heavy graph (24-layer Conformer ~580M params) — runs on
+    // the GPU when available. Decoder LSTM + joint are tiny (~50M decoder,
+    // ~1M joint) and ship small tensors per expansion; CUDA dispatch beats
+    // their compute time, same anti-pattern as Parakeet's decoder_joint.
+    enc_ = engine.load(encoder_path, hw_accel);
+    dec_ = engine.load(decoder_path, false);
+    jnt_ = engine.load(joint_path,   false);
+
+    query_io_names(enc_, enc_io_);
+    query_io_names(dec_, dec_io_);
+    query_io_names(jnt_, jnt_io_);
+
+    load_vocab(vocab_path);
+
+    // Encoder output[0] = encoded_output [1, T_out, H]; read T_out for buffer
+    // sizing. Static shape, available without a resize. Tolerate failure —
+    // fall back to the default (2 @ 80 ms).
+    OrtTypeInfo* ti = nullptr;
+    if (api_->SessionGetOutputTypeInfo(enc_, 0, &ti) == nullptr) {
+        const OrtTensorTypeAndShapeInfo* shape = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(ti, &shape) == nullptr && shape) {
+            size_t rank = 0;
+            api_->GetDimensionsCount(shape, &rank);
+            if (rank >= 3) {
+                std::vector<int64_t> dims(rank);
+                api_->GetDimensions(shape, dims.data(), rank);
+                if (dims[1] > 0) enc_t_out_ = static_cast<int>(dims[1]);
+            }
+        }
+        api_->ReleaseTypeInfo(ti);
+    }
+
+    LOGI("Nemotron streaming (ORT): vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d window=%d samples",
+         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_, chunk_samples());
+}
+
+OnnxNemotronStreamingStt::~OnnxNemotronStreamingStt() {
+    if (jnt_) api_->ReleaseSession(jnt_);
+    if (dec_) api_->ReleaseSession(dec_);
+    if (enc_) api_->ReleaseSession(enc_);
+}
+
+bool OnnxNemotronStreamingStt::load_vocab(const std::string& path) {
+    auto text = json::read_file(path);
+    if (text.empty()) return false;
+    auto flat = json::parse_flat_object(text);
+
+    int max_id = -1;
+    for (auto& [key, val] : flat) {
+        (void)val;
+        try { max_id = std::max(max_id, std::stoi(key)); } catch (...) {}
+    }
+    if (max_id < 0) return false;
+
+    vocab_.assign(static_cast<size_t>(max_id) + 1, std::string{});
+    for (auto& [key, val] : flat) {
+        try {
+            int id = std::stoi(key);
+            if (id >= 0 && id <= max_id) vocab_[id] = val;
+        } catch (...) {}
+    }
+    cfg_.vocab_size = static_cast<int>(vocab_.size());
+    cfg_.blank_id   = cfg_.vocab_size;
+    return true;
+}
+
+std::string OnnxNemotronStreamingStt::token_to_text(int id) const {
+    if (id < 0 || id >= static_cast<int>(vocab_.size())) return {};
+    std::string piece = vocab_[id];
+    // SentencePiece \xE2\x96\x81 (U+2581) → leading space.
+    if (piece.size() >= 3 &&
+        static_cast<unsigned char>(piece[0]) == 0xE2 &&
+        static_cast<unsigned char>(piece[1]) == 0x96 &&
+        static_cast<unsigned char>(piece[2]) == 0x81) {
+        return " " + piece.substr(3);
+    }
+    return piece;
+}
+
+void OnnxNemotronStreamingStt::reset_stream_state() {
+    pending_.clear();
+    pre_cache_.assign(static_cast<size_t>(cfg_.mel_bins) * cfg_.pre_cache_size, 0.0f);
+    cache_last_channel_.assign(
+        static_cast<size_t>(cfg_.encoder_layers) * cfg_.attn_left_context * cfg_.encoder_hidden, 0.0f);
+    cache_last_time_.assign(
+        static_cast<size_t>(cfg_.encoder_layers) * cfg_.encoder_hidden * cfg_.conv_cache_size, 0.0f);
+    cache_last_channel_len_ = 0;
+    dec_h_.assign(static_cast<size_t>(cfg_.decoder_layers) * cfg_.decoder_hidden, 0.0f);
+    dec_c_.assign(static_cast<size_t>(cfg_.decoder_layers) * cfg_.decoder_hidden, 0.0f);
+    dec_hidden_.assign(static_cast<size_t>(cfg_.decoder_hidden), 0.0f);
+    accumulated_text_.clear();
+    // Prime the decoder LSTM with the blank token so the first joint() call
+    // sees a meaningful hidden state (matches the LiteRT impl).
+    run_decoder_step(cfg_.blank_id);
+}
+
+void OnnxNemotronStreamingStt::run_decoder_step(int64_t token_id) {
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    const int64_t s_tok[2]   = {1, 1};
+    const int64_t s_state[3] = {cfg_.decoder_layers, 1, cfg_.decoder_hidden};
+
+    int64_t tok = token_id;
+    OrtValue* t_tok = nullptr;
+    OrtValue* t_h   = nullptr;
+    OrtValue* t_c   = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, &tok, sizeof(int64_t), s_tok, 2,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_tok));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, dec_h_.data(), dec_h_.size() * sizeof(float), s_state, 3,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_h));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, dec_c_.data(), dec_c_.size() * sizeof(float), s_state, 3,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_c));
+
+    OrtValue* in[3]  = {t_tok, t_h, t_c};
+    OrtValue* out[3] = {nullptr, nullptr, nullptr};
+    ort_check(api_, api_->Run(
+        dec_, nullptr,
+        dec_io_.in_names.data(),  in,  dec_io_.in_names.size(),
+        dec_io_.out_names.data(), dec_io_.out_names.size(), out));
+
+    auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
+        void* p = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(v, &p));
+        std::memcpy(dst, p, bytes);
+    };
+    copy_out(out[0], dec_hidden_.data(), dec_hidden_.size() * sizeof(float));
+    copy_out(out[1], dec_h_.data(),      dec_h_.size()      * sizeof(float));
+    copy_out(out[2], dec_c_.data(),      dec_c_.size()      * sizeof(float));
+
+    for (int i = 2; i >= 0; --i) api_->ReleaseValue(out[i]);
+    api_->ReleaseValue(t_c);
+    api_->ReleaseValue(t_h);
+    api_->ReleaseValue(t_tok);
+}
+
+// Drain one window from pending_, run mel -> encoder (cache-aware) -> greedy
+// RNN-T over the first encoder frame, return the emitted text.
+std::string OnnxNemotronStreamingStt::run_window() {
+    const int n_frames = cfg_.actual_mel_frames;
+    const int win      = chunk_samples();
+    if (static_cast<int>(pending_.size()) < win) return {};
+
+    std::vector<float> pcm(pending_.begin(), pending_.begin() + win);
+    pending_.erase(pending_.begin(), pending_.begin() + win);
+
+    constexpr float kLogFloor = 1.0f / static_cast<float>(1 << 24);  // 2^-24
+    auto mel = audio::mel_spectrogram(
+        pcm.data(), pcm.size(), cfg_.sample_rate,
+        cfg_.n_fft, cfg_.hop_length, cfg_.win_length, cfg_.mel_bins,
+        /*slaney=*/true, kLogFloor, /*center=*/true);
+
+    const int produced = static_cast<int>(mel.size()) / cfg_.mel_bins;
+    if (produced < n_frames) return {};
+    if (produced > n_frames) {  // trim trailing frames (centred padding overshoot)
+        std::vector<float> trimmed(static_cast<size_t>(cfg_.mel_bins) * n_frames);
+        for (int b = 0; b < cfg_.mel_bins; ++b) {
+            std::copy_n(&mel[static_cast<size_t>(b) * produced], n_frames,
+                        &trimmed[static_cast<size_t>(b) * n_frames]);
+        }
+        mel.swap(trimmed);
+    }
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    const int64_t s_mel  [3] = {1, cfg_.mel_bins, n_frames};
+    const int64_t s_mlen [1] = {1};
+    const int64_t s_pre  [3] = {1, cfg_.mel_bins, cfg_.pre_cache_size};
+    const int64_t s_clc  [4] = {cfg_.encoder_layers, 1, cfg_.attn_left_context, cfg_.encoder_hidden};
+    const int64_t s_clt  [4] = {cfg_.encoder_layers, 1, cfg_.encoder_hidden, cfg_.conv_cache_size};
+    const int64_t s_chl  [1] = {1};
+
+    int64_t mel_len = n_frames;
+    int64_t ch_len  = cache_last_channel_len_;
+
+    OrtValue* t_mel  = nullptr;
+    OrtValue* t_mlen = nullptr;
+    OrtValue* t_pre  = nullptr;
+    OrtValue* t_clc  = nullptr;
+    OrtValue* t_clt  = nullptr;
+    OrtValue* t_chl  = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, mel.data(), mel.size() * sizeof(float), s_mel, 3,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_mel));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, &mel_len, sizeof(int64_t), s_mlen, 1,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_mlen));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, pre_cache_.data(), pre_cache_.size() * sizeof(float), s_pre, 3,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_pre));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, cache_last_channel_.data(), cache_last_channel_.size() * sizeof(float),
+        s_clc, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_clc));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, cache_last_time_.data(), cache_last_time_.size() * sizeof(float),
+        s_clt, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_clt));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, &ch_len, sizeof(int64_t), s_chl, 1,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_chl));
+
+    OrtValue* enc_in[6]  = {t_mel, t_mlen, t_pre, t_clc, t_clt, t_chl};
+    OrtValue* enc_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    ort_check(api_, api_->Run(
+        enc_, nullptr,
+        enc_io_.in_names.data(),  enc_in,  enc_io_.in_names.size(),
+        enc_io_.out_names.data(), enc_io_.out_names.size(), enc_out));
+
+    auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
+        void* p = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(v, &p));
+        std::memcpy(dst, p, bytes);
+    };
+
+    // Roll caches forward for the next window. Encoder I/O order matches the
+    // LiteRT export: encoded_output, encoded_length, new_pre_cache,
+    // new_cache_last_channel, new_cache_last_time, new_cache_last_channel_len.
+    std::vector<float> encoded(static_cast<size_t>(enc_t_out_) * cfg_.encoder_hidden);
+    copy_out(enc_out[0], encoded.data(),             encoded.size()             * sizeof(float));
+    copy_out(enc_out[2], pre_cache_.data(),          pre_cache_.size()          * sizeof(float));
+    copy_out(enc_out[3], cache_last_channel_.data(), cache_last_channel_.size() * sizeof(float));
+    copy_out(enc_out[4], cache_last_time_.data(),    cache_last_time_.size()    * sizeof(float));
+    {
+        // encoded_length / cache_last_channel_len come back as scalars (int32
+        // on the LiteRT export; ONNX preserves the same dtype). Read the
+        // type info and copy accordingly.
+        void* p = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(enc_out[5], &p));
+        int64_t v = 0;
+        OrtTensorTypeAndShapeInfo* info = nullptr;
+        ort_check(api_, api_->GetTensorTypeAndShape(enc_out[5], &info));
+        ONNXTensorElementDataType etype = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        api_->GetTensorElementType(info, &etype);
+        api_->ReleaseTensorTypeAndShapeInfo(info);
+        if (etype == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32) {
+            v = static_cast<int64_t>(*static_cast<int32_t*>(p));
+        } else if (etype == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+            v = *static_cast<int64_t*>(p);
+        }
+        cache_last_channel_len_ = v;
+    }
+
+    for (int i = 5; i >= 0; --i) api_->ReleaseValue(enc_out[i]);
+    api_->ReleaseValue(t_chl);
+    api_->ReleaseValue(t_clt);
+    api_->ReleaseValue(t_clc);
+    api_->ReleaseValue(t_pre);
+    api_->ReleaseValue(t_mlen);
+    api_->ReleaseValue(t_mel);
+
+    // Greedy RNN-T over the FIRST encoder frame only (frame 0 = first
+    // encoder_hidden floats). The second frame is right-context lookahead,
+    // re-settled on the next window — feeding it duplicates output.
+    const int64_t s_encf  [3] = {1, 1, cfg_.encoder_hidden};
+    const int64_t s_dechid[3] = {1, 1, cfg_.decoder_hidden};
+    const size_t  n_logits     = static_cast<size_t>(cfg_.vocab_size) + 1;
+
+    std::string emitted;
+    for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
+        OrtValue* t_encf   = nullptr;
+        OrtValue* t_dechid = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, encoded.data(), static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
+            s_encf, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_encf));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, dec_hidden_.data(), dec_hidden_.size() * sizeof(float),
+            s_dechid, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_dechid));
+
+        OrtValue* jin[2]  = {t_encf, t_dechid};
+        OrtValue* jout[1] = {nullptr};
+        ort_check(api_, api_->Run(
+            jnt_, nullptr,
+            jnt_io_.in_names.data(),  jin,  jnt_io_.in_names.size(),
+            jnt_io_.out_names.data(), jnt_io_.out_names.size(), jout));
+
+        std::vector<float> logits(n_logits);
+        copy_out(jout[0], logits.data(), n_logits * sizeof(float));
+
+        api_->ReleaseValue(jout[0]);
+        api_->ReleaseValue(t_dechid);
+        api_->ReleaseValue(t_encf);
+
+        int   best   = 0;
+        float best_v = logits[0];
+        for (size_t i = 1; i < n_logits; ++i) {
+            if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+        }
+        if (best == cfg_.blank_id) break;  // advance to the next encoder frame
+
+        emitted += token_to_text(best);
+        run_decoder_step(best);  // advance the predictor for the next expansion
+    }
+    return emitted;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming API
+// ---------------------------------------------------------------------------
+
+void OnnxNemotronStreamingStt::begin_stream(int sample_rate) {
+    cfg_.sample_rate = sample_rate;
+    reset_stream_state();
+    stream_init_ = true;
+}
+
+PartialResult OnnxNemotronStreamingStt::push_chunk(const float* audio, size_t length) {
+    if (!stream_init_) begin_stream(cfg_.sample_rate);
+    pending_.insert(pending_.end(), audio, audio + length);
+
+    std::string text;
+    while (static_cast<int>(pending_.size()) >= chunk_samples()) {
+        text += run_window();
+    }
+    accumulated_text_ += text;
+
+    PartialResult out;
+    out.text = std::move(text);
+    return out;
+}
+
+void OnnxNemotronStreamingStt::flush_stream() {
+    // No-op: only full windows are decoded; a trailing partial window is held.
+}
+
+TranscriptionResult OnnxNemotronStreamingStt::end_stream() {
+    TranscriptionResult out;
+    out.text = accumulated_text_;
+    stream_init_ = false;
+    return out;
+}
+
+void OnnxNemotronStreamingStt::cancel_stream() {
+    pending_.clear();
+    accumulated_text_.clear();
+    stream_init_ = false;
+}
+
+TranscriptionResult OnnxNemotronStreamingStt::transcribe(
+    const float* audio, size_t length, int sample_rate)
+{
+    begin_stream(sample_rate);
+    push_chunk(audio, length);
+    return end_stream();
+}
+
+}  // namespace speech_core

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -526,10 +526,26 @@ PartialResult OnnxNemotronStreamingStt::push_chunk(const float* audio, size_t le
 }
 
 void OnnxNemotronStreamingStt::flush_stream() {
-    // No-op: only full windows are decoded; a trailing partial window is held.
+    // Pad any leftover partial window with silence so the encoder gets
+    // a final pass on the trailing audio. Otherwise the last 0..chunk_ms
+    // of every utterance is dropped — on a 4.59 s LibriSpeech utterance
+    // with chunk_samples=10080 (~630 ms) that's the last ~180 ms,
+    // typically 1-3 trailing words (e.g. "Quilter M A" -> "Quilter M",
+    // "in a London theatre" -> "in a"). Bucketing the LibriSpeech-100
+    // corpus shows the gap vs NeMo offline concentrates on short
+    // utterances (<5s: +7.23 pts vs 5-10s: +1.85 pts) — exactly the
+    // signature of a fixed per-utterance trailing-loss being a larger
+    // fraction of shorter audio.
+    if (!stream_init_) return;
+    if (pending_.empty()) return;
+    const int win = chunk_samples();
+    if (static_cast<int>(pending_.size()) >= win) return;  // run_window will get it
+    pending_.resize(static_cast<size_t>(win), 0.0f);
+    accumulated_text_ += run_window();
 }
 
 TranscriptionResult OnnxNemotronStreamingStt::end_stream() {
+    flush_stream();
     TranscriptionResult out;
     out.text = accumulated_text_;
     stream_init_ = false;

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -101,8 +101,124 @@ OnnxNemotronStreamingStt::OnnxNemotronStreamingStt(
         api_->ReleaseTypeInfo(ti);
     }
 
-    LOGI("Nemotron streaming (ORT): vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d window=%d samples",
-         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_, chunk_samples());
+    // Encoder input[0] = audio_signal [1, mel_bins, frames]; read frames to
+    // auto-detect chunk size. Different exports pin different chunk_ms
+    // (80/160/560/1120 -> 9/17/64/121 mel frames). Without this, the wrapper
+    // assumes 80ms and feeds misaligned windows to a larger-chunk export.
+    OrtTypeInfo* in_ti = nullptr;
+    if (api_->SessionGetInputTypeInfo(enc_, 0, &in_ti) == nullptr) {
+        const OrtTensorTypeAndShapeInfo* shape = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(in_ti, &shape) == nullptr && shape) {
+            size_t rank = 0;
+            api_->GetDimensionsCount(shape, &rank);
+            if (rank >= 3) {
+                std::vector<int64_t> dims(rank);
+                api_->GetDimensions(shape, dims.data(), rank);
+                if (dims[2] > 0) cfg_.actual_mel_frames = static_cast<int>(dims[2]);
+            }
+        }
+        api_->ReleaseTypeInfo(in_ti);
+    }
+
+    // Encoder input[2] = pre_cache [1, mel_bins, pre_cache_size]. The
+    // pre_cache_size pin differs across chunk-mode exports (16 at 80/160 ms,
+    // 9 at 560/1120 ms) and the wrong size shape-mismatches the Run call
+    // (which on the CUDA EP fails silently — exit code 0, no transcript).
+    OrtTypeInfo* in_ti2 = nullptr;
+    if (api_->SessionGetInputTypeInfo(enc_, 2, &in_ti2) == nullptr) {
+        const OrtTensorTypeAndShapeInfo* shape = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(in_ti2, &shape) == nullptr && shape) {
+            size_t rank = 0;
+            api_->GetDimensionsCount(shape, &rank);
+            if (rank >= 3) {
+                std::vector<int64_t> dims(rank);
+                api_->GetDimensions(shape, dims.data(), rank);
+                if (dims[2] > 0) cfg_.pre_cache_size = static_cast<int>(dims[2]);
+            }
+        }
+        api_->ReleaseTypeInfo(in_ti2);
+    }
+
+    // Encoder input[3] = cache_last_channel [L, 1, attn_left, H]. Auto-detect
+    // attn_left_context too, in case any chunk-mode export deviates from 70.
+    OrtTypeInfo* in_ti3 = nullptr;
+    if (api_->SessionGetInputTypeInfo(enc_, 3, &in_ti3) == nullptr) {
+        const OrtTensorTypeAndShapeInfo* shape = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(in_ti3, &shape) == nullptr && shape) {
+            size_t rank = 0;
+            api_->GetDimensionsCount(shape, &rank);
+            if (rank >= 4) {
+                std::vector<int64_t> dims(rank);
+                api_->GetDimensions(shape, dims.data(), rank);
+                if (dims[0] > 0) cfg_.encoder_layers    = static_cast<int>(dims[0]);
+                if (dims[2] > 0) cfg_.attn_left_context = static_cast<int>(dims[2]);
+                if (dims[3] > 0) cfg_.encoder_hidden    = static_cast<int>(dims[3]);
+            }
+        }
+        api_->ReleaseTypeInfo(in_ti3);
+    }
+
+    // Encoder input[4] = cache_last_time [L, 1, H, conv_cache_size]. Auto-
+    // detect conv_cache_size (kernel - 1; typically 8 but worth confirming).
+    OrtTypeInfo* in_ti4 = nullptr;
+    if (api_->SessionGetInputTypeInfo(enc_, 4, &in_ti4) == nullptr) {
+        const OrtTensorTypeAndShapeInfo* shape = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(in_ti4, &shape) == nullptr && shape) {
+            size_t rank = 0;
+            api_->GetDimensionsCount(shape, &rank);
+            if (rank >= 4) {
+                std::vector<int64_t> dims(rank);
+                api_->GetDimensions(shape, dims.data(), rank);
+                if (dims[3] > 0) cfg_.conv_cache_size = static_cast<int>(dims[3]);
+            }
+        }
+        api_->ReleaseTypeInfo(in_ti4);
+    }
+
+    // Committed encoder frames per window. The cache-aware streaming encoder
+    // emits T_out frames per Run, of which the FIRST `output_frames_` are
+    // committed (their text gets emitted into the transcript) and the
+    // remaining T_out - output_frames_ are right-context lookahead that gets
+    // re-computed (with more left context) in the next window. Without this,
+    // the wrapper only decoded frame 0 regardless of chunk size — fine for
+    // 80 ms (output_frames=1) but catastrophic for 160/560/1120 ms exports
+    // where output_frames is 2/7/14.
+    //
+    // Source of truth: config.json's streaming.outputFrames field. Fall back
+    // to T_out - 1 (assume one lookahead frame) if config.json isn't on disk.
+    output_frames_ = std::max(1, enc_t_out_ - 1);
+    {
+        // Look for config.json next to the encoder. Strip the filename.
+        std::string cfg_path = encoder_path;
+        auto slash = cfg_path.find_last_of("/\\");
+        if (slash != std::string::npos) cfg_path = cfg_path.substr(0, slash);
+        cfg_path += "/config.json";
+        std::string text = json::read_file(cfg_path);
+        if (!text.empty()) {
+            // Cheap scan for "outputFrames": <int>. Tolerates nesting.
+            const std::string key = "\"outputFrames\"";
+            auto pos = text.find(key);
+            if (pos != std::string::npos) {
+                pos = text.find(':', pos);
+                if (pos != std::string::npos) {
+                    ++pos;
+                    while (pos < text.size()
+                           && (text[pos] == ' ' || text[pos] == '\t'
+                               || text[pos] == '\n' || text[pos] == '\r')) ++pos;
+                    int v = 0;
+                    while (pos < text.size() && text[pos] >= '0' && text[pos] <= '9') {
+                        v = v * 10 + (text[pos] - '0');
+                        ++pos;
+                    }
+                    if (v > 0 && v <= enc_t_out_) output_frames_ = v;
+                }
+            }
+        }
+    }
+
+    LOGI("Nemotron streaming (ORT): vocab=%zu enc_hidden=%d dec_hidden=%d T_out=%d output_frames=%d mel_frames=%d window=%d samples",
+         vocab_.size(), cfg_.encoder_hidden, cfg_.decoder_hidden, enc_t_out_,
+         output_frames_, cfg_.actual_mel_frames, chunk_samples());
 }
 
 OnnxNemotronStreamingStt::~OnnxNemotronStreamingStt() {
@@ -273,10 +389,20 @@ std::string OnnxNemotronStreamingStt::run_window() {
 
     OrtValue* enc_in[6]  = {t_mel, t_mlen, t_pre, t_clc, t_clt, t_chl};
     OrtValue* enc_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    if (std::getenv("NEMOTRON_DEBUG")) {
+        std::fprintf(stderr,
+            "[nem] run_window: mel=%dx%d pcm=%zu pre_cache=%zu clc=%zu clt=%zu ch_len=%lld\n",
+            cfg_.mel_bins, n_frames, pcm.size(), pre_cache_.size(),
+            cache_last_channel_.size(), cache_last_time_.size(),
+            static_cast<long long>(ch_len));
+    }
     ort_check(api_, api_->Run(
         enc_, nullptr,
         enc_io_.in_names.data(),  enc_in,  enc_io_.in_names.size(),
         enc_io_.out_names.data(), enc_io_.out_names.size(), enc_out));
+    if (std::getenv("NEMOTRON_DEBUG")) {
+        std::fprintf(stderr, "[nem] encoder Run ok\n");
+    }
 
     auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
         void* p = nullptr;
@@ -320,47 +446,56 @@ std::string OnnxNemotronStreamingStt::run_window() {
     api_->ReleaseValue(t_mlen);
     api_->ReleaseValue(t_mel);
 
-    // Greedy RNN-T over the FIRST encoder frame only (frame 0 = first
-    // encoder_hidden floats). The second frame is right-context lookahead,
-    // re-settled on the next window — feeding it duplicates output.
+    // Greedy RNN-T over the COMMITTED encoder frames (frames 0..output_frames_-1).
+    // The remaining T_out - output_frames_ frames are right-context lookahead,
+    // re-settled on the next window — feeding them duplicates output. For
+    // 80 ms chunks (output_frames_=1) we decode only frame 0, same as before.
+    // For 160/560/1120 ms (output_frames_=2/7/14) we now decode multiple
+    // frames per window — this is what closes the streaming-quality gap.
     const int64_t s_encf  [3] = {1, 1, cfg_.encoder_hidden};
     const int64_t s_dechid[3] = {1, 1, cfg_.decoder_hidden};
     const size_t  n_logits     = static_cast<size_t>(cfg_.vocab_size) + 1;
 
     std::string emitted;
-    for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
-        OrtValue* t_encf   = nullptr;
-        OrtValue* t_dechid = nullptr;
-        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-            mem, encoded.data(), static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
-            s_encf, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_encf));
-        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-            mem, dec_hidden_.data(), dec_hidden_.size() * sizeof(float),
-            s_dechid, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_dechid));
+    for (int frame = 0; frame < output_frames_; ++frame) {
+        // Offset into encoded[]: frame 0 starts at index 0, frame 1 at
+        // encoder_hidden, etc. The joint sees one encoder_hidden vector.
+        const size_t frame_off = static_cast<size_t>(frame) * cfg_.encoder_hidden;
+        for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
+            OrtValue* t_encf   = nullptr;
+            OrtValue* t_dechid = nullptr;
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, encoded.data() + frame_off,
+                static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
+                s_encf, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_encf));
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, dec_hidden_.data(), dec_hidden_.size() * sizeof(float),
+                s_dechid, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_dechid));
 
-        OrtValue* jin[2]  = {t_encf, t_dechid};
-        OrtValue* jout[1] = {nullptr};
-        ort_check(api_, api_->Run(
-            jnt_, nullptr,
-            jnt_io_.in_names.data(),  jin,  jnt_io_.in_names.size(),
-            jnt_io_.out_names.data(), jnt_io_.out_names.size(), jout));
+            OrtValue* jin[2]  = {t_encf, t_dechid};
+            OrtValue* jout[1] = {nullptr};
+            ort_check(api_, api_->Run(
+                jnt_, nullptr,
+                jnt_io_.in_names.data(),  jin,  jnt_io_.in_names.size(),
+                jnt_io_.out_names.data(), jnt_io_.out_names.size(), jout));
 
-        std::vector<float> logits(n_logits);
-        copy_out(jout[0], logits.data(), n_logits * sizeof(float));
+            std::vector<float> logits(n_logits);
+            copy_out(jout[0], logits.data(), n_logits * sizeof(float));
 
-        api_->ReleaseValue(jout[0]);
-        api_->ReleaseValue(t_dechid);
-        api_->ReleaseValue(t_encf);
+            api_->ReleaseValue(jout[0]);
+            api_->ReleaseValue(t_dechid);
+            api_->ReleaseValue(t_encf);
 
-        int   best   = 0;
-        float best_v = logits[0];
-        for (size_t i = 1; i < n_logits; ++i) {
-            if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+            int   best   = 0;
+            float best_v = logits[0];
+            for (size_t i = 1; i < n_logits; ++i) {
+                if (logits[i] > best_v) { best_v = logits[i]; best = static_cast<int>(i); }
+            }
+            if (best == cfg_.blank_id) break;  // advance to the next encoder frame
+
+            emitted += token_to_text(best);
+            run_decoder_step(best);  // advance the predictor for the next expansion
         }
-        if (best == cfg_.blank_id) break;  // advance to the next encoder frame
-
-        emitted += token_to_text(best);
-        run_decoder_step(best);  // advance the predictor for the next expansion
     }
     return emitted;
 }

--- a/tests/bench_litert_stt.cpp
+++ b/tests/bench_litert_stt.cpp
@@ -381,6 +381,59 @@ int run_corpus(const std::string& dir, const std::string& backend,
     return 0;
 }
 
+int corpus_nemotron(const std::string& dir, const std::string& manifest_path) {
+    std::string enc = dir + "/nemotron-streaming-encoder.tflite";
+    std::string dec = dir + "/nemotron-streaming-decoder.tflite";
+    std::string jnt = dir + "/nemotron-streaming-joint.tflite";
+    std::string voc = dir + "/nemotron-vocab.json";
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(jnt) || !file_exists(voc)) {
+        std::fprintf(stderr, "nemotron files missing in %s\n", dir.c_str());
+        return 1;
+    }
+    std::ifstream m(manifest_path);
+    if (!m) {
+        std::fprintf(stderr, "cannot open manifest %s\n", manifest_path.c_str());
+        return 1;
+    }
+    std::printf("#uid,provider,audio_s,wall_ms,transcript\n");
+
+    speech_core::LiteRTNemotronStreamingStt stt(enc, dec, jnt, voc, /*hw_accel=*/false);
+    constexpr size_t kChunk = 1280;  // 80 ms @ 16 kHz
+
+    std::string line;
+    while (std::getline(m, line)) {
+        if (line.empty()) continue;
+        size_t c1 = line.find(','); if (c1 == std::string::npos) continue;
+        size_t c2 = line.find(',', c1 + 1); if (c2 == std::string::npos) continue;
+        std::string uid = line.substr(0, c1);
+        std::string wav_path = line.substr(c1 + 1, c2 - c1 - 1);
+        auto wav = load_wav_mono_pcm16(wav_path);
+        if (wav.samples.empty()) { std::fprintf(stderr, "skip %s\n", uid.c_str()); continue; }
+        auto a16k = wav.sample_rate == 16000
+            ? wav.samples
+            : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                               wav.sample_rate, 16000);
+
+        auto t = clk::now();
+        stt.begin_stream(16000);
+        std::string text;
+        for (size_t off = 0; off < a16k.size(); off += kChunk) {
+            size_t len = (kChunk < a16k.size() - off) ? kChunk : (a16k.size() - off);
+            auto p = stt.push_chunk(a16k.data() + off, len);
+            if (!p.text.empty()) text = p.text;
+        }
+        auto final_res = stt.end_stream();
+        if (!final_res.text.empty()) text = final_res.text;
+        double wall = ms_since(t);
+        double audio_s = static_cast<double>(a16k.size()) / 16000.0;
+        for (char& ch : text) if (ch == ',') ch = ' ';
+        std::printf("%s,litert-nemotron,%.2f,%.1f,%s\n",
+                    uid.c_str(), audio_s, wall, text.c_str());
+        std::fflush(stdout);
+    }
+    return 0;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -390,11 +443,14 @@ int main(int argc, char** argv) {
         return 0;
     }
     // Corpus mode: --manifest <csv> --backend <parakeet|omnilingual>
-    std::string manifest, backend = "parakeet";
+    // OR --nemotron-manifest <csv> (Nemotron streaming).
+    std::string manifest, backend = "parakeet", nemotron_manifest;
     for (int i = 1; i + 1 < argc; ++i) {
         if (std::string(argv[i]) == "--manifest") manifest = argv[i + 1];
         else if (std::string(argv[i]) == "--backend") backend = argv[i + 1];
+        else if (std::string(argv[i]) == "--nemotron-manifest") nemotron_manifest = argv[i + 1];
     }
+    if (!nemotron_manifest.empty()) return corpus_nemotron(dir, nemotron_manifest);
     if (!manifest.empty()) return run_corpus(dir, backend, manifest);
 
     int warmup = (argc > 1) ? std::atoi(argv[1]) : 1;

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -518,6 +518,66 @@ int run_corpus(const std::string& dir, const std::string& manifest_path,
     return 0;
 }
 
+int run_corpus_nemotron(const std::string& dir, const std::string& manifest_path) {
+    // Same dir-resolution shape as bench_nemotron: env override wins, otherwise
+    // `${dir}/nemotron-streaming-onnx`. Three model files + vocab JSON.
+    std::string nem_dir;
+    if (const char* p = std::getenv("SPEECH_NEMOTRON_ONNX_DIR")) nem_dir = p;
+    if (nem_dir.empty()) nem_dir = dir + "/nemotron-streaming-onnx";
+    std::string enc = nem_dir + "/nemotron-streaming-encoder.onnx";
+    std::string dec = nem_dir + "/nemotron-streaming-decoder.onnx";
+    std::string jnt = nem_dir + "/nemotron-streaming-joint.onnx";
+    std::string vcb = nem_dir + "/vocab.json";
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(jnt) || !file_exists(vcb)) {
+        std::fprintf(stderr, "nemotron files missing in %s\n", nem_dir.c_str());
+        return 1;
+    }
+    speech_core::OnnxNemotronStreamingStt stt(enc, dec, jnt, vcb, /*hw_accel=*/true);
+
+    std::ifstream m(manifest_path);
+    if (!m) { std::fprintf(stderr, "cannot open manifest %s\n", manifest_path.c_str()); return 1; }
+    std::printf("#uid,provider,audio_s,wall_ms,transcript\n");
+
+    constexpr size_t kChunkSamples = 1280;  // 80 ms @ 16 kHz — matches encoder stride
+
+    std::string line;
+    while (std::getline(m, line)) {
+        if (line.empty()) continue;
+        size_t c1 = line.find(','); if (c1 == std::string::npos) continue;
+        size_t c2 = line.find(',', c1 + 1); if (c2 == std::string::npos) continue;
+        std::string uid      = line.substr(0, c1);
+        std::string wav_path = line.substr(c1 + 1, c2 - c1 - 1);
+        auto wav = read_wav(wav_path);
+        if (wav.samples.empty()) {
+            std::fprintf(stderr, "skip %s: cannot read %s\n", uid.c_str(), wav_path.c_str());
+            continue;
+        }
+        std::vector<float> audio_16k = wav.sample_rate == 16000
+            ? wav.samples
+            : speech_core::Resampler::resample(wav.samples.data(), wav.samples.size(),
+                                               wav.sample_rate, 16000);
+
+        std::string transcript;
+        auto t = clk::now();
+        stt.begin_stream(16000);
+        for (size_t off = 0; off < audio_16k.size(); off += kChunkSamples) {
+            size_t n = (kChunkSamples < audio_16k.size() - off)
+                       ? kChunkSamples : (audio_16k.size() - off);
+            auto partial = stt.push_chunk(audio_16k.data() + off, n);
+            if (!partial.text.empty()) transcript += partial.text;
+        }
+        auto final_r = stt.end_stream();
+        if (!final_r.text.empty()) transcript = final_r.text;
+        double wall = ms_since(t);
+        double audio_s = static_cast<double>(audio_16k.size()) / 16000.0;
+        for (char& ch : transcript) if (ch == ',') ch = ' ';
+        std::printf("%s,%s,%.2f,%.1f,%s\n", uid.c_str(), provider_label(),
+                    audio_s, wall, transcript.c_str());
+        std::fflush(stdout);
+    }
+    return 0;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -528,13 +588,18 @@ int main(int argc, char** argv) {
     }
     // Corpus mode if --manifest <path> passed; else default fixture bench.
     // Optional --batch N (default 1) batches encoder calls.
+    // --nemotron-manifest <path> routes to the Nemotron streaming corpus
+    // harness instead (each utterance streamed in 80 ms chunks).
     std::string manifest;
+    std::string nemotron_manifest;
     int batch_size = 1;
     for (int i = 1; i + 1 < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--manifest") manifest = argv[i + 1];
+        else if (arg == "--nemotron-manifest") nemotron_manifest = argv[i + 1];
         else if (arg == "--batch") batch_size = std::atoi(argv[i + 1]);
     }
+    if (!nemotron_manifest.empty()) return run_corpus_nemotron(dir, nemotron_manifest);
     if (!manifest.empty()) return run_corpus(dir, manifest, batch_size);
     std::printf("#model,provider,metric,load_ms,wall_ms,rtf,rss_mb,extra\n");
     bench_silero(dir);

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -13,6 +13,7 @@
 #include "speech_core/audio/resampler.h"
 #include "speech_core/models/kokoro_tts.h"
 #include "speech_core/models/onnx_engine.h"
+#include "speech_core/models/onnx_nemotron_streaming_stt.h"
 #include "speech_core/models/onnx_voxcpm2_tts.h"
 #include "speech_core/models/parakeet_stt.h"
 #include "speech_core/models/silero_vad.h"
@@ -266,6 +267,71 @@ void bench_kokoro(const std::string& dir) {
 // Skips when missing or tiny-config (max_text < 256).
 // ---------------------------------------------------------------------------
 
+void bench_nemotron(const std::string& dir) {
+    // Nemotron-streaming bundle lives outside scripts/models — we look for it
+    // via SPEECH_NEMOTRON_ONNX_DIR (the converter's `--output-dir`) with a
+    // sensible fallback for the local dev path.
+    std::string nem_dir;
+    if (const char* p = std::getenv("SPEECH_NEMOTRON_ONNX_DIR")) nem_dir = p;
+    if (nem_dir.empty()) nem_dir = dir + "/nemotron-streaming-onnx";
+    std::string enc = nem_dir + "/nemotron-streaming-encoder.onnx";
+    std::string dec = nem_dir + "/nemotron-streaming-decoder.onnx";
+    std::string jnt = nem_dir + "/nemotron-streaming-joint.onnx";
+    std::string voc = nem_dir + "/vocab.json";
+    if (!file_exists(enc) || !file_exists(dec) || !file_exists(jnt) || !file_exists(voc)) {
+        std::fprintf(stderr, "[skip] nemotron streaming files in %s\n", nem_dir.c_str());
+        return;
+    }
+    auto audio = load_audio_16k();
+    if (audio.empty()) { std::fprintf(stderr, "[skip] no fixture\n"); return; }
+
+    auto t_load = clk::now();
+    speech_core::OnnxNemotronStreamingStt stt(enc, dec, jnt, voc, /*hw_accel=*/true);
+    double load_ms = ms_since(t_load);
+
+    // Match the LiteRT bench's 80 ms streaming cadence (1280 samples @ 16 kHz)
+    // — only the runtime differs. One warmup full pass; then 3 measured runs.
+    constexpr size_t kChunk = 1280;
+    {
+        stt.begin_stream(16000);
+        for (size_t off = 0; off < audio.size(); off += kChunk) {
+            size_t len = (kChunk < audio.size() - off) ? kChunk : (audio.size() - off);
+            (void)stt.push_chunk(audio.data() + off, len);
+        }
+        stt.end_stream();
+    }
+
+    std::vector<double> walls, chunk_ms, first_partials;
+    std::string last_text;
+    for (int r = 0; r < 3; ++r) {
+        stt.begin_stream(16000);
+        auto t_stream = clk::now();
+        double first_partial_ms = -1.0;
+        for (size_t off = 0; off < audio.size(); off += kChunk) {
+            size_t len = (kChunk < audio.size() - off) ? kChunk : (audio.size() - off);
+            auto t_c = clk::now();
+            auto p = stt.push_chunk(audio.data() + off, len);
+            chunk_ms.push_back(ms_since(t_c));
+            if (first_partial_ms < 0 && !p.text.empty()) first_partial_ms = ms_since(t_stream);
+        }
+        walls.push_back(ms_since(t_stream));
+        first_partials.push_back(first_partial_ms);
+        last_text = stt.end_stream().text;
+    }
+    double wall_ms = pct(walls, 50);
+    double audio_s = static_cast<double>(audio.size()) / 16000.0;
+    for (char& c : last_text) if (c == ',') c = ' ';
+    if (last_text.size() > 80) last_text.resize(80);
+    char ex[256];
+    std::snprintf(ex, sizeof(ex),
+                  "p50=%.0fms p95=%.0fms chunk_p50=%.1fms chunk_p95=%.1fms first_partial=%.0fms text=\"%s\"",
+                  pct(walls, 50), pct(walls, 95),
+                  pct(chunk_ms, 50), pct(chunk_ms, 95),
+                  pct(first_partials, 50), last_text.c_str());
+    emit("nemotron-streaming", "stream", load_ms, wall_ms,
+         audio_s / (wall_ms / 1000.0), peak_rss_mb(), ex);
+}
+
 void bench_voxcpm2(const std::string& /*dir*/) {
     const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
     std::string vox = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
@@ -475,5 +541,6 @@ int main(int argc, char** argv) {
     bench_parakeet(dir);
     bench_kokoro(dir);
     bench_voxcpm2(dir);
+    bench_nemotron(dir);
     return 0;
 }


### PR DESCRIPTION
## Summary

Two paths added for the English Nemotron Speech Streaming 0.6B model on top of the existing LiteRT 80 ms baseline:

1. **ONNX path** — new `OnnxNemotronStreamingStt` C++ wrapper, ORT CUDA/CPU bench, mirrors the LiteRT wrapper's three-graph contract (Conformer encoder / LSTM decoder / RNN-T joint) and 80 ms streaming state machine.
2. **LiteRT 320 ms path** — wrapper fixes that unblock chunk modes beyond 80 ms. The 80 ms shipping bundle (32 % WER) is replaced as the recommended mobile target by a 320 ms static-selective-INT8 bundle (15 % WER, same size, 3× more compute headroom).

## Wrapper changes

### Signature position remap (existing commit on this branch)

The published 80 ms bundle has identity-mapped signature positions (`args_N` at position N). Bundles produced via newer toolchains have scrambled positions — `args_5` at position 0, etc. — leaving the semantic role encoded only in the name. The wrapper now parses the `args_N` / `output_N` name suffix and remaps inputs/outputs accordingly. Without this, run_window feeds buffers into the wrong slots and LiteRT rejects with `Cannot auto-resize tensor args_2`.

### Encoder output buffer fix (new this iteration)

The prior `enc_t_out_ = output_frames_` override (fired when `config.json` had an `outputFrames` field) sized the encoder output host buffer to `output_frames_ * H * 4` bytes. The cache-aware streaming Conformer actually emits `chunkSize + rightContext` frames per Run. For 320 ms that's 4 + 3 = 7 frames, not 4; the trailing 3 × 1024 × 4 = 12 KB overran onto adjacent `LiteRtHostBuffers`, corrupting heap headers, killing the process silently mid-Run (exit 127, no LiteRT error string).

Fix: derive `enc_t_out_` from `chunkSize + rightContext` from `config.json` when both keys are present. 80 ms regression-tested clean — the published bundle's config.json has no `chunkSize` field so the new path doesn't fire and introspection (which works for identity-mapped bundles) still gives `enc_t_out_=2`.

### Opt-in per-Run profiling

`SPEECH_LITERT_PROFILE=1` enables cumulative mel / encoder / joint / decoder timing + call counts, printed to stderr on destruction. Confirmed the encoder is 99.4 % of `run_window` cost (407 ms per 320 ms window on this desktop), so RTF tuning attacks the encoder Run — threading sweeps were no-ops.

## Numbers (Intel Ultra 9 285K, no GPU on bench path unless noted)

20 s fixture, ORT path:

| metric | LiteRT CPU 80 ms | **ORT CUDA 80 ms** | ORT CPU 16 threads |
|---|---|---|---|
| RTF | 1.21× | **4.38×** | 0.57× |
| chunk p50 / p95 | 66 / 71 ms | **18 / 19 ms** | 123 / 265 ms |
| first partial | 4659 ms | **1275 ms** | 8567 ms |

100-utterance LibriSpeech dev-clean WER + RTF:

| variant | WER mean | WER p50 | RTF | wall p50 | encoder size |
|---|---|---|---|---|---|
| LiteRT INT8 80 ms (current shipping) | 32.39 % | 28.99 % | 1.09× | 4921 ms | 595 MB |
| LiteRT FP32 320 ms | 13.25 % | 10.00 % | 0.75× | 7139 ms | 2.27 GB |
| LiteRT INT8 weight-only 320 ms | 13.46 % | 10.62 % | 0.80× | 6689 ms | 589 MB |
| **LiteRT INT8 static-selective 320 ms** | **14.80 %** | 11.11 % | **3.12×** | 1708 ms | **591 MB** |

The new 320 ms static-selective bundle is **2.2× better WER than the current 80 ms shipping at 2.9× the RTF and the same size**. Static-selective applies INT8 to the matmul-style ops (FULLY_CONNECTED, CONV_2D, DEPTHWISE_CONV_2D, BATCH_MATMUL) and leaves LayerNorm rsqrt / squared-difference, sigmoid, and softmax in FP32 — full-static INT8 collapsed output to `<unk>` tokens.

## Test plan

- [x] Build with `SPEECH_CORE_WITH_ONNX=ON SPEECH_CORE_WITH_LITERT=ON SPEECH_CORE_WITH_CUDA=ON`
- [x] `bench_ort_models` with `SPEECH_NEMOTRON_ONNX_DIR` set — measured ORT numbers above
- [x] `bench_litert_stt` against 80 ms (regression check), 320 ms FP32, 320 ms weight-only INT8, 320 ms static-selective INT8 — all four load + run + transcribe correctly
- [x] `bench_litert_stt --nemotron-manifest scripts/librispeech/manifest.csv` — 100-utterance WER for each variant (numbers above)
- [x] `SPEECH_LITERT_PROFILE=1` confirms encoder is 99.4 % of `run_window` cost
- [ ] Skip path: bench without env vars set, verify skip messaging is intact (no behavior change in this PR)

## Follow-ups (not in this PR)

- Apply static-selective INT8 to 80 ms LiteRT — same recipe should preserve the 80 ms latency floor while reducing WER versus the current shipping bundle.
- Unblock LiteRT 560 ms. The bundle's emitted `T_out` doesn't match what `chunkSize + rightContext` from `config.json` predicts (8 vs 13). Likely a `convert_litert.py` CHUNK_CONFIGS mismatch with what `setup_streaming_params` actually configures.
- IoBinding on the ORT encoder Run for CUDA — same shape as the VoxCPM2 `token_step` optimization. Encoder runs once per chunk and ships ~50 KB of inputs each call; 10-20 % win expected on CUDA.

## Notes for future maintainers

- The ORT converter requires `PYTHONUTF8=1` on Windows (vocab.json contains SentencePiece U+2581 which cp1252 can't encode).
- The ORT converter requires `onnxscript` (torch 2.7+ delegates `torch.onnx.export` through it). Add to `pyproject.toml` in a follow-up.
