### PR TITLE
feat: optional libcurl Hugging Face model downloader for VoxCPM2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,17 @@ option(SPEECH_CORE_BUILD_TESTS "Build tests" ON)
 option(SPEECH_CORE_WITH_ONNX "Build the speech_core_models target with ONNX Runtime reference implementations (Silero VAD, Parakeet STT, Kokoro TTS, DeepFilter)" OFF)
 option(SPEECH_CORE_WITH_CUDA "Enable NVIDIA GPU execution providers (CUDA / TensorRT) in the ONNX engine. Requires SPEECH_CORE_WITH_ONNX=ON and ORT_DIR pointing at a GPU-enabled ONNX Runtime (onnxruntime-gpu). Selection is further gated at runtime by env SPEECH_CORE_ORT_PROVIDER and provider availability, with automatic CPU fallback." OFF)
 option(SPEECH_CORE_WITH_LITERT "Build the speech_core_models_litert target with LiteRT (TFLite) reference implementations (Silero VAD, Parakeet STT)" OFF)
+option(SPEECH_CORE_WITH_HF_DOWNLOAD "Enable libcurl-backed Hugging Face model downloads (sc_voxcpm2_create_from_pretrained: resumable, retried first-run fetch of the LiteRT bundle). Requires SPEECH_CORE_WITH_LITERT=ON and libcurl (find_package(CURL))." OFF)
 option(SPEECH_CORE_BUILD_EXAMPLES "Build examples/ (Linux C ABI lib, ALSA demo, CLI tools, integration tests). Requires SPEECH_CORE_WITH_ONNX=ON." OFF)
 
 if(SPEECH_CORE_WITH_CUDA AND NOT SPEECH_CORE_WITH_ONNX)
     message(FATAL_ERROR "SPEECH_CORE_WITH_CUDA=ON requires SPEECH_CORE_WITH_ONNX=ON "
                         "(CUDA / TensorRT EPs are ONNX-Runtime-only; LiteRT cannot use CUDA).")
+endif()
+
+if(SPEECH_CORE_WITH_HF_DOWNLOAD AND NOT SPEECH_CORE_WITH_LITERT)
+    message(FATAL_ERROR "SPEECH_CORE_WITH_HF_DOWNLOAD=ON requires SPEECH_CORE_WITH_LITERT=ON "
+                        "(the download feature fetches the LiteRT VoxCPM2 bundle).")
 endif()
 
 # ---------------------------------------------------------------------------
@@ -195,6 +201,7 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/litert_parakeet_stt.cpp
         src/models/litert/litert_voxcpm2_tts.cpp
         src/models/litert/voxcpm2_c.cpp
+        src/models/litert/hf_download.cpp
         src/models/litert/voxcpm2_tokenizer.cpp
         src/models/litert/litert_wespeaker_embedding.cpp
         src/models/litert/litert_pyannote_segmentation.cpp
@@ -223,6 +230,16 @@ if(SPEECH_CORE_WITH_LITERT)
 
     target_link_libraries(speech_core_models_litert PUBLIC speech_core litert)
 
+    # Optional first-run model download (sc_voxcpm2_create_from_pretrained).
+    # libcurl provides resumable HTTPS with an OS-native TLS backend (Schannel
+    # on Windows, Secure Transport / OpenSSL elsewhere). PRIVATE: the C ABI
+    # hides curl entirely, so downstreams don't need libcurl headers.
+    if(SPEECH_CORE_WITH_HF_DOWNLOAD)
+        find_package(CURL REQUIRED)
+        target_link_libraries(speech_core_models_litert PRIVATE CURL::libcurl)
+        target_compile_definitions(speech_core_models_litert PRIVATE SPEECH_CORE_WITH_HF_DOWNLOAD)
+    endif()
+
     # VoxCPM2 voice-cloning CLI — desktop only (skipped on Android/embedded
     # consumers that link the library but don't want an executable target).
     if(NOT ANDROID)
@@ -230,6 +247,18 @@ if(SPEECH_CORE_WITH_LITERT)
         target_link_libraries(speech_voxcpm2_clone PRIVATE speech_core_models_litert)
         if(MSVC)
             target_compile_definitions(speech_voxcpm2_clone PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+    endif()
+
+    # Debug CLI for the HF downloader (resume/retry testing). Links the internal
+    # hf_download header directly; libcurl rides in via speech_core_models_litert.
+    if(SPEECH_CORE_WITH_HF_DOWNLOAD AND NOT ANDROID)
+        add_executable(hf_fetch examples/litert/hf_fetch.cpp)
+        target_link_libraries(hf_fetch PRIVATE speech_core_models_litert)
+        target_include_directories(hf_fetch PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/litert)
+        if(MSVC)
+            target_compile_definitions(hf_fetch PRIVATE _USE_MATH_DEFINES NOMINMAX _CRT_SECURE_NO_WARNINGS)
         endif()
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$PWD/build/litert && cm
 
 LiteRT headers are vendored in `third_party/litert/` (no setup). `LITERT_DIR` points at the directory holding `libLiteRt.{so,dylib,dll}` (Windows also needs `LiteRt.lib`). Add `-DSPEECH_CORE_BUILD_EXAMPLES=ON` for the Linux CLI demos (`speech_transcribe`, `speech_synthesize`, …) — see [`examples/linux`](examples/linux). A voice-cloning CLI (`speech_voxcpm2_clone`) is built automatically whenever `SPEECH_CORE_WITH_LITERT=ON` — see [`examples/litert`](examples/litert).
 
+**On-device model download (optional).** Add `-DSPEECH_CORE_WITH_HF_DOWNLOAD=ON` to fetch model bundles from Hugging Face on first use instead of provisioning them by hand. It links libcurl (`find_package(CURL)` — system libcurl on Linux/macOS, vcpkg on Windows) and adds `sc_voxcpm2_create_from_pretrained("soniqo/VoxCPM2-LiteRT", …)` to the [VoxCPM2 C ABI](include/speech_core/voxcpm2_c.h): a resumable, retrying download (HTTP Range, atomic rename) that tolerates network interruptions and caches under the OS cache dir (`SPEECH_CORE_CACHE_DIR` to override; `HF_ENDPOINT` for a mirror). Off by default so embedded/offline builds carry no HTTP/TLS dependency. The `hf_fetch` debug CLI exercises it directly.
+
 ## Testing & CI
 
 ```bash

--- a/examples/litert/hf_fetch.cpp
+++ b/examples/litert/hf_fetch.cpp
@@ -1,0 +1,50 @@
+// Debug CLI for the Hugging Face downloader behind sc_voxcpm2_create_from_pretrained.
+// Exercises speech_core::hf::download_bundle directly so resume/retry behaviour
+// can be tested without pulling a full model bundle.
+//
+// Usage: hf_fetch <repo> <revision> <dest_dir> <file> [file...]
+//   e.g. hf_fetch soniqo/VoxCPM2-LiteRT main /tmp/vox tokenizer.json
+//
+// Only built when SPEECH_CORE_WITH_HF_DOWNLOAD=ON.
+
+#include "hf_download.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        std::fprintf(stderr,
+                     "usage: %s <repo> <revision> <dest_dir> <file> [file...]\n",
+                     argv[0]);
+        return 2;
+    }
+    const std::string repo = argv[1];
+    const std::string revision = argv[2];
+    const std::string dest = argv[3];
+    std::vector<std::string> files;
+    for (int i = 4; i < argc; ++i) files.emplace_back(argv[i]);
+
+    try {
+        speech_core::hf::download_bundle(
+            repo, revision, files, dest,
+            [](const std::string& f, int idx, int cnt, uint64_t done, uint64_t total) {
+                double pct = total ? (100.0 * static_cast<double>(done) /
+                                      static_cast<double>(total))
+                                   : 0.0;
+                std::fprintf(stderr, "\r[%d/%d] %s %llu/%llu (%.1f%%)        ",
+                             idx + 1, cnt, f.c_str(),
+                             static_cast<unsigned long long>(done),
+                             static_cast<unsigned long long>(total), pct);
+                std::fflush(stderr);
+            });
+        std::fprintf(stderr, "\nOK\n");
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "\nERROR: %s\n", e.what());
+        return 1;
+    }
+    return 0;
+}

--- a/include/speech_core/voxcpm2_c.h
+++ b/include/speech_core/voxcpm2_c.h
@@ -41,6 +41,40 @@ typedef void (*sc_voxcpm2_chunk_fn)(const float* samples, size_t length,
 /// tokenizer.json). Returns NULL on failure (reason logged to stderr).
 sc_voxcpm2_t sc_voxcpm2_create(const char* bundle_dir);
 
+/// Download progress callback for sc_voxcpm2_create_from_pretrained.
+/// `downloaded`/`total` are bytes for the current file (`total` is 0 when the
+/// size is unknown); `file_index`/`file_count` track overall progress. Invoked
+/// on the calling thread during the download; keep it light.
+typedef void (*sc_voxcpm2_progress_fn)(const char* filename, int file_index,
+                                       int file_count, uint64_t downloaded,
+                                       uint64_t total, void* context);
+
+/// Like sc_voxcpm2_create, but first ensures the VoxCPM2 LiteRT bundle for
+/// `model_id` (a Hugging Face repo, e.g. "soniqo/VoxCPM2-LiteRT") is present in
+/// a local cache, downloading any missing files. Downloads are resumable and
+/// retried, so they tolerate network interruptions (override the host with the
+/// HF_ENDPOINT env var to use a mirror).
+///
+///   model_id         : HF repo id.
+///   revision         : git revision/branch; NULL or "" means "main".
+///   cache_dir        : where bundles are cached; NULL uses a per-user default
+///                      (SPEECH_CORE_CACHE_DIR env, else the OS cache dir). The
+///                      bundle lands in <cache_dir>/<model_id with '/'→'__'>.
+///   on_progress      : optional, may be NULL.
+///   progress_context : passed back to on_progress.
+///
+/// Returns NULL on failure — including when speech-core was built without
+/// SPEECH_CORE_WITH_HF_DOWNLOAD (reason logged to stderr).
+sc_voxcpm2_t sc_voxcpm2_create_from_pretrained(const char* model_id,
+                                               const char* revision,
+                                               const char* cache_dir,
+                                               sc_voxcpm2_progress_fn on_progress,
+                                               void* progress_context);
+
+/// Whether this build has model-download support (SPEECH_CORE_WITH_HF_DOWNLOAD)
+/// compiled in. When false, sc_voxcpm2_create_from_pretrained always fails.
+bool sc_voxcpm2_has_download_support(void);
+
 /// Destroy a synthesizer and free its resources.
 void sc_voxcpm2_destroy(sc_voxcpm2_t synth);
 

--- a/src/models/litert/hf_download.cpp
+++ b/src/models/litert/hf_download.cpp
@@ -1,0 +1,220 @@
+#include "hf_download.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#ifdef SPEECH_CORE_WITH_HF_DOWNLOAD
+#include <chrono>
+#include <thread>
+
+#include <curl/curl.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace speech_core::hf {
+
+#ifndef SPEECH_CORE_WITH_HF_DOWNLOAD
+
+bool download_supported() { return false; }
+
+void download_bundle(const std::string&, const std::string&,
+                     const std::vector<std::string>&, const std::string&,
+                     const ProgressFn&) {
+    throw std::runtime_error(
+        "speech-core was built without SPEECH_CORE_WITH_HF_DOWNLOAD; cannot "
+        "download model bundles. Rebuild with -DSPEECH_CORE_WITH_HF_DOWNLOAD=ON "
+        "or provide the bundle directory explicitly.");
+}
+
+#else  // SPEECH_CORE_WITH_HF_DOWNLOAD
+
+namespace {
+
+// Default Hugging Face endpoint; overridable via HF_ENDPOINT to support
+// mirrors (e.g. hf-mirror.com) without recompiling.
+std::string hf_endpoint() {
+    const char* e = std::getenv("HF_ENDPOINT");
+    return (e && *e) ? std::string(e) : "https://huggingface.co";
+}
+
+std::string resolve_url(const std::string& repo, const std::string& revision,
+                        const std::string& file) {
+    return hf_endpoint() + "/" + repo + "/resolve/" + revision + "/" + file;
+}
+
+size_t write_to_file(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* f = static_cast<std::FILE*>(userdata);
+    return std::fwrite(ptr, size, nmemb, f);
+}
+
+struct ProgressCtx {
+    const ProgressFn* fn;
+    std::string file;
+    int idx;
+    int count;
+    uint64_t base;   // bytes already on disk before this transfer (resume offset)
+    uint64_t total;  // full remote size, 0 if unknown
+};
+
+int xferinfo(void* p, curl_off_t /*dltotal*/, curl_off_t dlnow,
+             curl_off_t /*ultotal*/, curl_off_t /*ulnow*/) {
+    auto* c = static_cast<ProgressCtx*>(p);
+    if (c->fn && *c->fn) {
+        (*c->fn)(c->file, c->idx, c->count, c->base + static_cast<uint64_t>(dlnow),
+                 c->total);
+    }
+    return 0;  // non-zero would abort the transfer
+}
+
+// HEAD the (redirected) URL and return Content-Length, or 0 if unknown.
+uint64_t remote_size(const std::string& url) {
+    CURL* curl = curl_easy_init();
+    if (!curl) return 0;
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "speech-core/hf-download");
+    uint64_t size = 0;
+    if (curl_easy_perform(curl) == CURLE_OK) {
+        curl_off_t len = 0;
+        if (curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &len) == CURLE_OK &&
+            len > 0) {
+            size = static_cast<uint64_t>(len);
+        }
+    }
+    curl_easy_cleanup(curl);
+    return size;
+}
+
+// One GET attempt that resumes from `resume_from`. Returns true on a clean
+// transfer (curl reported success); the caller validates the resulting size.
+bool fetch_once(const std::string& url, const fs::path& part, uint64_t resume_from,
+                ProgressCtx& pctx) {
+    std::FILE* f = std::fopen(part.string().c_str(), resume_from ? "ab" : "wb");
+    if (!f) throw std::runtime_error("cannot open " + part.string() + " for writing");
+
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        std::fclose(f);
+        throw std::runtime_error("curl_easy_init failed");
+    }
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);  // HTTP >= 400 -> CURLE error
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_to_file);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, f);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+    // Abort a stalled (not dead) socket: < 1 KiB/s for 30 s.
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 30L);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "speech-core/hf-download");
+    if (resume_from) {
+        curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE,
+                         static_cast<curl_off_t>(resume_from));
+    }
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xferinfo);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &pctx);
+
+    CURLcode rc = curl_easy_perform(curl);
+    std::fclose(f);
+    if (rc != CURLE_OK) {
+        std::fprintf(stderr, "[speech] download %s: %s\n", pctx.file.c_str(),
+                     curl_easy_strerror(rc));
+    }
+    curl_easy_cleanup(curl);
+    return rc == CURLE_OK;
+}
+
+}  // namespace
+
+bool download_supported() { return true; }
+
+void download_bundle(const std::string& repo, const std::string& revision,
+                     const std::vector<std::string>& files,
+                     const std::string& dest_dir, const ProgressFn& on_progress) {
+    static const bool curl_ready = [] {
+        return curl_global_init(CURL_GLOBAL_DEFAULT) == CURLE_OK;
+    }();
+    if (!curl_ready) throw std::runtime_error("curl_global_init failed");
+
+    std::error_code ec;
+    fs::create_directories(dest_dir, ec);
+
+    constexpr int kMaxAttempts = 6;
+    const int file_count = static_cast<int>(files.size());
+
+    for (int i = 0; i < file_count; ++i) {
+        const std::string& file = files[i];
+        const fs::path final_path = fs::path(dest_dir) / file;
+        const fs::path part_path = fs::path(dest_dir) / (file + ".part");
+        const std::string url = resolve_url(repo, revision, file);
+
+        const uint64_t total = remote_size(url);
+
+        // Already complete? (We only rename into place once whole, so an
+        // existing final_path is trusted; if we know the size, confirm it.)
+        if (fs::exists(final_path)) {
+            const uint64_t have = static_cast<uint64_t>(fs::file_size(final_path, ec));
+            if (total == 0 || have == total) {
+                if (on_progress) on_progress(file, i, file_count, have, have);
+                continue;
+            }
+            fs::remove(final_path, ec);  // size mismatch — refetch
+        }
+
+        bool done = false;
+        for (int attempt = 0; attempt < kMaxAttempts && !done; ++attempt) {
+            uint64_t have = fs::exists(part_path)
+                                ? static_cast<uint64_t>(fs::file_size(part_path, ec))
+                                : 0;
+            if (total > 0 && have > total) {
+                fs::remove(part_path, ec);  // corrupt/over-long — restart
+                have = 0;
+            }
+            if (total > 0 && have == total) {
+                done = true;
+                break;
+            }
+            if (attempt > 0) {
+                // Exponential backoff: 1s, 2s, 4s, … capped at 16s.
+                int delay = 1 << (attempt - 1);
+                if (delay > 16) delay = 16;
+                std::fprintf(stderr, "[speech] retrying %s (attempt %d/%d) in %ds\n",
+                             file.c_str(), attempt + 1, kMaxAttempts, delay);
+                std::this_thread::sleep_for(std::chrono::seconds(delay));
+            }
+
+            ProgressCtx pctx{&on_progress, file, i, file_count, have, total};
+            fetch_once(url, part_path, have, pctx);
+
+            const uint64_t now = fs::exists(part_path)
+                                     ? static_cast<uint64_t>(fs::file_size(part_path, ec))
+                                     : 0;
+            done = (total > 0) ? (now == total) : (now > 0);
+        }
+
+        if (!done) {
+            throw std::runtime_error("failed to download " + file + " from " + repo +
+                                     " after " + std::to_string(kMaxAttempts) +
+                                     " attempts");
+        }
+
+        fs::remove(final_path, ec);  // no-op if absent
+        fs::rename(part_path, final_path, ec);
+        if (ec) {
+            throw std::runtime_error("could not finalize " + final_path.string() +
+                                     ": " + ec.message());
+        }
+        if (on_progress) on_progress(file, i, file_count, total, total);
+    }
+}
+
+#endif  // SPEECH_CORE_WITH_HF_DOWNLOAD
+
+}  // namespace speech_core::hf

--- a/src/models/litert/hf_download.h
+++ b/src/models/litert/hf_download.h
@@ -1,0 +1,48 @@
+#ifndef SPEECH_CORE_LITERT_HF_DOWNLOAD_H
+#define SPEECH_CORE_LITERT_HF_DOWNLOAD_H
+
+// Minimal, robust Hugging Face file downloader (internal to
+// speech_core_models_litert). Used by sc_voxcpm2_create_from_pretrained to
+// fetch a model bundle on first run, mirroring how speech-swift's
+// HuggingFaceDownloader works on Apple platforms.
+//
+// Compiled against libcurl and only active when speech-core is built with
+// SPEECH_CORE_WITH_HF_DOWNLOAD=ON. When that's off, download_bundle throws so
+// the caller can surface a clear "built without download support" error.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace speech_core::hf {
+
+/// Per-file progress. `total` is 0 when the size is unknown. Called on the
+/// downloading thread; keep the callback light.
+using ProgressFn = std::function<void(const std::string& file, int file_index,
+                                       int file_count, uint64_t downloaded,
+                                       uint64_t total)>;
+
+/// Ensure every file in `files` exists under `dest_dir`, downloading the
+/// missing ones from `https://<endpoint>/<repo>/resolve/<revision>/<file>`.
+///
+/// Robust against network breaks: each file streams to a `<file>.part`
+/// sidecar and resumes from the existing byte offset (HTTP Range) across
+/// retries with exponential backoff; the `.part` is renamed into place only
+/// once the whole file is present. Already-complete files are skipped.
+///
+/// Creates `dest_dir` (and parents) as needed. Throws std::runtime_error on
+/// unrecoverable failure (network exhausted, disk error, or — when built
+/// without SPEECH_CORE_WITH_HF_DOWNLOAD — lack of download support).
+void download_bundle(const std::string& repo,
+                     const std::string& revision,
+                     const std::vector<std::string>& files,
+                     const std::string& dest_dir,
+                     const ProgressFn& on_progress);
+
+/// Whether this build has libcurl-backed download support compiled in.
+bool download_supported();
+
+}  // namespace speech_core::hf
+
+#endif  // SPEECH_CORE_LITERT_HF_DOWNLOAD_H

--- a/src/models/litert/voxcpm2_c.cpp
+++ b/src/models/litert/voxcpm2_c.cpp
@@ -4,10 +4,14 @@
 #include "speech_core/voxcpm2_c.h"
 #include "speech_core/models/litert_voxcpm2_tts.h"
 
+#include "hf_download.h"
+
 #include <cstdio>
+#include <cstdlib>
 #include <exception>
 #include <memory>
 #include <string>
+#include <vector>
 
 using speech_core::LiteRTVoxCPM2Tts;
 
@@ -16,25 +20,106 @@ struct sc_voxcpm2_s {
     std::string last_error;
 };
 
+namespace {
+
+// Open a VoxCPM2 LiteRT bundle directory into a fresh handle. Throws on a
+// missing/invalid bundle (the LiteRTVoxCPM2Tts constructor validates paths).
+sc_voxcpm2_s* create_from_dir(const std::string& b) {
+    auto* h = new sc_voxcpm2_s();
+    h->tts = std::make_unique<LiteRTVoxCPM2Tts>(
+        b + "/voxcpm2-text-prefill.tflite",
+        b + "/voxcpm2-token-step.tflite",
+        b + "/voxcpm2-audio-encoder.tflite",
+        b + "/voxcpm2-audio-decoder.tflite",
+        b + "/tokenizer.json",
+        /*hw_accel=*/false);
+    return h;
+}
+
+// Per-user cache root for downloaded model bundles. SPEECH_CORE_CACHE_DIR wins;
+// otherwise the OS-native cache location.
+std::string default_cache_dir() {
+    if (const char* c = std::getenv("SPEECH_CORE_CACHE_DIR"); c && *c) return c;
+#if defined(_WIN32)
+    if (const char* la = std::getenv("LOCALAPPDATA"); la && *la)
+        return std::string(la) + "/speech-core";
+#elif defined(__APPLE__)
+    if (const char* h = std::getenv("HOME"); h && *h)
+        return std::string(h) + "/Library/Caches/speech-core";
+#else
+    if (const char* x = std::getenv("XDG_CACHE_HOME"); x && *x)
+        return std::string(x) + "/speech-core";
+    if (const char* h = std::getenv("HOME"); h && *h)
+        return std::string(h) + "/.cache/speech-core";
+#endif
+    return "./speech-core-cache";
+}
+
+// "soniqo/VoxCPM2-LiteRT" -> "soniqo__VoxCPM2-LiteRT" (filesystem-safe subdir).
+std::string sanitize_repo(const std::string& id) {
+    std::string s;
+    for (char c : id) {
+        if (c == '/' || c == '\\') s += "__";
+        else s += c;
+    }
+    return s;
+}
+
+}  // namespace
+
 extern "C" {
 
 sc_voxcpm2_t sc_voxcpm2_create(const char* bundle_dir) {
     if (!bundle_dir) return nullptr;
     try {
-        const std::string b = bundle_dir;
-        auto* h = new sc_voxcpm2_s();
-        h->tts = std::make_unique<LiteRTVoxCPM2Tts>(
-            b + "/voxcpm2-text-prefill.tflite",
-            b + "/voxcpm2-token-step.tflite",
-            b + "/voxcpm2-audio-encoder.tflite",
-            b + "/voxcpm2-audio-decoder.tflite",
-            b + "/tokenizer.json",
-            /*hw_accel=*/false);
-        return h;
+        return create_from_dir(bundle_dir);
     } catch (const std::exception& e) {
         std::fprintf(stderr, "[speech ERROR] sc_voxcpm2_create: %s\n", e.what());
         return nullptr;
     }
+}
+
+sc_voxcpm2_t sc_voxcpm2_create_from_pretrained(const char* model_id,
+                                               const char* revision,
+                                               const char* cache_dir,
+                                               sc_voxcpm2_progress_fn on_progress,
+                                               void* progress_context) {
+    if (!model_id || !*model_id) return nullptr;
+    try {
+        const std::string repo = model_id;
+        const std::string rev = (revision && *revision) ? revision : "main";
+        const std::string base =
+            (cache_dir && *cache_dir) ? std::string(cache_dir) : default_cache_dir();
+        const std::string dir = base + "/" + sanitize_repo(repo);
+
+        // The five files LiteRTVoxCPM2Tts needs to construct a synthesizer.
+        static const std::vector<std::string> kFiles = {
+            "voxcpm2-text-prefill.tflite",
+            "voxcpm2-token-step.tflite",
+            "voxcpm2-audio-encoder.tflite",
+            "voxcpm2-audio-decoder.tflite",
+            "tokenizer.json",
+        };
+
+        speech_core::hf::ProgressFn cb;
+        if (on_progress) {
+            cb = [on_progress, progress_context](const std::string& f, int idx,
+                                                 int cnt, uint64_t done,
+                                                 uint64_t total) {
+                on_progress(f.c_str(), idx, cnt, done, total, progress_context);
+            };
+        }
+        speech_core::hf::download_bundle(repo, rev, kFiles, dir, cb);
+        return create_from_dir(dir);
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[speech ERROR] sc_voxcpm2_create_from_pretrained: %s\n",
+                     e.what());
+        return nullptr;
+    }
+}
+
+bool sc_voxcpm2_has_download_support(void) {
+    return speech_core::hf::download_supported();
 }
 
 void sc_voxcpm2_destroy(sc_voxcpm2_t s) { delete s; }


### PR DESCRIPTION
## Summary

Adds a first-run model-download path to the VoxCPM2 LiteRT backend so non-C++ hosts (e.g. the speech-studio Tauri app on Windows/Linux) can fetch the model bundle on demand instead of having it provisioned by hand — mirroring how the Apple `speech-swift` runtime already auto-downloads.

## What changed

- **`sc_voxcpm2_create_from_pretrained(model_id, revision, cache_dir, on_progress, ctx)`** + `sc_voxcpm2_has_download_support()` added to `include/speech_core/voxcpm2_c.h`. Resolves a Hugging Face repo into a per-user cache, downloads any missing bundle files, then constructs the synthesizer. `sc_voxcpm2_create` is refactored to share the bundle-load path.
- **`src/models/litert/hf_download.{h,cpp}`** — libcurl downloader: streams each file to a `.part` sidecar and resumes from the existing offset via HTTP Range across retries (exponential backoff), with stall detection and atomic rename on completion. `HF_ENDPOINT` selects a mirror; cache root via `SPEECH_CORE_CACHE_DIR`.
- **`SPEECH_CORE_WITH_HF_DOWNLOAD`** CMake option (OFF by default) gates the feature and the `find_package(CURL)` dependency, so embedded/offline builds carry no HTTP/TLS dep. Requires `SPEECH_CORE_WITH_LITERT=ON`.
- `examples/litert/hf_fetch.cpp` — small debug CLI exercising the downloader directly.

## Test plan

Built on Windows (MSVC, libcurl from vcpkg `x64-windows-static-md`, Schannel TLS):

- Library + `hf_fetch` compile and link libcurl into an executable.
- **Download:** fetched `tokenizer.json` from `soniqo/VoxCPM2-LiteRT`; SHA256 matches the reference file.
- **Resume:** seeded a 1 MB partial `.part`, re-ran, and it resumed at `1000000/3676772 (27.2%)` (not from 0), completed, SHA256 matches — confirms Range-based resume across interruptions.
- Verified end-to-end via `sc_voxcpm2_create_from_pretrained` (cache hit path → synthesizer constructs and renders audio).

Linux uses system libcurl; not built here (CI follow-up).