### PR TITLE
test: unit-test the HF downloader's resume/skip/restart logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,13 +276,28 @@ if(SPEECH_CORE_BUILD_TESTS)
         get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
         # test_models.cpp needs ORT — handled below when SPEECH_CORE_WITH_ONNX=ON.
         # test_litert_models.cpp needs LiteRT — handled below when SPEECH_CORE_WITH_LITERT=ON.
-        if(TEST_NAME STREQUAL "test_models" OR TEST_NAME STREQUAL "test_litert_models")
+        if(TEST_NAME STREQUAL "test_models" OR TEST_NAME STREQUAL "test_litert_models"
+           OR TEST_NAME STREQUAL "test_hf_download")
             continue()
         endif()
         add_executable(${TEST_NAME} ${TEST_SRC})
         target_link_libraries(${TEST_NAME} PRIVATE speech_core)
         add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     endforeach()
+
+    # HF downloader decision-logic test — the pure resume/skip/restart rules
+    # behind sc_voxcpm2_create_from_pretrained. Needs no libcurl or LiteRT, so it
+    # compiles hf_download.cpp's no-network branch directly and runs in every
+    # configuration (not just LiteRT builds).
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_hf_download.cpp)
+        add_executable(test_hf_download
+            tests/test_hf_download.cpp
+            src/models/litert/hf_download.cpp)
+        target_include_directories(test_hf_download PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/models/litert
+            ${CMAKE_CURRENT_SOURCE_DIR}/include)
+        add_test(NAME test_hf_download COMMAND test_hf_download)
+    endif()
 
     # Model integration tests — require SPEECH_CORE_WITH_ONNX=ON.
     # Skip gracefully at runtime when SPEECH_MODEL_DIR isn't set.

--- a/src/models/litert/hf_download.cpp
+++ b/src/models/litert/hf_download.cpp
@@ -17,6 +17,25 @@ namespace fs = std::filesystem;
 
 namespace speech_core::hf {
 
+// Pure decision logic shared by download_bundle. Compiled regardless of whether
+// libcurl support is enabled, so it is unit-testable in any build.
+bool final_is_complete(uint64_t final_size, uint64_t remote_size) {
+    return remote_size == 0 || final_size == remote_size;
+}
+
+FetchAction plan_part_fetch(uint64_t part_size, uint64_t remote_size, uint64_t* resume_from) {
+    if (remote_size > 0 && part_size > remote_size) {
+        if (resume_from) *resume_from = 0;
+        return FetchAction::Restart;  // over-long/corrupt .part — start over
+    }
+    if (remote_size > 0 && part_size == remote_size) {
+        if (resume_from) *resume_from = part_size;
+        return FetchAction::Complete;  // already fully downloaded
+    }
+    if (resume_from) *resume_from = part_size;  // resume (part_size may be 0)
+    return FetchAction::Resume;
+}
+
 #ifndef SPEECH_CORE_WITH_HF_DOWNLOAD
 
 bool download_supported() { return false; }
@@ -161,7 +180,7 @@ void download_bundle(const std::string& repo, const std::string& revision,
         // existing final_path is trusted; if we know the size, confirm it.)
         if (fs::exists(final_path)) {
             const uint64_t have = static_cast<uint64_t>(fs::file_size(final_path, ec));
-            if (total == 0 || have == total) {
+            if (final_is_complete(have, total)) {
                 if (on_progress) on_progress(file, i, file_count, have, have);
                 continue;
             }
@@ -170,14 +189,15 @@ void download_bundle(const std::string& repo, const std::string& revision,
 
         bool done = false;
         for (int attempt = 0; attempt < kMaxAttempts && !done; ++attempt) {
-            uint64_t have = fs::exists(part_path)
+            const uint64_t have = fs::exists(part_path)
                                 ? static_cast<uint64_t>(fs::file_size(part_path, ec))
                                 : 0;
-            if (total > 0 && have > total) {
-                fs::remove(part_path, ec);  // corrupt/over-long — restart
-                have = 0;
-            }
-            if (total > 0 && have == total) {
+            uint64_t resume_from = 0;
+            const FetchAction act = plan_part_fetch(have, total, &resume_from);
+            if (act == FetchAction::Restart) {
+                fs::remove(part_path, ec);  // over-long/corrupt — start over
+                resume_from = 0;
+            } else if (act == FetchAction::Complete) {
                 done = true;
                 break;
             }
@@ -190,8 +210,8 @@ void download_bundle(const std::string& repo, const std::string& revision,
                 std::this_thread::sleep_for(std::chrono::seconds(delay));
             }
 
-            ProgressCtx pctx{&on_progress, file, i, file_count, have, total};
-            fetch_once(url, part_path, have, pctx);
+            ProgressCtx pctx{&on_progress, file, i, file_count, resume_from, total};
+            fetch_once(url, part_path, resume_from, pctx);
 
             const uint64_t now = fs::exists(part_path)
                                      ? static_cast<uint64_t>(fs::file_size(part_path, ec))

--- a/src/models/litert/hf_download.h
+++ b/src/models/litert/hf_download.h
@@ -43,6 +43,19 @@ void download_bundle(const std::string& repo,
 /// Whether this build has libcurl-backed download support compiled in.
 bool download_supported();
 
+// --- Pure decision helpers (no network/IO; unit-tested in test_hf_download) ---
+
+// An already-present final file is trusted as complete when the remote size is
+// unknown (0) or matches it — files are only renamed into place once whole.
+bool final_is_complete(uint64_t final_size, uint64_t remote_size);
+
+enum class FetchAction { Complete, Resume, Restart };
+
+// Decide what to do with a partial download given the bytes already on disk
+// (`part_size`) and the known remote size (`remote_size`; 0 = unknown). Sets
+// *resume_from to the byte offset to continue from (0 on Restart).
+FetchAction plan_part_fetch(uint64_t part_size, uint64_t remote_size, uint64_t* resume_from);
+
 }  // namespace speech_core::hf
 
 #endif  // SPEECH_CORE_LITERT_HF_DOWNLOAD_H

--- a/tests/test_hf_download.cpp
+++ b/tests/test_hf_download.cpp
@@ -1,0 +1,69 @@
+// Unit tests for the Hugging Face downloader's pure decision logic — the
+// resume / skip / restart rules behind sc_voxcpm2_create_from_pretrained. The
+// libcurl transport is exercised separately (end-to-end); this guards OUR
+// decisions, which is where the bugs would live. No network or libcurl needed:
+// hf_download.cpp's pure helpers compile regardless of the build flag.
+
+#include "hf_download.h"
+
+#include <cstdint>
+#include <cstdio>
+
+using speech_core::hf::FetchAction;
+using speech_core::hf::final_is_complete;
+using speech_core::hf::plan_part_fetch;
+
+static int g_fail = 0;
+#define CHECK(cond, msg)                                  \
+    do {                                                  \
+        if (!(cond)) {                                    \
+            std::fprintf(stderr, "FAIL: %s\n", (msg));    \
+            ++g_fail;                                     \
+        }                                                 \
+    } while (0)
+
+int main() {
+    // --- final_is_complete: an existing final file is trusted when the size
+    //     matches or the remote size is unknown (0). ---
+    CHECK(final_is_complete(100, 100), "exact size match is complete");
+    CHECK(final_is_complete(100, 0), "unknown remote size trusts existing final");
+    CHECK(!final_is_complete(99, 100), "short final is incomplete");
+    CHECK(!final_is_complete(101, 100), "over-long final is incomplete");
+
+    // --- plan_part_fetch: resume / complete / restart on the .part file. ---
+    uint64_t off = 999;  // sentinel; must be overwritten
+
+    CHECK(plan_part_fetch(0, 1000, &off) == FetchAction::Resume && off == 0,
+          "no bytes yet -> resume from 0");
+
+    off = 999;
+    CHECK(plan_part_fetch(400, 1000, &off) == FetchAction::Resume && off == 400,
+          "partial < remote -> resume from offset");
+
+    off = 999;
+    CHECK(plan_part_fetch(1000, 1000, &off) == FetchAction::Complete && off == 1000,
+          "partial == remote -> complete");
+
+    off = 999;
+    CHECK(plan_part_fetch(1500, 1000, &off) == FetchAction::Restart && off == 0,
+          "over-long .part -> restart from 0");
+
+    off = 999;
+    CHECK(plan_part_fetch(700, 0, &off) == FetchAction::Resume && off == 700,
+          "unknown remote size -> resume from what we have");
+
+    off = 999;
+    CHECK(plan_part_fetch(0, 0, &off) == FetchAction::Resume && off == 0,
+          "unknown remote size, nothing local -> resume from 0");
+
+    // resume_from may be null.
+    CHECK(plan_part_fetch(50, 100, nullptr) == FetchAction::Resume,
+          "null resume_from is tolerated");
+
+    if (g_fail == 0) {
+        std::fprintf(stderr, "test_hf_download: all assertions passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "test_hf_download: %d failure(s)\n", g_fail);
+    return 1;
+}


### PR DESCRIPTION
## Why

`sc_voxcpm2_create_from_pretrained`'s downloader (added in #48) had **no automated tests** — the resume/skip/restart rules that make it tolerate interrupted downloads were only verified by hand. This guards that logic.

## What

- Extract the per-file decision out of `download_bundle` into two pure, no-IO helpers in `hf_download.{h,cpp}`:
  - `final_is_complete(final_size, remote_size)` — trust an existing final file when the size matches (or the remote size is unknown).
  - `plan_part_fetch(part_size, remote_size, &resume_from)` → `Complete` / `Resume(offset)` / `Restart` — the resume-from-offset, already-complete, and over-long/corrupt-`.part` rules.
  `download_bundle` now calls these (behavior unchanged).
- `tests/test_hf_download.cpp` covers both helpers across the edge cases (fresh, partial<remote, partial==remote, over-long, unknown remote size, null out-param) with an always-on `CHECK` macro (not `assert`, which `NDEBUG`/Release would strip).

## Notes

- The test needs **neither libcurl nor LiteRT** — it compiles `hf_download.cpp`'s no-network branch directly — so it's excluded from the LiteRT-only block and runs in **every** build config via `ctest` (including the minimal unit-tests lane). The libcurl transport stays covered end-to-end.

## Test plan

- Minimal config (`-DSPEECH_CORE_BUILD_TESTS=ON`, no ONNX/LiteRT): `ctest -R test_hf_download` passes — confirms it builds without curl.
- LiteRT+HF-download config: `speech_core_models_litert` still compiles with the refactored `download_bundle`.