### PR TITLE
docs(readme): match speech-studio language switcher convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Speech Core
 
-**English** · **[简体中文](README.zh-CN.md)**
+**English** · [简体中文](README.zh-CN.md)
 
 Voice-agent pipeline engine in **C++17** — on-device speech for **Linux, Windows, and Android** (plus Apple via a [Swift sibling](https://github.com/soniqo/speech-swift)).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Speech Core
 
-**[English](README.md)** · **简体中文**
+[English](README.md) · **简体中文**
 
 **C++17** 编写的语音 Agent 流水线引擎 —— 面向 **Linux、Windows 和 Android** 的设备端语音（Apple 平台见 [Swift 姊妹仓库](https://github.com/soniqo/speech-swift)）。
 


### PR DESCRIPTION
Aligns the README language switcher with the convention used in [speech-studio](https://github.com/soniqo/speech-studio): only the **active** language is bold; the alternate is a plain link.

| File | Before | After |
|---|---|---|
| README.md | `**English** · **[简体中文](README.zh-CN.md)**` | `**English** · [简体中文](README.zh-CN.md)` |
| README.zh-CN.md | `**[English](README.md)** · **简体中文**` | `[English](README.md) · **简体中文**` |

Tiny cosmetic fix on top of #53.