### PR TITLE
feat(packaging): Linux .deb/.tar.gz 'speech' CLI package + default model dirs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF — they execute on Linux/macOS (CI, containers,
+# the .deb's installed speech_download_models*) even when the repo is checked
+# out on Windows with core.autocrlf=true.
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,10 @@ jobs:
       - name: Download ONNX Runtime (aarch64)
         run: |
           ./examples/linux/setup_linux.sh aarch64
-          file ort-linux/lib/libonnxruntime.so | grep -q "aarch64"
+          # -L: libonnxruntime.so is now a symlink into the versioned .so
+          # (setup_linux.sh preserves the chain for packaging); follow it so
+          # `file` reports the ELF arch, not "symbolic link to ...".
+          file -L ort-linux/lib/libonnxruntime.so | grep -q "aarch64"
 
       - name: Configure
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,13 @@ jobs:
                   echo "UNRESOLVED LIBS in $exe"; exit 1
                 fi
               done
-              for sh in speech_download_models speech_download_models_litert; do
+              for sh in speech_download_models speech_download_models_litert speech; do
                 test -x "/usr/bin/$sh" || { echo "MISSING $sh"; exit 1; }
               done
+              # Multiplexer dispatch must reach the real binaries.
+              /usr/bin/speech --help | grep -q transcribe
+              out=$(/usr/bin/speech phonemize 2>&1 | head -2 || true)
+              [ -n "$out" ] || { echo "speech phonemize dispatch failed"; exit 1; }
               # Usage exits are non-zero by design; assert the binaries load
               # far enough to print *something* (a crash prints nothing).
               out=$(/usr/bin/speech_phonemize 2>&1 | head -2 || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release XCFramework
+name: Release
 
 on:
   push:
@@ -8,6 +8,146 @@ permissions:
   contents: write
 
 jobs:
+  # Linux CLI packages — .deb + .tar.gz per arch, attached to the release.
+  # Built on ubuntu-22.04 (oldest supported glibc 2.35) so the binaries run
+  # on 22.04, 24.04 and newer. amd64 is the full package (ONNX CLI tools +
+  # LiteRT voice-cloning CLI); arm64 is cross-compiled and ONNX-only, since
+  # fetch_litert.sh resolves the host-platform wheel and the cross sysroot
+  # has no ALSA (mirrors ci.yml's linux-examples-aarch64 lane).
+  build-linux-packages:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+          - arch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              build-essential cmake libasound2-dev curl ca-certificates \
+              python3-pip unzip file
+
+      - name: Install cross toolchain (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              g++-aarch64-linux-gnu gcc-aarch64-linux-gnu cmake curl \
+              ca-certificates file
+
+      - name: Download ONNX Runtime
+        run: |
+          ./examples/linux/setup_linux.sh ${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}
+          ls -la ort-linux/lib/
+
+      - name: Fetch LiteRT runtime (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          ./scripts/fetch_litert.sh litert-linux
+          ls -la litert-linux/
+
+      - name: Configure (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          cmake -B build-pkg \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSPEECH_CORE_WITH_ONNX=ON \
+              -DSPEECH_CORE_WITH_LITERT=ON \
+              -DLITERT_DIR=litert-linux \
+              -DSPEECH_CORE_BUILD_EXAMPLES=ON \
+              -DSPEECH_CORE_BUILD_TESTS=OFF \
+              -DSPEECH_LINUX_BUILD_TESTS=OFF \
+              -DSPEECH_CORE_PACKAGE=ON \
+              -DSPEECH_CORE_PACKAGE_VERSION=${GITHUB_REF_NAME#v} \
+              -DORT_DIR=ort-linux
+
+      - name: Configure (arm64 cross)
+        if: matrix.arch == 'arm64'
+        run: |
+          cmake -B build-pkg \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
+              -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ \
+              -DCMAKE_SYSTEM_NAME=Linux \
+              -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
+              -DSPEECH_CORE_WITH_ONNX=ON \
+              -DSPEECH_CORE_BUILD_EXAMPLES=ON \
+              -DSPEECH_CORE_BUILD_TESTS=OFF \
+              -DSPEECH_LINUX_BUILD_DEMO=OFF \
+              -DSPEECH_LINUX_BUILD_TESTS=OFF \
+              -DSPEECH_CORE_PACKAGE=ON \
+              -DSPEECH_CORE_PACKAGE_VERSION=${GITHUB_REF_NAME#v} \
+              -DORT_DIR=ort-linux
+
+      - name: Build
+        run: cmake --build build-pkg --parallel
+
+      - name: Package
+        run: |
+          cd build-pkg
+          cpack -B ../dist
+          ls -la ../dist
+
+      - name: Smoke-test .deb in clean containers (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          for img in ubuntu:22.04 ubuntu:24.04; do
+            echo "=== $img ==="
+            docker run --rm -v "$PWD/dist:/dist:ro" "$img" bash -ec '
+              apt-get update -q
+              apt-get install -yq /dist/speech_*_amd64.deb
+              for exe in speech_transcribe speech_synthesize speech_phonemize \
+                         speech_voxcpm2_clone speech_demo; do
+                echo "--- ldd $exe"
+                test -x "/usr/bin/$exe" || { echo "MISSING $exe"; exit 1; }
+                if ldd /usr/bin/$exe | grep "not found"; then
+                  echo "UNRESOLVED LIBS in $exe"; exit 1
+                fi
+              done
+              for sh in speech_download_models speech_download_models_litert; do
+                test -x "/usr/bin/$sh" || { echo "MISSING $sh"; exit 1; }
+              done
+              # Usage exits are non-zero by design; assert the binaries load
+              # far enough to print *something* (a crash prints nothing).
+              out=$(/usr/bin/speech_phonemize 2>&1 | head -2 || true)
+              [ -n "$out" ] || { echo "speech_phonemize produced no output"; exit 1; }
+              out=$(/usr/bin/speech_voxcpm2_clone 2>&1 | head -2 || true)
+              [ -n "$out" ] || { echo "speech_voxcpm2_clone produced no output"; exit 1; }
+              echo SMOKE-OK
+            '
+          done
+
+      - name: Verify arm64 artefacts (cross — no execution possible)
+        if: matrix.arch == 'arm64'
+        run: |
+          # The .deb can't be installed on the x86_64 runner; assert the staged
+          # binaries are really aarch64 and carry the packaging RPATH.
+          for exe in build-pkg/examples/linux/speech_transcribe \
+                     build-pkg/examples/linux/speech_synthesize \
+                     build-pkg/examples/linux/speech_phonemize; do
+            file "$exe" | tee /dev/stderr | grep -q "aarch64"
+            readelf -d "$exe" | tee /dev/stderr | grep -E "RUNPATH|RPATH" | grep -q '\$ORIGIN/../lib'
+          done
+          dpkg -c dist/speech_*_arm64.deb | grep -E "bin/|lib/" | head -30
+
+      # Pure asset upload — never PATCHes the release body, so it can't race
+      # the xcframework job's checksum notes (gh release upload only POSTs to
+      # the asset endpoint). The empty-notes create is a no-op if the release
+      # already exists; --clobber makes re-runs idempotent.
+      - name: Attach packages to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --verify-tag --notes "" || true
+          gh release upload "$GITHUB_REF_NAME" dist/*.deb dist/*.tar.gz --clobber
+
   build-xcframework:
     runs-on: macos-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,6 +676,12 @@ if(SPEECH_CORE_PACKAGE)
             DESTINATION bin RENAME speech_download_models_litert)
     endif()
 
+    # `speech` multiplexer — verb-style front-end (speech transcribe …,
+    # speech speak …) matching speech-swift's CLI on macOS
+    # (brew install soniqo/tap/speech), so cross-platform docs share one
+    # command surface. Dispatches to the sibling speech_* binaries.
+    install(PROGRAMS scripts/speech-dispatch.sh DESTINATION bin RENAME speech)
+
     # --- CPack ---
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
         set(_pkg_arch "arm64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ option(SPEECH_CORE_WITH_LITERT "Build the speech_core_models_litert target with 
 option(SPEECH_CORE_WITH_HF_DOWNLOAD "Enable libcurl-backed Hugging Face model downloads (sc_voxcpm2_create_from_pretrained: resumable, retried first-run fetch of the LiteRT bundle). Requires SPEECH_CORE_WITH_LITERT=ON and libcurl (find_package(CURL))." OFF)
 option(SPEECH_CORE_BUILD_EXAMPLES "Build examples/ (Linux C ABI lib, ALSA demo, CLI tools, integration tests). Requires SPEECH_CORE_WITH_ONNX=ON." OFF)
 option(SPEECH_CORE_WITH_OLLAMA "Build the speech_core_llm_ollama target — Ollama HTTP LLM adapter (tool-calling agents over /api/chat). Vendors cpp-httplib + nlohmann/json under third_party/; no system deps beyond OS sockets." OFF)
+option(SPEECH_CORE_PACKAGE "Add install rules for the CLI tools + bundled runtime libraries and configure CPack (Linux .deb / .tar.gz). Linux-only; see the Packaging section at the bottom of this file." OFF)
+set(SPEECH_CORE_PACKAGE_VERSION "${PROJECT_VERSION}" CACHE STRING "Version stamped into binary packages. The release workflow passes the git tag (e.g. 0.0.8); local builds default to the project version.")
 
 if(SPEECH_CORE_WITH_CUDA AND NOT SPEECH_CORE_WITH_ONNX)
     message(FATAL_ERROR "SPEECH_CORE_WITH_CUDA=ON requires SPEECH_CORE_WITH_ONNX=ON "
@@ -555,26 +557,31 @@ endif()
 # Install
 # ---------------------------------------------------------------------------
 
-set(_install_targets speech_core)
-if(SPEECH_CORE_WITH_ONNX)
-    list(APPEND _install_targets speech_core_models)
-endif()
-if(SPEECH_CORE_WITH_LITERT)
-    list(APPEND _install_targets speech_core_models_litert)
-endif()
-if(SPEECH_CORE_WITH_OLLAMA)
-    list(APPEND _install_targets speech_core_llm_ollama)
-endif()
+# Dev install rules (static libs + headers) — skipped when building the
+# end-user CLI package (SPEECH_CORE_PACKAGE=ON), which would otherwise drop
+# tens of MB of .a files and the header tree into /usr.
+if(NOT SPEECH_CORE_PACKAGE)
+    set(_install_targets speech_core)
+    if(SPEECH_CORE_WITH_ONNX)
+        list(APPEND _install_targets speech_core_models)
+    endif()
+    if(SPEECH_CORE_WITH_LITERT)
+        list(APPEND _install_targets speech_core_models_litert)
+    endif()
+    if(SPEECH_CORE_WITH_OLLAMA)
+        list(APPEND _install_targets speech_core_llm_ollama)
+    endif()
 
-install(TARGETS ${_install_targets}
-    EXPORT speech_core-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
+    install(TARGETS ${_install_targets}
+        EXPORT speech_core-targets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+    )
 
-install(DIRECTORY include/speech_core
-    DESTINATION include
-)
+    install(DIRECTORY include/speech_core
+        DESTINATION include
+    )
+endif()
 
 # ---------------------------------------------------------------------------
 # Examples (optional)
@@ -587,4 +594,117 @@ if(SPEECH_CORE_BUILD_EXAMPLES)
             " (the examples consume speech_core_models)")
     endif()
     add_subdirectory(examples/linux)
+endif()
+
+# ---------------------------------------------------------------------------
+# Packaging (optional) — Linux .deb / .tar.gz with the CLI tools
+#
+# Adds RUNTIME install rules for whichever CLI executables the enabled options
+# produced, bundles the runtime shared libraries that no distro packages
+# (libonnxruntime.so, libLiteRt.so) into a private lib/speech-core/ dir wired
+# up via $ORIGIN RPATHs, and configures CPack DEB+TGZ generators. Models are
+# never packaged — they are fetched at runtime from HuggingFace (see
+# scripts/download_models*.sh and docs/models.md).
+#
+# Driven by .github/workflows/release.yml on v* tags; for a local package:
+#   cmake -B build-pkg -DCMAKE_BUILD_TYPE=Release \
+#       -DSPEECH_CORE_WITH_ONNX=ON -DORT_DIR=ort-linux \
+#       -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=litert-linux \
+#       -DSPEECH_CORE_BUILD_EXAMPLES=ON -DSPEECH_CORE_BUILD_TESTS=OFF \
+#       -DSPEECH_CORE_PACKAGE=ON
+#   cmake --build build-pkg --parallel && (cd build-pkg && cpack -B ../dist)
+# ---------------------------------------------------------------------------
+
+if(SPEECH_CORE_PACKAGE)
+    if(NOT UNIX OR APPLE OR ANDROID)
+        message(FATAL_ERROR "SPEECH_CORE_PACKAGE=ON currently targets Linux only")
+    endif()
+
+    # Collect whichever CLI targets this configuration actually built.
+    set(_pkg_cli_targets "")
+    foreach(_t speech_demo speech_transcribe speech_synthesize speech_phonemize
+               speech_voxcpm2_clone)
+        if(TARGET ${_t})
+            list(APPEND _pkg_cli_targets ${_t})
+        endif()
+    endforeach()
+    if(NOT _pkg_cli_targets)
+        message(FATAL_ERROR
+            "SPEECH_CORE_PACKAGE=ON but no CLI executables are enabled — turn on"
+            " SPEECH_CORE_BUILD_EXAMPLES (ONNX tools) and/or SPEECH_CORE_WITH_LITERT"
+            " (speech_voxcpm2_clone)")
+    endif()
+
+    # Executables install to bin/, bundled runtimes to lib/speech/, the
+    # example C ABI lib (libspeech.so) to lib/. $ORIGIN RPATHs make the package
+    # self-contained without ld.so.conf entries.
+    set_target_properties(${_pkg_cli_targets} PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/../lib;\$ORIGIN/../lib/speech")
+    install(TARGETS ${_pkg_cli_targets} RUNTIME DESTINATION bin)
+
+    if(TARGET speech)
+        set_target_properties(speech PROPERTIES
+            INSTALL_RPATH "\$ORIGIN;\$ORIGIN/speech")
+        install(TARGETS speech LIBRARY DESTINATION lib)
+    endif()
+
+    # Runtime shared libraries that no distro packages. setup_linux.sh keeps
+    # the libonnxruntime.so -> .so.X.Y.Z symlink chain (cp -RP); the glob picks
+    # up every name and install(PROGRAMS) preserves symlinks, so the SONAME
+    # chain stays intact in lib/speech without duplicate payload.
+    if(SPEECH_CORE_WITH_ONNX)
+        file(GLOB _pkg_ort_libs "${ORT_DIR}/lib/libonnxruntime.so*")
+        if(NOT _pkg_ort_libs)
+            message(FATAL_ERROR "SPEECH_CORE_PACKAGE: no libonnxruntime.so* under ${ORT_DIR}/lib")
+        endif()
+        install(PROGRAMS ${_pkg_ort_libs} DESTINATION lib/speech)
+    endif()
+    if(SPEECH_CORE_WITH_LITERT)
+        install(PROGRAMS "${LITERT_DIR}/libLiteRt.so" DESTINATION lib/speech)
+    endif()
+
+    install(FILES LICENSE THIRD-PARTY-NOTICES.md DESTINATION share/doc/speech)
+
+    # Model fetchers, renamed into the speech_ command namespace. When run
+    # from the read-only install location they default to the per-user cache
+    # dir (~/.cache/speech-core/models*) — the same place the CLIs look when
+    # invoked without a model_dir argument.
+    install(PROGRAMS scripts/download_models.sh
+        DESTINATION bin RENAME speech_download_models)
+    if(SPEECH_CORE_WITH_LITERT)
+        install(PROGRAMS scripts/download_models_litert.sh
+            DESTINATION bin RENAME speech_download_models_litert)
+    endif()
+
+    # --- CPack ---
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+        set(_pkg_arch "arm64")
+    else()
+        set(_pkg_arch "amd64")
+    endif()
+
+    set(CPACK_GENERATOR "DEB;TGZ")
+    set(CPACK_PACKAGE_NAME "speech")
+    set(CPACK_PACKAGE_VERSION "${SPEECH_CORE_PACKAGE_VERSION}")
+    set(CPACK_PACKAGE_CONTACT "ivan-digital <ivan.aufkl@gmail.com>")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+        "speech — voice agent CLI tools (STT, TTS, phonemizer, voice cloning)")
+    set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/soniqo/speech-core")
+    set(CPACK_PACKAGE_FILE_NAME "speech-${SPEECH_CORE_PACKAGE_VERSION}-linux-${_pkg_arch}")
+    set(CPACK_STRIP_FILES ON)
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
+    set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${_pkg_arch}")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "sound")
+    set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/soniqo/speech-core")
+    # Hand-written Depends (dpkg-shlibdeps can't resolve our private
+    # lib/speech-core dir). Built on ubuntu-22.04 → needs glibc ≥ 2.35.
+    # libasound2t64 is the 24.04 time64 rename; the alternation covers 22.04.
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.35), libstdc++6 (>= 11)")
+    if(TARGET speech_demo)
+        string(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS ", libasound2t64 | libasound2")
+    endif()
+
+    include(CPack)
 endif()

--- a/README.md
+++ b/README.md
@@ -208,6 +208,29 @@ LiteRT headers are vendored in `third_party/litert/` (no setup). `LITERT_DIR` po
 
 **On-device model download (optional).** Add `-DSPEECH_CORE_WITH_HF_DOWNLOAD=ON` to fetch model bundles from Hugging Face on first use instead of provisioning them by hand. It links libcurl (`find_package(CURL)` — system libcurl on Linux/macOS, vcpkg on Windows) and adds `sc_voxcpm2_create_from_pretrained("soniqo/VoxCPM2-LiteRT", …)` to the [VoxCPM2 C ABI](include/speech_core/voxcpm2_c.h): a resumable, retrying download (HTTP Range, atomic rename) that tolerates network interruptions and caches under the OS cache dir (`SPEECH_CORE_CACHE_DIR` to override; `HF_ENDPOINT` for a mirror). Off by default so embedded/offline builds carry no HTTP/TLS dependency. The `hf_fetch` debug CLI exercises it directly.
 
+### Install on Linux (prebuilt `speech` package)
+
+Each release ships `.deb` and `.tar.gz` packages with the CLI tools
+(`speech_transcribe`, `speech_synthesize`, `speech_phonemize`, `speech_demo`,
+and on amd64 the `speech_voxcpm2_clone` voice-cloning CLI), with
+`libonnxruntime.so` / `libLiteRt.so` bundled under `/usr/lib/speech/` — no
+extra runtime setup:
+
+```bash
+# amd64 (arm64: speech_VERSION_arm64.deb — transcribe/synthesize/phonemize only)
+curl -LO https://github.com/soniqo/speech-core/releases/latest/download/speech_VERSION_amd64.deb
+sudo apt install ./speech_VERSION_amd64.deb
+
+speech_download_models           # ONNX set → ~/.cache/speech-core/models (~1.2 GB)
+speech_transcribe input.wav      # tools find the cache dir automatically
+```
+
+Models are never inside the package. The tools look in `$SPEECH_MODEL_DIR`
+(LiteRT: `$SPEECH_LITERT_MODEL_DIR`), falling back to the per-user cache dir
+that `speech_download_models` / `speech_download_models_litert` populate; an
+explicit model-dir argument always wins. Ubuntu 22.04+ / Debian 12+
+(glibc ≥ 2.35).
+
 ## Testing & CI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -221,9 +221,13 @@ extra runtime setup:
 curl -LO https://github.com/soniqo/speech-core/releases/latest/download/speech_VERSION_amd64.deb
 sudo apt install ./speech_VERSION_amd64.deb
 
-speech_download_models           # ONNX set → ~/.cache/speech-core/models (~1.2 GB)
-speech_transcribe input.wav      # tools find the cache dir automatically
+speech download-models           # ONNX set → ~/.cache/speech-core/models (~1.2 GB)
+speech transcribe input.wav      # same verb-style CLI as speech-swift's `brew install speech`
+speech speak "Hello world"
 ```
+
+The `speech` command dispatches to standalone `speech_<command>` binaries
+(`speech_transcribe`, `speech_synthesize`, …) which expose extra options.
 
 Models are never inside the package. The tools look in `$SPEECH_MODEL_DIR`
 (LiteRT: `$SPEECH_LITERT_MODEL_DIR`), falling back to the per-user cache dir

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -208,6 +208,29 @@ LiteRT 头文件随仓库内置于 `third_party/litert/`（无需额外配置）
 
 **设备端模型下载（可选）。** 添加 `-DSPEECH_CORE_WITH_HF_DOWNLOAD=ON` 可在首次使用时从 Hugging Face 拉取模型 bundle，免去手动配置。该选项链接 libcurl（`find_package(CURL)` —— Linux/macOS 使用系统 libcurl，Windows 使用 vcpkg），并为 [VoxCPM2 C ABI](include/speech_core/voxcpm2_c.h) 增加 `sc_voxcpm2_create_from_pretrained("soniqo/VoxCPM2-LiteRT", …)`：可恢复、可重试的下载（HTTP Range、原子重命名），容忍网络中断，缓存在系统缓存目录（`SPEECH_CORE_CACHE_DIR` 可覆盖；`HF_ENDPOINT` 可使用镜像）。默认关闭，嵌入式/离线构建不会引入 HTTP/TLS 依赖。`hf_fetch` 调试 CLI 可直接演练该流程。
 
+### 在 Linux 上安装（预编译 `speech` 软件包）
+
+每个 release 都附带 `.deb` 和 `.tar.gz` 软件包，内含 CLI 工具
+（`speech_transcribe`、`speech_synthesize`、`speech_phonemize`、`speech_demo`，
+amd64 还包含声音克隆 CLI `speech_voxcpm2_clone`），并将
+`libonnxruntime.so` / `libLiteRt.so` 一并打包在 `/usr/lib/speech/` 下 ——
+无需额外的运行时配置：
+
+```bash
+# amd64（arm64：speech_VERSION_arm64.deb —— 仅含 transcribe/synthesize/phonemize）
+curl -LO https://github.com/soniqo/speech-core/releases/latest/download/speech_VERSION_amd64.deb
+sudo apt install ./speech_VERSION_amd64.deb
+
+speech_download_models           # ONNX 模型集 → ~/.cache/speech-core/models（约 1.2 GB）
+speech_transcribe input.wav      # 工具会自动找到缓存目录
+```
+
+软件包不含任何模型。工具按 `$SPEECH_MODEL_DIR`（LiteRT 为
+`$SPEECH_LITERT_MODEL_DIR`）查找模型，未设置时回退到
+`speech_download_models` / `speech_download_models_litert` 填充的用户缓存目录；
+显式传入的模型目录参数始终优先。要求 Ubuntu 22.04+ / Debian 12+
+（glibc ≥ 2.35）。
+
 ## 测试与 CI
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,9 +221,13 @@ amd64 还包含声音克隆 CLI `speech_voxcpm2_clone`），并将
 curl -LO https://github.com/soniqo/speech-core/releases/latest/download/speech_VERSION_amd64.deb
 sudo apt install ./speech_VERSION_amd64.deb
 
-speech_download_models           # ONNX 模型集 → ~/.cache/speech-core/models（约 1.2 GB）
-speech_transcribe input.wav      # 工具会自动找到缓存目录
+speech download-models           # ONNX 模型集 → ~/.cache/speech-core/models（约 1.2 GB）
+speech transcribe input.wav      # 与 speech-swift 的 `brew install speech` 相同的子命令式 CLI
+speech speak "Hello world"
 ```
+
+`speech` 命令会分发到独立的 `speech_<command>` 可执行文件
+（`speech_transcribe`、`speech_synthesize` 等），后者提供更多选项。
 
 软件包不含任何模型。工具按 `$SPEECH_MODEL_DIR`（LiteRT 为
 `$SPEECH_LITERT_MODEL_DIR`）查找模型，未设置时回退到

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,55 @@
+# Third-party notices
+
+Binary distributions of the `speech` package (the `.deb` / `.tar.gz` packages published
+on GitHub Releases) bundle the following third-party runtime libraries. The
+speech-core source tree itself has no third-party code beyond the vendored
+LiteRT C API headers noted below.
+
+## ONNX Runtime
+
+- **Files:** `lib/speech/libonnxruntime.so*`
+- **Source:** https://github.com/microsoft/onnxruntime (prebuilt release binaries)
+- **License:** MIT — https://github.com/microsoft/onnxruntime/blob/main/LICENSE
+- Copyright (c) Microsoft Corporation
+
+## LiteRT (`libLiteRt.so`)
+
+- **Files:** `lib/speech/libLiteRt.so`
+- **Source:** extracted from Google's [`ai-edge-litert`](https://pypi.org/project/ai-edge-litert/)
+  PyPI package (see `scripts/fetch_litert.sh`); upstream repository
+  https://github.com/google-ai-edge/LiteRT
+- **License:** Apache License 2.0 —
+  https://github.com/google-ai-edge/LiteRT/blob/main/LICENSE
+- Copyright Google LLC. This product includes software developed at Google
+  as part of the LiteRT / TensorFlow Lite projects. Use of this library does
+  not imply endorsement by Google.
+
+The LiteRT shared library statically incorporates the following components,
+each under its own permissive license:
+
+| Component | License |
+|---|---|
+| TensorFlow / TensorFlow Lite | Apache-2.0 |
+| XNNPACK | BSD-3-Clause |
+| Eigen | MPL-2.0 |
+| FlatBuffers | Apache-2.0 |
+| ruy | Apache-2.0 |
+| farmhash | MIT |
+| FP16 / pthreadpool / cpuinfo | BSD-2/3-Clause |
+| Abseil | Apache-2.0 |
+
+Refer to the upstream LiteRT repository's `LICENSE` and third-party notices
+for the complete texts.
+
+## Vendored headers (source tree)
+
+- **Files:** `third_party/litert/` (~44 LiteRT C API headers)
+- **License:** Apache License 2.0 (same as LiteRT above)
+
+## Models
+
+No machine-learning models are included in any speech-core package. Models
+are downloaded separately by the user at runtime (see
+`scripts/download_models.sh`, `scripts/download_models_litert.sh`, and
+`docs/models.md`) and are governed by their own licenses as published on
+their respective HuggingFace repositories.

--- a/docs/voxcpm2-clone-testing.md
+++ b/docs/voxcpm2-clone-testing.md
@@ -53,13 +53,16 @@ On Windows, copy `libLiteRt.dll` next to the executables in `build\Release\`.
 
 Run the same text through both references:
 
-```bash
-BUNDLE=scripts/models-litert
+`bundle_dir` is optional: omit it and the CLI reads `$SPEECH_LITERT_MODEL_DIR`
+(else the per-user cache dir). An explicit first-arg directory still wins.
 
-./build/speech_voxcpm2_clone "$BUNDLE" quiet_ref.wav \
+```bash
+export SPEECH_LITERT_MODEL_DIR=scripts/models-litert
+
+./build/speech_voxcpm2_clone quiet_ref.wav \
     "The quick brown fox jumps over the lazy dog" out_quiet.wav
 
-./build/speech_voxcpm2_clone "$BUNDLE" tests/data/test_audio.wav \
+./build/speech_voxcpm2_clone tests/data/test_audio.wav \
     "The quick brown fox jumps over the lazy dog" out_healthy.wav
 ```
 

--- a/examples/common/default_model_dir.h
+++ b/examples/common/default_model_dir.h
@@ -1,0 +1,46 @@
+#pragma once
+// Default model-directory resolution for the example CLIs, so the installed
+// `speech` package works without a model-dir argument once models are fetched:
+//
+//   scripts/download_models.sh ~/.cache/speech-core/models
+//   speech_transcribe input.wav
+//
+// ONNX tools:   $SPEECH_MODEL_DIR        else <cache>/models
+// VoxCPM2 CLI:  $SPEECH_LITERT_MODEL_DIR else <cache>/soniqo__VoxCPM2-LiteRT
+//               (where sc_voxcpm2_create_from_pretrained / hf_fetch place the
+//               downloaded bundle — repo id with '/' sanitized to '__')
+// <cache>:      $SPEECH_CORE_CACHE_DIR else %LOCALAPPDATA%\speech-core on
+//               Windows, else $XDG_CACHE_HOME/speech-core, else
+//               ~/.cache/speech-core
+//
+// Mirrors default_cache_dir() in src/models/litert/voxcpm2_c.cpp — keep the
+// two in sync so the CLIs find what the in-library downloader fetched.
+
+#include <cstdlib>
+#include <string>
+
+inline std::string speech_example_cache_dir() {
+    if (const char* c = std::getenv("SPEECH_CORE_CACHE_DIR"); c && *c) return c;
+#ifdef _WIN32
+    if (const char* la = std::getenv("LOCALAPPDATA"); la && *la)
+        return std::string(la) + "\\speech-core";
+#else
+    if (const char* x = std::getenv("XDG_CACHE_HOME"); x && *x)
+        return std::string(x) + "/speech-core";
+    if (const char* h = std::getenv("HOME"); h && *h)
+        return std::string(h) + "/.cache/speech-core";
+#endif
+    return "./speech-core-cache";
+}
+
+/// Default directory for the ONNX model set (Silero, Parakeet, Kokoro, …).
+inline std::string speech_example_model_dir() {
+    if (const char* e = std::getenv("SPEECH_MODEL_DIR"); e && *e) return e;
+    return speech_example_cache_dir() + "/models";
+}
+
+/// Default directory for the VoxCPM2 LiteRT bundle.
+inline std::string speech_example_voxcpm2_dir() {
+    if (const char* e = std::getenv("SPEECH_LITERT_MODEL_DIR"); e && *e) return e;
+    return speech_example_cache_dir() + "/soniqo__VoxCPM2-LiteRT";
+}

--- a/examples/linux/demo/main.cpp
+++ b/examples/linux/demo/main.cpp
@@ -1,9 +1,12 @@
 #include "speech.h"
 
+#include "../../common/default_model_dir.h"
+
 #include <cstdio>
 #include <cstdlib>
 #include <csignal>
 #include <cstring>
+#include <string>
 #include <unistd.h>
 
 #ifdef HAS_ALSA
@@ -40,10 +43,14 @@ static void on_event(const speech_event_t* event, void* /*ctx*/) {
 }
 
 static void print_usage(const char* prog) {
-    fprintf(stderr, "Usage: %s --model-dir <path> [--qnn] [--transcribe-only] [--device <alsa_dev>]\n", prog);
+    fprintf(stderr,
+        "Usage: %s [--model-dir <path>] [--qnn] [--transcribe-only] [--device <alsa_dev>]\n"
+        "  --model-dir defaults to $SPEECH_MODEL_DIR, else %s\n",
+        prog, speech_example_model_dir().c_str());
 }
 
 int main(int argc, char* argv[]) {
+    std::string model_dir_storage;
     const char* model_dir = nullptr;
     const char* alsa_device = "default";
     bool use_qnn = false;
@@ -65,8 +72,8 @@ int main(int argc, char* argv[]) {
     }
 
     if (!model_dir) {
-        print_usage(argv[0]);
-        return 1;
+        model_dir_storage = speech_example_model_dir();
+        model_dir = model_dir_storage.c_str();
     }
 
     fprintf(stderr, "speech-linux %s\n", speech_version());

--- a/examples/linux/setup_linux.sh
+++ b/examples/linux/setup_linux.sh
@@ -48,7 +48,10 @@ if [ ! -f "${ORT_DIR}/include/onnxruntime_c_api.h" ]; then
 
     mkdir -p "${ORT_DIR}/include" "${ORT_DIR}/lib"
     cp "${ORT_EXTRACTED}"/include/*.h "${ORT_DIR}/include/"
-    cp "${ORT_EXTRACTED}"/lib/${ORT_LIB_GLOB} "${ORT_DIR}/lib/"
+    # -RP: preserve the libonnxruntime.so -> .so.X.Y.Z symlink chain instead of
+    # dereferencing into duplicate ~16 MB copies (packaging installs this dir
+    # verbatim; -P alone doesn't suppress dereference on BSD cp without -R).
+    cp -RP "${ORT_EXTRACTED}"/lib/${ORT_LIB_GLOB} "${ORT_DIR}/lib/"
 
     rm -rf "${TMP_DIR}"
     echo "ONNX Runtime installed to ${ORT_DIR}"

--- a/examples/linux/tools/phonemize.cpp
+++ b/examples/linux/tools/phonemize.cpp
@@ -2,25 +2,35 @@
 // produces for a piece of text. Used to verify text→phoneme conversion is
 // correct before blaming the TTS model.
 //
-// Usage: speech_phonemize <model_dir> "<text>" [language]
+// Usage: speech_phonemize [model_dir] "<text>" [language]
 
 #include <speech_core/models/kokoro_phonemizer.h>
 
+#include "../../common/default_model_dir.h"
+
 #include <cstdio>
+#include <filesystem>
 #include <string>
 
 int main(int argc, char** argv) {
-    if (argc < 3) {
+    if (argc < 2) {
         std::fprintf(stderr,
-            "usage: %s <model_dir> \"<text>\" [language]\n"
+            "usage: %s [model_dir] \"<text>\" [language]\n"
             "  model_dir : directory holding vocab_index.json + dictionaries\n"
+            "              (default: $SPEECH_MODEL_DIR, else %s)\n"
             "  language  : BCP-47 tag (default: en)\n",
-            argv[0]);
+            argv[0], speech_example_model_dir().c_str());
         return 2;
     }
-    const std::string model_dir = argv[1];
-    const std::string text      = argv[2];
-    const std::string language  = (argc >= 4) ? argv[3] : "en";
+    // model_dir is optional. With 3 args, <model_dir> <text> and
+    // <text> <language> are both plausible — disambiguate by whether argv[1]
+    // is an existing directory.
+    const bool has_dir = (argc >= 4)
+        || (argc == 3 && std::filesystem::is_directory(argv[1]));
+    const int base = has_dir ? 2 : 1;
+    const std::string model_dir = has_dir ? argv[1] : speech_example_model_dir();
+    const std::string text      = argv[base];
+    const std::string language  = (argc >= base + 2) ? argv[base + 1] : "en";
 
     speech_core::KokoroPhonemizer p;
     if (!p.load_vocab(model_dir + "/vocab_index.json")) {

--- a/examples/linux/tools/synthesize.cpp
+++ b/examples/linux/tools/synthesize.cpp
@@ -1,6 +1,7 @@
 // Tiny CLI that runs Kokoro TTS on a piece of text and writes the audio to a WAV.
 //
-// Usage: speech_synthesize <model_dir> <output.wav> "<text>" [language]
+// Usage: speech_synthesize [model_dir] <output.wav> "<text>" [language]
+//        (model_dir defaults to $SPEECH_MODEL_DIR, else ~/.cache/speech-core/models)
 //
 // Pairs with speech_transcribe — round-trip a known prompt through synthesis
 // and back through STT to surface phonemizer / tokenizer / decoder bugs
@@ -11,9 +12,12 @@
 
 #include <speech_core/models/kokoro_tts.h>
 
+#include "../../common/default_model_dir.h"
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -62,18 +66,29 @@ static bool write_wav(const std::string& path,
 }  // namespace
 
 int main(int argc, char** argv) {
-    if (argc < 4) {
+    if (argc < 3) {
         std::fprintf(stderr,
-            "usage: %s <model_dir> <output.wav> \"<text>\" [language]\n"
+            "usage: %s [model_dir] <output.wav> \"<text>\" [language]\n"
             "  model_dir : directory holding kokoro-e2e.onnx + voices/*.bin\n"
+            "              (default: $SPEECH_MODEL_DIR, else %s)\n"
             "  language  : BCP-47 tag (default: en). Auto-switches voice.\n",
-            argv[0]);
+            argv[0], speech_example_model_dir().c_str());
         return 2;
     }
-    const std::string model_dir = argv[1];
-    const std::string out_wav   = argv[2];
-    const std::string text      = argv[3];
-    const std::string language  = (argc >= 5) ? argv[4] : "en";
+    // model_dir is optional. Old form: <model_dir> <out.wav> <text> [lang];
+    // new form drops model_dir. With 4 args, both parses are plausible —
+    // disambiguate by whether argv[1] is an existing directory.
+    const bool has_dir = (argc >= 5)
+        || (argc == 4 && std::filesystem::is_directory(argv[1]));
+    const int base = has_dir ? 2 : 1;
+    if (argc < base + 2) {
+        std::fprintf(stderr, "usage: %s [model_dir] <output.wav> \"<text>\" [language]\n", argv[0]);
+        return 2;
+    }
+    const std::string model_dir = has_dir ? argv[1] : speech_example_model_dir();
+    const std::string out_wav   = argv[base];
+    const std::string text      = argv[base + 1];
+    const std::string language  = (argc >= base + 3) ? argv[base + 2] : "en";
 
     speech_core::KokoroTts tts(model_dir + "/kokoro-e2e.onnx",
                                model_dir + "/voices",

--- a/examples/linux/tools/transcribe.cpp
+++ b/examples/linux/tools/transcribe.cpp
@@ -1,6 +1,7 @@
 // Tiny CLI that runs Parakeet STT on a WAV file and prints what it heard.
 //
-// Usage: speech_transcribe <model_dir> <input.wav>
+// Usage: speech_transcribe [model_dir] <input.wav>
+//        (model_dir defaults to $SPEECH_MODEL_DIR, else ~/.cache/speech-core/models)
 //
 // Reads PCM Float32 / Int16 / Int24 mono or stereo at any sample rate, then
 // resamples + downmixes to 16 kHz mono Float32 and feeds it through the
@@ -10,6 +11,8 @@
 // No external deps beyond libspeech.
 
 #include "speech.h"
+
+#include "../../common/default_model_dir.h"
 
 #include <atomic>
 #include <chrono>
@@ -196,16 +199,17 @@ static void on_event(const speech_event_t* event, void* ctx) {
 }  // namespace
 
 int main(int argc, char** argv) {
-    if (argc != 3) {
+    if (argc != 2 && argc != 3) {
         std::fprintf(stderr,
-            "usage: %s <model_dir> <input.wav>\n"
+            "usage: %s [model_dir] <input.wav>\n"
             "  model_dir : directory holding parakeet-* + silero-vad.onnx\n"
+            "              (default: $SPEECH_MODEL_DIR, else %s)\n"
             "  input.wav : audio to transcribe (mono or stereo, 16-bit/24-bit/float)\n",
-            argv[0]);
+            argv[0], speech_example_model_dir().c_str());
         return 2;
     }
-    const std::string model_dir = argv[1];
-    const std::string wav_path  = argv[2];
+    const std::string model_dir = (argc == 3) ? argv[1] : speech_example_model_dir();
+    const std::string wav_path  = (argc == 3) ? argv[2] : argv[1];
 
     WavData wav;
     std::string err;

--- a/examples/litert/voxcpm2_clone.cpp
+++ b/examples/litert/voxcpm2_clone.cpp
@@ -4,11 +4,14 @@
 // synthesizes the given text in that voice — writing a 48 kHz mono WAV.
 //
 // Usage:
-//   speech_voxcpm2_clone <bundle_dir> <ref.wav> "<text>" <out.wav> \
+//   speech_voxcpm2_clone [bundle_dir] <ref.wav> "<text>" <out.wav> \
 //       [instruction] [max_steps]
 //
 //   bundle_dir  : directory holding voxcpm2-{text-prefill,token-step,
 //                 audio-encoder,audio-decoder}.tflite + tokenizer.json
+//                 (default: $SPEECH_LITERT_MODEL_DIR, else the per-user cache
+//                 dir where sc_voxcpm2_create_from_pretrained downloads the
+//                 bundle — ~/.cache/speech-core/soniqo__VoxCPM2-LiteRT)
 //   ref.wav     : reference speaker clip (mono/stereo PCM-16 WAV, any rate;
 //                 resampled to 16 kHz and trimmed/padded to 6.4 s internally)
 //   instruction : optional style prefix, e.g. "calm, clear delivery"
@@ -24,6 +27,7 @@
 #include <speech_core/models/litert_voxcpm2_tts.h>
 
 #include "../common/utf8_args.h"
+#include "../common/default_model_dir.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -136,22 +140,39 @@ int main(int argc, char** argv) {
     // behind this was a Hindi clone where the model was literally asked to
     // speak fourteen question marks.
     const std::vector<std::string> args = speech_examples::utf8_args(argc, argv);
-    if (args.size() < 5) {
+    if (args.size() < 4) {
         std::fprintf(stderr,
-            "usage: %s <bundle_dir> <ref.wav> \"<text>\" <out.wav> "
+            "usage: %s [bundle_dir] <ref.wav> \"<text>\" <out.wav> "
+            "[instruction] [max_steps] [seed]\n"
+            "  bundle_dir : VoxCPM2 LiteRT bundle (default: $SPEECH_LITERT_MODEL_DIR,\n"
+            "               else %s)\n",
+            args.empty() ? "speech_voxcpm2_clone" : args[0].c_str(),
+            speech_example_voxcpm2_dir().c_str());
+        return 2;
+    }
+    // bundle_dir is optional. Old form starts with the bundle directory; the
+    // new form starts with ref.wav (a file, or the literal "none") —
+    // disambiguate by whether args[1] is an existing directory. (The old
+    // argc-threshold heuristic is gone: the optional [seed] arg makes a full
+    // new-form call reach the same count as a short old-form one.)
+    const bool has_dir = std::filesystem::is_directory(args[1]);
+    const int base = has_dir ? 2 : 1;
+    if (static_cast<int>(args.size()) < base + 3) {
+        std::fprintf(stderr,
+            "usage: %s [bundle_dir] <ref.wav> \"<text>\" <out.wav> "
             "[instruction] [max_steps] [seed]\n",
             args.empty() ? "speech_voxcpm2_clone" : args[0].c_str());
         return 2;
     }
-    const std::string bundle      = args[1];
-    const std::string ref_wav     = args[2];
-    const std::string text        = args[3];
-    const std::string out_wav     = args[4];
+    const std::string bundle      = has_dir ? args[1] : speech_example_voxcpm2_dir();
+    const std::string ref_wav     = args[base];
+    const std::string text        = args[base + 1];
+    const std::string out_wav     = args[base + 2];
     // No default style instruction: conditioning on an (English) style line
     // measurably shifts a non-English clone away from the reference voice.
-    const std::string instruction = (args.size() >= 6) ? args[5] : "";
-    const int         max_steps   = (args.size() >= 7) ? std::atoi(args[6].c_str()) : 256;
-    const long        seed        = (args.size() >= 8) ? std::atol(args[7].c_str()) : 0;
+    const std::string instruction = (static_cast<int>(args.size()) >= base + 4) ? args[base + 3] : "";
+    const int         max_steps   = (static_cast<int>(args.size()) >= base + 5) ? std::atoi(args[base + 4].c_str()) : 256;
+    const long        seed        = (static_cast<int>(args.size()) >= base + 6) ? std::atol(args[base + 5].c_str()) : 0;
 
     const bool no_ref = (ref_wav == "none");
     std::vector<float> ref;

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -9,7 +9,15 @@
 set -euo pipefail
 
 BASE_URL="https://huggingface.co/soniqo"
-OUT="${1:-$(dirname "$0")/models}"
+# Default output: repo-relative scripts/models when run from a writable
+# checkout; the per-user cache dir when run from a read-only install location
+# (e.g. /usr/bin/speech_download_models from the .deb). $SPEECH_MODEL_DIR
+# overrides either — it is also where the installed CLIs look by default.
+DEFAULT_OUT="$(dirname "$0")/models"
+if [ ! -w "$(dirname "$0")" ]; then
+    DEFAULT_OUT="${XDG_CACHE_HOME:-$HOME/.cache}/speech-core/models"
+fi
+OUT="${1:-${SPEECH_MODEL_DIR:-$DEFAULT_OUT}}"
 mkdir -p "$OUT/voices"
 
 FILES=(

--- a/scripts/download_models_litert.sh
+++ b/scripts/download_models_litert.sh
@@ -9,7 +9,11 @@
 set -euo pipefail
 
 BASE_URL="https://huggingface.co/soniqo"
-OUT="${1:-$(dirname "$0")/models-litert}"
+DEFAULT_OUT="$(dirname "$0")/models-litert"
+if [ ! -w "$(dirname "$0")" ]; then
+    DEFAULT_OUT="${XDG_CACHE_HOME:-$HOME/.cache}/speech-core/models-litert"
+fi
+OUT="${1:-${SPEECH_LITERT_MODEL_DIR:-$DEFAULT_OUT}}"
 mkdir -p "$OUT"
 
 # The soniqo/* model repos are public — anonymous fetch works out of the box,

--- a/scripts/speech-dispatch.sh
+++ b/scripts/speech-dispatch.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# speech — multiplexer for the speech_* CLI tools, mirroring the verb-style
+# interface of speech-swift's `speech` CLI (brew install soniqo/tap/speech)
+# so cross-platform docs can say `speech transcribe recording.wav` everywhere.
+#
+# Dispatches to the sibling speech_* executables in the same directory, so it
+# works from /usr/bin (the .deb), a brew Cellar, or an unpacked tarball alike.
+set -e
+here="$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")"
+cmd="${1:-}"
+[ $# -gt 0 ] && shift
+case "$cmd" in
+    transcribe)        exec "$here/speech_transcribe" "$@" ;;
+    speak|synthesize)
+        # speech-swift form: speech speak "<text>" [out.wav]
+        # speech_synthesize wants: [model_dir] <out.wav> "<text>" [language]
+        if [ $# -ge 1 ]; then
+            text="$1"; shift
+            out="${1:-speech-out.wav}"; [ $# -ge 1 ] && shift
+            exec "$here/speech_synthesize" "$out" "$text" "$@"
+        fi
+        exec "$here/speech_synthesize" ;;
+    phonemize)         exec "$here/speech_phonemize" "$@" ;;
+    clone)             exec "$here/speech_voxcpm2_clone" "$@" ;;
+    demo)              exec "$here/speech_demo" "$@" ;;
+    download-models)
+        case "${1:-}" in
+            litert) shift; exec "$here/speech_download_models_litert" "$@" ;;
+            *)             exec "$here/speech_download_models" "$@" ;;
+        esac ;;
+    -h|--help|help|"")
+        cat <<USAGE
+usage: speech <command> [args]
+
+commands:
+  transcribe <input.wav>             speech-to-text (Parakeet + Silero VAD)
+  speak "<text>" [out.wav]           text-to-speech (Kokoro)
+  clone <ref.wav> "<text>" <out.wav> voice cloning (VoxCPM2)
+  phonemize "<text>" [language]      text -> phonemes (Kokoro phonemizer)
+  demo [--transcribe-only]           live ALSA mic loop
+  download-models [litert]           fetch models to ~/.cache/speech-core
+
+Each command is also available as a standalone speech_<command> binary with
+extra options — run it with no arguments for full usage. Model directories
+default to \$SPEECH_MODEL_DIR / \$SPEECH_LITERT_MODEL_DIR, else the per-user
+cache populated by download-models.
+USAGE
+        ;;
+    *)
+        echo "speech: unknown command '$cmd' (try: speech --help)" >&2
+        exit 2 ;;
+esac

--- a/tests/test_litert_voxcpm2_clone_cli.cpp
+++ b/tests/test_litert_voxcpm2_clone_cli.cpp
@@ -438,7 +438,12 @@ void test_cli_utf8_argv_echo() {
     std::printf("  test_cli_utf8_argv_echo ...\n");
     const std::string err_file = tmp_path("cli_test_utf8.txt");
     const std::string devanagari_ref = "मेरा-missing-fixture.wav";
-    int code = run_cli({"no-such-bundle", devanagari_ref, "hello", tmp_path("cli_test_out.wav")},
+    // bundle_dir is optional (defaults to the model cache); omit it so the
+    // Devanagari path is argv[1] = ref.wav. The fixture is missing, so the ref
+    // load fails and echoes the path before any model is touched — no models
+    // needed. (A non-existent first arg can't double as the bundle: the CLI
+    // disambiguates by std::filesystem::is_directory, so it'd be read as ref.)
+    int code = run_cli({devanagari_ref, "hello", tmp_path("cli_test_out.wav")},
                        err_file);
     REQUIRE(code == 1);
     const std::string err = read_file(err_file);


### PR DESCRIPTION
## Summary

Ships the CLI tools as an installable Linux package named **`speech`** — `.deb` + `.tar.gz` attached to GitHub Releases on every `v*` tag — and makes all five CLIs usable without a model-dir argument via sensible per-user-cache defaults.

```bash
sudo apt install ./speech_0.0.8_amd64.deb
speech download-models           # ONNX set → ~/.cache/speech-core/models
speech transcribe input.wav      # same verb-style CLI as speech-swift's `brew install speech`
speech speak "Hello world"
```

Channel choice per distribution research: GitHub Releases first (what whisper.cpp/llama.cpp/piper users expect; official Debian is blocked by the vendored libLiteRt.so + from-source policy — whisper.cpp only entered sid in Jan 2026 via a +dfsg repack). A Cloudsmith apt repo and a Homebrew tap can be layered on the same artifacts later — the `$ORIGIN` RPATHs make the binaries relocatable, which is exactly what brew bottles need.

## What's in the package

| Path | Contents |
|---|---|
| `/usr/bin/` | **`speech`** (verb-style multiplexer matching speech-swift's CLI), `speech_transcribe`, `speech_synthesize`, `speech_phonemize`, `speech_demo`, `speech_voxcpm2_clone` (amd64), `speech_download_models{,_litert}` |
| `/usr/lib/libspeech.so` | example C ABI library |
| `/usr/lib/speech/` | bundled `libonnxruntime.so*` (symlink chain preserved) + `libLiteRt.so` — no distro packages exist for either |
| `/usr/share/doc/speech/` | `LICENSE`, `THIRD-PARTY-NOTICES.md` (Apache-2.0 attribution for the LiteRT blob, MIT for ORT) |

Models are never packaged — fetched into the per-user cache at runtime.

## Key changes

- **CMake `SPEECH_CORE_PACKAGE=ON`** (Linux-only): RUNTIME install rules, `$ORIGIN/../lib;$ORIGIN/../lib/speech` RPATHs, CPack DEB+TGZ, hand-written Depends covering 22.04 (`libasound2`) and 24.04 (`libasound2t64`); dev install rules (static libs + headers) skipped when packaging.
- **`release.yml` `build-linux-packages` job**: amd64 (full) + arm64 (cross, ONNX-only) on ubuntu-22.04 for oldest-glibc compat; amd64 `.deb` smoke-installed into clean 22.04 + 24.04 containers (presence, `ldd` resolution, usage-output probes) before upload; assets attached via `gh release upload` (pure asset POST — cannot race the xcframework job's release-notes body).
- **Default model dirs** (new `examples/common/default_model_dir.h`): explicit arg > `$SPEECH_MODEL_DIR` / `$SPEECH_LITERT_MODEL_DIR` > per-user cache, matching `sc_voxcpm2_create_from_pretrained`'s convention so downloaded bundles are found automatically. Old positional forms keep working (argc + `is_directory` disambiguation) — existing CI pipelines unaffected.
- **`speech_download_models{,_litert}`**: the download scripts default to the cache dir when run from a read-only install location; repo-checkout behavior unchanged.
- **`setup_linux.sh` `cp -RP`**: preserves the ORT symlink chain instead of dereferencing into duplicate ~16 MB payloads per artifact.
- **`.gitattributes` `*.sh text eol=lf`**: Windows checkouts (`core.autocrlf=true`) produced CRLF shell scripts that break with `/bin/bash^M` in Linux containers — surfaced by this validation, real pre-existing repo bug.
- **`speech` multiplexer** (`scripts/speech-dispatch.sh` → `/usr/bin/speech`): speech-swift already ships `brew install speech` with a verb-style CLI (`speech transcribe …`, `speech speak …`) documented at soniqo.audio/cli; the dispatcher gives Linux the same command surface (verb map: `transcribe`, `speak|synthesize` text-first, `phonemize`, `clone`, `demo`, `download-models [litert]`), dispatching to the sibling `speech_*` binaries via dirname-relative resolution (works from `/usr/bin`, a brew Cellar, or an unpacked tarball — brew-bottle-ready).
- **README** (EN + zh-CN): "Install on Linux" section.

The diff was adversarially reviewed pre-push (two lenses: CMake/CPack, Actions semantics; every finding verified against the actual files): 4 confirmed issues fixed — duplicate ORT payload, dev-file leakage, a release-notes-body clobber race between concurrent `gh-release` invocations, and a smoke-test blind spot for missing executables.

## Validation (full pipeline run locally in Docker)

- [x] Clean-source build in `ubuntu:22.04` (ONNX + LiteRT together) → `cpack` → **`speech_0.0.8_amd64.deb` (9.3 MB)** + `speech-0.0.8-linux-amd64.tar.gz`
- [x] Contents verified: all 7 commands, symlink chain intact (one 16 MB ORT file + 2 links), zero static-lib/header leakage
- [x] `apt install` into clean **22.04.5** and **24.04.4** containers: deps resolve (incl. the asound alternation), all binaries `ldd`-clean through the RPATHs, usage probes print resolved defaults
- [x] Windows MSVC compile-check of the shared default-dir header via `speech_voxcpm2_clone`
- [ ] arm64 leg: cross-compile pattern mirrors the proven `linux-examples-aarch64` CI job; `.deb` install-smoke is amd64-only by necessity (first real tag exercises it)

## Follow-ups (not in this PR)

- First-run auto-download in the CLIs (design complete: hoist `hf_download` into a standalone lib, manifest-driven `ensure_models`, matches speech-swift's implicit-download UX with `--no-download`/`SPEECH_NO_DOWNLOAD` opt-outs)
- Cloudsmith apt repo + Homebrew tap fed by the same release artifacts
