### PR TITLE
fix(voxcpm2): rescue quiet reference clips before audio_encoder

### DIFF
--- a/docs/voxcpm2-clone-testing.md
+++ b/docs/voxcpm2-clone-testing.md
@@ -1,0 +1,135 @@
+# Testing VoxCPM2 voice cloning — quiet-reference rescue
+
+VoxCPM2's `audio_encoder` conditions on both timbre **and** amplitude of the
+reference clip, so output loudness tracks reference loudness within ±10%. A
+reference recorded quietly (RMS ~0.002, typical of un-mastered phone-mic
+captures) used to clone at sub-audible level — perceived as "broken speech" /
+"missing audio".
+
+Both wrappers (`LiteRTVoxCPM2Tts`, `OnnxVoxCPM2Tts`) now rescue quiet
+references in `set_reference()`: when the clip's RMS (after the leading-silence
+trim) is below **0.04**, it is scaled to **~0.08 RMS** with a **0.95 peak cap**.
+Clips already at healthy loudness pass through unchanged — bit-exact with the
+previous behaviour and with upstream `openbmb/VoxCPM2` (whose canonical
+fixture `examples/reference_speaker.wav` measures RMS 0.0896; our 0.08 target
+matches that distribution).
+
+This doc shows how to verify the behaviour on any machine, two ways: via the
+clone CLI (listening test) and via the regression test (automated).
+
+## Prerequisites
+
+- CMake ≥ 3.22, a C++17 toolchain (MSVC 2022 / clang / gcc), git, Python 3.10+
+  with `numpy` and `scipy`.
+- `libLiteRt` for your platform — on Windows the repo vendors it under
+  `litert/`; on Linux/macOS run `scripts/fetch_litert.sh` to extract it from
+  the `ai-edge-litert` PyPI wheel.
+- The VoxCPM2 LiteRT bundle (~4.6 GB): `scripts/download_models_litert.sh`
+  fetches it into `scripts/models-litert/`.
+- Two reference clips:
+  - **Quiet** (the case being fixed): any mono speech WAV with RMS below ~0.01.
+    To fabricate one from a normal clip:
+    ```bash
+    python - <<'EOF'
+    import scipy.io.wavfile as wav, numpy as np
+    sr, x = wav.read("tests/data/test_audio.wav")
+    wav.write("quiet_ref.wav", sr, (x * 0.04).astype(np.int16))  # ~25x quieter
+    EOF
+    ```
+  - **Healthy** (the control): `tests/data/test_audio.wav` as-is (RMS ~0.05).
+
+## Build
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DSPEECH_CORE_WITH_LITERT=ON \
+    -DLITERT_DIR=path/to/litert        # repo's litert/ dir on Windows
+cmake --build build --config Release --target speech_voxcpm2_clone test_litert_models -j
+```
+
+On Windows, copy `libLiteRt.dll` next to the executables in `build\Release\`.
+
+## Way 1 — clone CLI (listening test)
+
+Run the same text through both references:
+
+```bash
+BUNDLE=scripts/models-litert
+
+./build/speech_voxcpm2_clone "$BUNDLE" quiet_ref.wav \
+    "The quick brown fox jumps over the lazy dog" out_quiet.wav
+
+./build/speech_voxcpm2_clone "$BUNDLE" tests/data/test_audio.wav \
+    "The quick brown fox jumps over the lazy dog" out_healthy.wav
+```
+
+Each run takes ~3–5 min on a modern CPU. Measure:
+
+```bash
+python - <<'EOF'
+import scipy.io.wavfile as wav, numpy as np
+for name in ("out_quiet.wav", "out_healthy.wav"):
+    sr, x = wav.read(name); x = x.astype(np.float32) / 32768.0
+    print(f"{name:18s} dur={len(x)/sr:5.2f}s "
+          f"peak={float(np.max(np.abs(x))):.4f} "
+          f"rms={float(np.sqrt((x**2).mean())):.4f}")
+EOF
+```
+
+**Pass criteria:**
+
+| Output | Expected RMS | Meaning |
+|---|---|---|
+| `out_quiet.wav` | **0.04 – 0.10** | rescue engaged; intelligible cloned speech |
+| `out_healthy.wav` | 0.04 – 0.12 | unchanged from pre-fix behaviour (no-op path) |
+
+On a pre-fix build (any commit before this fix), `out_quiet.wav` lands at
+RMS ≈ 0.001–0.005 — audibly a whisper. That is the regression this guards.
+
+Also listen to both in a DAW: the quiet-ref output must be intelligible
+speech in the cloned voice (not amplified noise), and there must be no new
+artifacts (clicks, distortion, EQ shifts) — the rescue is pure scalar gain.
+
+## Way 2 — regression test (automated)
+
+`tests/test_litert_models.cpp` includes `test_litert_voxcpm2_hindi_cloning`,
+which clones five Hindi phrases and prints per-phrase `rms`/`peak`/`dur` so
+loudness regressions are visible in stdout. It prefers
+`tests/data/test_hindi_ref.wav` as the reference when that file exists —
+drop in any quiet clip (it is intentionally not committed):
+
+```bash
+cp quiet_ref.wav tests/data/test_hindi_ref.wav
+
+SPEECH_LITERT_MODEL_DIR=scripts/models-litert \
+SPEECH_VOXCPM2_WAV_DUMP=/tmp/voxcpm2-wavs \
+./build/test_litert_models
+```
+
+Look for the per-phrase lines:
+
+```
+test_litert_voxcpm2_hindi_cloning ... (stt=off)
+  [stt-lang=... reference=test_hindi_ref ref_rms=0.0019 ...]
+  [0] tokens=38 dur=6.08s rms=0.0674 peak=0.4911  ref="..."
+```
+
+Every phrase should report `rms` ≥ 0.02. On a pre-fix build with a quiet
+reference, these lines show `rms=0.0012`-class values.
+
+Optionally run the dumped WAVs through the spectral checker:
+
+```bash
+python scripts/spectrum_check.py /tmp/voxcpm2-wavs
+```
+
+Note: the `BASS DROPOUTS` heuristic in `spectrum_check.py` is noisy on clips
+shorter than ~3 s — judge short phrases by the `rms` column, not the verdict.
+
+## Tuning knobs (in both wrappers' `set_reference()`)
+
+| Constant | Value | Rationale |
+|---|---|---|
+| `kQuietThreshold` | 0.04 | upstream-healthy references measure 0.09+; below 0.04 is outside the training distribution |
+| `kTargetRms` | 0.08 | matches upstream `reference_speaker.wav` (RMS 0.0896) |
+| `kPeakCap` | 0.95 | prevents clipping on clips with high peak-to-RMS ratio |

--- a/scripts/spectrum_check.py
+++ b/scripts/spectrum_check.py
@@ -1,0 +1,37 @@
+import numpy as np, scipy.io.wavfile as wav, os, glob, math, sys
+
+dump = sys.argv[1] if len(sys.argv) > 1 else "C:/tmp/voxcpm2-hi-wavs"
+files = sorted(glob.glob(os.path.join(dump, "voxcpm2_hindi_*.wav")))
+hdr = f"{'file':30s}  {'dur':>5s}  {'rms':>6s}  {'low_frac':>8s}  {'tstab':>6s}  {'spec_cv':>7s}  {'verdict':>20s}"
+print(hdr); print("-" * len(hdr))
+
+for f in files:
+    sr, x = wav.read(f); x = x.astype(np.float32) / 32768.0
+    N, H = 4096, 1024
+    win = np.hanning(N)
+    n = max(0, (len(x) - N) // H + 1)
+    sp = np.empty((n, N // 2 + 1), dtype=np.float64)
+    for t in range(n):
+        X = np.fft.rfft(x[t*H:t*H+N] * win); sp[t] = X.real**2 + X.imag**2
+    def b(hz): return int(round(hz * N / sr))
+    tot = sp.sum(axis=1)
+    lo  = sp[:, b(50):b(500)+1].sum(axis=1)
+    act = tot > 0.05 * tot.max()
+    low_frac = ((lo > 0.05 * tot) & act).sum() / max(1, act.sum())
+    hb = sp[act, b(4000):b(12000)+1]
+    if hb.shape[0] < 3:
+        print(f"{os.path.basename(f):30s}  too short to analyse")
+        continue
+    bm = hb.mean(axis=0); bs = hb.std(axis=0); cv = bs / (bm + 1e-20)
+    thr = np.quantile(bm, 0.95)
+    tall = bm > thr
+    stationary = tall & (cv < 0.5)
+    tstab = stationary.sum() / max(1, tall.sum())
+    top3 = np.argsort(bm)[-3:]
+    spec_cv = float(cv[top3].mean())
+    rms = float(np.sqrt(x.astype(np.float64).mean() ** 2 + (x.astype(np.float64) ** 2).mean()))
+    flags = []
+    if low_frac < 0.95:                       flags.append("BASS DROPOUTS")
+    if tstab   > 0.30 and spec_cv < 0.50:     flags.append("STRIATIONS")
+    verdict = ", ".join(flags) if flags else "clean"
+    print(f"{os.path.basename(f):30s}  {len(x)/sr:5.2f}  {rms:6.4f}  {low_frac:8.2f}  {tstab:6.2f}  {spec_cv:7.3f}  {verdict:>20s}")

--- a/src/models/litert/litert_voxcpm2_tts.cpp
+++ b/src/models/litert/litert_voxcpm2_tts.cpp
@@ -228,6 +228,36 @@ void LiteRTVoxCPM2Tts::set_reference(const float* pcm, size_t length, int sample
         }
     }
 
+    // Rescue quiet reference clips. VoxCPM2's audio_encoder conditions on
+    // both timbre AND amplitude — a reference at RMS ~0.002 (e.g. an
+    // unmastered phone-mic capture) clones at sub-audible level, because
+    // output amplitude tracks reference amplitude within ±10%. The upstream
+    // openbmb VoxCPM2 Python (src/voxcpm/model/voxcpm2.py:_encode_wav)
+    // similarly does no amplitude normalization — it relies on callers
+    // passing already-loudness-normalized reference clips. We do the same for
+    // any clip already in a healthy range (RMS ≥ kQuietThreshold), but
+    // rescue obviously-quiet inputs by scaling them to ~kTargetRms with a
+    // peak cap. Pure scalar gain; no compression / EQ.
+    {
+        double ss = 0.0;
+        float peak = 0.0f;
+        for (float v : mono) {
+            ss += double(v) * v;
+            peak = std::max(peak, std::abs(v));
+        }
+        if (!mono.empty() && peak > 1e-6f) {
+            const double rms = std::sqrt(ss / mono.size());
+            const float kQuietThreshold = 0.04f;   // upstream-healthy refs are above this
+            const float kTargetRms      = 0.08f;
+            const float kPeakCap        = 0.95f;
+            if (rms < kQuietThreshold) {
+                float scale = static_cast<float>(kTargetRms / rms);
+                if (peak * scale > kPeakCap) scale = kPeakCap / peak;
+                for (float& v : mono) v *= scale;
+            }
+        }
+    }
+
     // Frames backed by *real* (pre-pad) audio. The encoder always emits
     // kMaxRefFrames, but trailing frames over zero-padding carry silence — we
     // condition only on the real ones (matches the MLX dynamic-length path).

--- a/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
+++ b/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
@@ -198,6 +198,28 @@ void OnnxVoxCPM2Tts::set_reference(const float* pcm, size_t length, int sample_r
         }
     }
 
+    // Rescue quiet reference clips (same recipe as the LiteRT variant). See
+    // litert_voxcpm2_tts.cpp set_reference() for the full rationale.
+    {
+        double ss = 0.0;
+        float peak = 0.0f;
+        for (float v : mono) {
+            ss += double(v) * v;
+            peak = std::max(peak, std::abs(v));
+        }
+        if (!mono.empty() && peak > 1e-6f) {
+            const double rms = std::sqrt(ss / mono.size());
+            const float kQuietThreshold = 0.04f;
+            const float kTargetRms      = 0.08f;
+            const float kPeakCap        = 0.95f;
+            if (rms < kQuietThreshold) {
+                float scale = static_cast<float>(kTargetRms / rms);
+                if (peak * scale > kPeakCap) scale = kPeakCap / peak;
+                for (float& v : mono) v *= scale;
+            }
+        }
+    }
+
     const size_t real_samples = std::min<size_t>(mono.size(), kRefAudioSamples);
     int real_frames = static_cast<int>((real_samples + kRefFrameStride - 1) / kRefFrameStride);
     real_frames = std::clamp(real_frames, 1, kMaxRefFrames);

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -68,6 +69,17 @@ std::string test_audio_path() {
     return std::string(SPEECH_CORE_TEST_DATA_DIR) + "/test_audio.wav";
 #else
     return "tests/data/test_audio.wav";
+#endif
+}
+
+/// Reference voice for the Hindi cloning test. Prefer the studio-pipeline
+/// reference if a user has dropped it into tests/data as test_hindi_ref.wav;
+/// fall back to the generic English fixture otherwise.
+std::string test_hindi_ref_path() {
+#ifdef SPEECH_CORE_TEST_DATA_DIR
+    return std::string(SPEECH_CORE_TEST_DATA_DIR) + "/test_hindi_ref.wav";
+#else
+    return "tests/data/test_hindi_ref.wav";
 #endif
 }
 
@@ -1159,6 +1171,164 @@ void test_litert_nemotron_multilingual_stt(const std::string& dir) {
     std::printf("final=\"%.50s\" ok\n", result.text.c_str());
 }
 
+// ---------------------------------------------------------------------------
+// VoxCPM2 Hindi cloning — Windows artifact repro harness. Mirrors the studio
+// voice-cloning flow exactly (set_reference + per-phrase seed + bounded
+// max_steps) over 5 Hindi phrases. Dumps each synthesized 48 kHz PCM16 WAV to
+// $SPEECH_VOXCPM2_WAV_DUMP/voxcpm2_hindi_NN.wav for offline spectral analysis,
+// and roundtrips each through Nemotron multilingual STT for a hyp transcript.
+// Skipped when any model file is missing or set_reference is rejected.
+// ---------------------------------------------------------------------------
+
+// UTF-8-aware tokenizer for Devanagari; splits on ASCII whitespace/punct AND
+// Devanagari danda (U+0964) / double-danda (U+0965). The repo's standard
+// tokenize_lower() drops Devanagari because std::isalnum is ASCII-only.
+std::vector<std::string> tokenize_unicode_words(const std::string& s) {
+    std::vector<std::string> toks; std::string cur;
+    auto flush = [&]() { if (!cur.empty()) { toks.push_back(std::move(cur)); cur.clear(); } };
+    size_t i = 0;
+    while (i < s.size()) {
+        unsigned char c = static_cast<unsigned char>(s[i]); int len = 1;
+        if      ((c & 0x80) == 0x00) len = 1;
+        else if ((c & 0xE0) == 0xC0) len = 2;
+        else if ((c & 0xF0) == 0xE0) len = 3;
+        else if ((c & 0xF8) == 0xF0) len = 4;
+        if (i + static_cast<size_t>(len) > s.size()) break;
+        bool sep = false;
+        if (len == 1) {
+            if (c <= 0x20) sep = true;
+            else switch (c) {
+                case '!': case '?': case '.': case ',': case ':': case ';':
+                case '"': case '\'': case '(': case ')': case '[': case ']':
+                case '{': case '}': case '/': case '\\': case '-':
+                case '_': case '*': case '=': sep = true; break;
+                default: break;
+            }
+        } else if (len == 3) {
+            unsigned char b1 = static_cast<unsigned char>(s[i+1]);
+            unsigned char b2 = static_cast<unsigned char>(s[i+2]);
+            if (c == 0xE0 && b1 == 0xA5 && (b2 == 0xA4 || b2 == 0xA5)) sep = true;
+        }
+        if (sep) flush(); else cur.append(s, i, len);
+        i += len;
+    }
+    flush();
+    return toks;
+}
+
+void test_litert_voxcpm2_hindi_cloning(const std::string& dir) {
+    std::string pref = dir + "/voxcpm2-text-prefill.tflite";
+    std::string step = dir + "/voxcpm2-token-step.tflite";
+    std::string venc = dir + "/voxcpm2-audio-encoder.tflite";
+    std::string vdec = dir + "/voxcpm2-audio-decoder.tflite";
+    std::string vtok = dir + "/tokenizer.json";
+    std::string nenc = dir + "/nemotron-multilingual-encoder.tflite";
+    std::string ndec = dir + "/nemotron-multilingual-decoder.tflite";
+    std::string njnt = dir + "/nemotron-multilingual-joint.tflite";
+    std::string nvoc = dir + "/nemotron-multilingual-vocab.json";
+    std::string nlng = dir + "/nemotron-multilingual-languages.json";
+    // Prefer the studio-pipeline reference voice (Ruuchi mono) at
+    // tests/data/test_hindi_ref.wav when present; fall back to the generic
+    // English test fixture so the test still runs in CI without the bundle.
+    std::string ref_path = test_hindi_ref_path();
+    auto wav = load_wav_mono_pcm16(ref_path);
+    bool used_hindi_ref = !wav.samples.empty();
+    if (!used_hindi_ref) {
+        ref_path = test_audio_path();
+        wav = load_wav_mono_pcm16(ref_path);
+    }
+    if (!file_exists(pref) || !file_exists(step) || !file_exists(venc)
+        || !file_exists(vdec) || !file_exists(vtok) || wav.samples.empty()) {
+        std::printf("  [skip] hindi cloning VoxCPM2 files/fixture missing in %s\n", dir.c_str());
+        return;
+    }
+    const bool have_stt = file_exists(nenc) && file_exists(ndec) && file_exists(njnt)
+        && file_exists(nvoc) && file_exists(nlng);
+    std::printf("  test_litert_voxcpm2_hindi_cloning ... (stt=%s)\n",
+                have_stt ? "on" : "off");
+
+    speech_core::LiteRTVoxCPM2Tts tts(pref, step, venc, vdec, vtok, /*hw_accel=*/false);
+    if (tts.max_text_tokens() < 256) {
+        std::printf("  [skip] hindi cloning needs production VoxCPM2 (max_text=%d)\n",
+                    tts.max_text_tokens());
+        return;
+    }
+    std::unique_ptr<speech_core::LiteRTNemotronMultilingualStt> stt_ptr;
+    const char* res = "(skipped)";
+    if (have_stt) {
+        stt_ptr = std::make_unique<speech_core::LiteRTNemotronMultilingualStt>(
+            nenc, ndec, njnt, nvoc, nlng, /*hw_accel=*/false);
+        const char* locs[] = {"hi-IN", "hi", "hi-HI"};
+        for (const char* l : locs) if (stt_ptr->set_language(l)) { res = l; break; }
+        if (std::string(res) == "(skipped)") {
+            std::printf("    [warn] no Hindi slot in nemotron — running without STT\n");
+            stt_ptr.reset();
+            res = "(no-hi-slot)";
+        }
+    }
+
+    tts.set_reference(wav.samples.data(), wav.samples.size(), wav.sample_rate);
+    if (!tts.has_reference()) { std::printf("  [skip] set_reference rejected clip\n"); return; }
+    // Log the reference RMS — useful when chasing a "cloned voice is too
+    // quiet" report; loudness can collapse if the reference clip itself is
+    // quiet and the model preserves its level too literally.
+    double ref_rms_sq = 0.0;
+    for (float s : wav.samples) ref_rms_sq += static_cast<double>(s) * s;
+    double ref_rms = std::sqrt(ref_rms_sq / std::max<size_t>(wav.samples.size(), 1));
+    std::printf("    [stt-lang=%s reference=%s ref_rms=%.4f ref_dur=%.2fs sr=%d]\n",
+                res, used_hindi_ref ? "test_hindi_ref" : "test_audio",
+                ref_rms, double(wav.samples.size()) / wav.sample_rate, wav.sample_rate);
+
+    tts.set_instruction("");
+    const std::vector<std::string> phrases = {
+        "इसे कहाँ रखें: गियर साइडबार खोलें। इसके अंदर, हॉटकीज़ ब्लॉक और नीचे के टेक्स्ट के बीच में एक हॉरिजॉन्टल लाइन जोड़ें।",
+        "मेरा नाम राहुल है।",
+        "आज मौसम बहुत अच्छा है।",
+        "मुझे संगीत सुनना पसंद है।",
+        "क्या आप मेरी मदद कर सकते हैं?",
+    };
+    const char* dump = std::getenv("SPEECH_VOXCPM2_WAV_DUMP");
+    for (size_t i = 0; i < phrases.size(); ++i) {
+        const auto& p = phrases[i];
+        int wc = static_cast<int>(tokenize_unicode_words(p).size());
+        int ms = std::clamp(wc * 12 + 40, 60, 240);
+        tts.set_max_steps(ms);
+        tts.set_seed(static_cast<unsigned>(1000 + i));
+
+        std::vector<float> a48; bool fin = false;
+        tts.synthesize(p, "hi", [&](const float* s, size_t n, bool isf) {
+            if (s && n) a48.insert(a48.end(), s, s + n);
+            if (isf) fin = true;
+        });
+        if (!fin || a48.empty()) { std::printf("    [%zu] EMPTY\n", i); continue; }
+        if (dump) {
+            char path[512];
+            std::snprintf(path, sizeof(path), "%s/voxcpm2_hindi_%02zu.wav", dump, i);
+            dump_wav48k_mono(path, a48);
+        }
+        std::string hyp = "(stt-off)";
+        if (stt_ptr) {
+            auto a16 = speech_core::Resampler::resample(a48.data(), a48.size(), 48000, 16000);
+            stt_ptr->begin_stream(16000);
+            constexpr size_t kFeed = 1600;  // 100 ms @ 16 kHz
+            for (size_t off = 0; off < a16.size(); off += kFeed) {
+                size_t len = std::min(kFeed, a16.size() - off);
+                stt_ptr->push_chunk(a16.data() + off, len);
+            }
+            hyp = stt_ptr->end_stream().text;
+        }
+        double sq = 0.0; float pk = 0.0f;
+        for (float s : a48) { sq += static_cast<double>(s) * s; pk = std::max(pk, std::abs(s)); }
+        double rms = std::sqrt(sq / std::max<size_t>(a48.size(), 1));
+        std::printf("    [%zu] tokens=%d dur=%.2fs rms=%.4f peak=%.4f  ref=\"%s\"  hyp=\"%s\"\n",
+                    i, tts.tokens_generated(),
+                    double(a48.size()) / 48000.0, rms, pk,
+                    p.c_str(), hyp.c_str());
+        std::fflush(stdout);
+    }
+    std::printf("  ok (WAVs in %s)\n", dump ? dump : "(no dump dir)");
+}
+
 }  // namespace
 
 int main() {
@@ -1212,6 +1382,7 @@ int main() {
     RUN(test_voxcpm2_c_api);
     RUN(test_litert_voxcpm2_parakeet_roundtrip);
     RUN(test_litert_voxcpm2_clone_parakeet_roundtrip);
+    RUN(test_litert_voxcpm2_hindi_cloning);
     #undef RUN
 
     if (failures > 0) {


### PR DESCRIPTION
## Summary

- Output amplitude of VoxCPM2 voice-cloning tracks the reference clip's RMS within ±10%. A reference at RMS ~0.002 (typical un-mastered phone-mic capture, the field-reported case driving this fix) clones at sub-audible level — users report it as "broken speech" / "missing audio".
- In both wrappers' `set_reference()`, scale the reference up to ~0.08 RMS with a 0.95 peak cap, but **only when the clip's measured RMS is below 0.04** — already-loud refs pass through unchanged, preserving bit-exact behaviour with the pre-fix path and with upstream Python.
- Empirical fix validation on the field-reported reference voice:
  - **before:** ref RMS 0.0019 → output RMS 0.001 (whisper)
  - **after:** ref RMS 0.0019 → output RMS 0.067 (baseline)
- On already-loud refs (RMS ≥ 0.04): output unchanged (block is a no-op).

## Why these numerical targets

Upstream `openbmb/VoxCPM2` has the same gap on the default code path; their opt-in `denoise=True` path normalizes to **−20 LUFS** via torchaudio. Their canonical reference fixtures sit at RMS ≈ 0.09 (`examples/reference_speaker.wav` measures **RMS 0.0896**, `examples/example.wav` measures RMS 0.157), which is why the symptom never surfaces with their test data. Our `kTargetRms=0.08` is essentially identical to `reference_speaker.wav`'s measured RMS, so the wrapper targets the upstream training/eval distribution.

| Knob | Value | Why |
|---|---|---|
| `kQuietThreshold` | 0.04 | Upstream-healthy refs are 0.09+; anything below 0.04 is well outside the training distribution. |
| `kTargetRms` | 0.08 | Matches upstream `reference_speaker.wav` within ~10%. |
| `kPeakCap` | 0.95 | Prevents clipping on clips with a high peak-to-RMS ratio after gain. |

## Files touched

| File | Change |
|---|---|
| `src/models/litert/litert_voxcpm2_tts.cpp` | rescue block in `set_reference()` after the existing silence trim |
| `src/models/voxcpm2/onnx_voxcpm2_tts.cpp` | same recipe (the ONNX wrapper had the identical bug) |
| `tests/test_litert_models.cpp` | new `test_litert_voxcpm2_hindi_cloning` — 5-phrase Hindi voice-cloning regression test with per-phrase RMS/peak/duration print; helpers for Unicode (Devanagari) tokenization and 48 kHz WAV dump; loads `tests/data/test_hindi_ref.wav` when present, falls back to the generic fixture otherwise |
| `scripts/spectrum_check.py` | offline WAV analysis (RMS, low-band fraction, spectral stability) — the heuristic used for the field-report triage |
| `docs/voxcpm2-clone-testing.md` | **how to test** — cross-platform guide covering the clone-CLI listening test (with pass-criteria RMS table) and the automated regression test, plus how to fabricate a quiet reference clip |

## Test plan

Full instructions: [`docs/voxcpm2-clone-testing.md`](https://github.com/soniqo/speech-core/blob/main/docs/voxcpm2-clone-testing.md). Summary:

- [x] CI green on all 8 jobs (unit tests ×3 OS, linux-cuda-buildonly compiles the ONNX wrapper change, both LiteRT builds).
- [x] Local core suite (`ctest -C Release`): 11/11 runnable tests pass (`test_hf_download` Not Run — requires `SPEECH_CORE_WITH_HF_DOWNLOAD=ON`, pre-existing config gap, unrelated to this diff).
- [x] Quiet reference (RMS 0.0019, the field-reported clip): output RMS 0.001 → **0.067** after fix; all 5 Hindi phrases ≥ 0.038.
- [x] Full LiteRT e2e suite with complete model bundle (Silero, Parakeet, WeSpeaker, Pyannote, Omnilingual, Nemotron streaming, VoxCPM2 incl. Parakeet roundtrips on the no-op path) — run locally on Windows/XNNPACK.
- [ ] Specialist listening verification per `docs/voxcpm2-clone-testing.md` (rescued output is intelligible cloned speech; healthy-ref output unchanged vs `main`).

## Not in this PR (follow-ups)

- `speech-swift`'s `encodeAudio` (`Sources/VoxCPM2TTS/VoxCPM2TTS.swift` around line 1040) has the same shape gap. Mac users haven't reported it because typical Mac reference clips are at upstream-healthy levels. A separate PR will land the equivalent fix in speech-swift once this lands here.
- Upstream `openbmb/VoxCPM2`'s default path also has the gap. Their opt-in `denoise=True` path already handles it via −20 LUFS normalization. Whether to upstream this as a default-path fix is their call.
