### PR TITLE
fix(pipeline): dispatch tts/llm cancel off the audio thread

### DIFF
--- a/include/speech_core/pipeline/voice_pipeline.h
+++ b/include/speech_core/pipeline/voice_pipeline.h
@@ -147,7 +147,21 @@ private:
     std::atomic<bool> worker_busy_{false};
     std::atomic<bool> eager_invalidated_{false};  // set when SpeechResumed discards an eager utterance
 
+    // Cancel dispatcher — keeps tts_.cancel() / llm_->cancel() off the
+    // audio thread so push_audio is not stalled by slow third-party
+    // cancel impls (Ollama HTTP socket close etc.). cancel_pending_ is
+    // a coalesced bool, not a queue: rapid barge-in collapses to at most
+    // one in-flight cancel + one pending re-run. cancel_loop never holds
+    // mutex_ or worker_mutex_ — only cancel_mutex_ — so slow cancels
+    // cannot block any other pipeline path on a lock.
+    std::thread cancel_thread_;
+    std::mutex cancel_mutex_;
+    std::condition_variable cancel_cv_;
+    bool cancel_pending_ = false;
+    bool cancel_shutdown_ = false;
+
     void worker_loop();
+    void cancel_loop();
     void on_turn_event(const TurnEvent& event);
     void process_utterance(const std::string& transcript, const std::string& language = "",
                            float stt_duration_ms = 0.0f);

--- a/src/pipeline/voice_pipeline.cpp
+++ b/src/pipeline/voice_pipeline.cpp
@@ -38,7 +38,22 @@ void VoicePipeline::start() {
         state_.store(State::Idle);
         if (echo_canceller_) echo_canceller_->reset();
     }
+    // Reset dispatcher flags BEFORE spawning so a previous stop() cycle
+    // doesn't leave shutdown=true (which would make the new dispatcher
+    // exit immediately, silently dropping every Interruption).
+    {
+        std::lock_guard<std::mutex> clk(cancel_mutex_);
+        cancel_shutdown_ = false;
+        cancel_pending_ = false;
+    }
+    // Defensive: a prior stop() always joins the dispatcher, so the
+    // thread object should be non-joinable here. Joining belt-and-
+    // suspenders rather than std::terminate'ing if some path skipped
+    // stop().
+    if (cancel_thread_.joinable()) cancel_thread_.join();
+    if (worker_thread_.joinable()) worker_thread_.join();
     worker_thread_ = std::thread(&VoicePipeline::worker_loop, this);
+    cancel_thread_ = std::thread(&VoicePipeline::cancel_loop, this);
 }
 
 void VoicePipeline::stop() {
@@ -65,6 +80,20 @@ void VoicePipeline::stop() {
     worker_idle_cv_.notify_all();
     if (worker_thread_.joinable()) {
         worker_thread_.join();
+    }
+    // Tear down the cancel dispatcher AFTER the worker so the worker's
+    // force_final speak() path (which calls tts_.cancel() on the worker
+    // thread) cannot race with the dispatcher's own cancel call. Same
+    // store-under-mutex pattern as the worker shutdown above so the
+    // dispatcher's cv predicate (cancel_pending_ || cancel_shutdown_)
+    // observes the shutdown flag before it sleeps.
+    {
+        std::lock_guard<std::mutex> clk(cancel_mutex_);
+        cancel_shutdown_ = true;
+    }
+    cancel_cv_.notify_all();
+    if (cancel_thread_.joinable()) {
+        cancel_thread_.join();
     }
 }
 
@@ -352,15 +381,38 @@ void VoicePipeline::on_turn_event(const TurnEvent& event) {
     }
 
     case TurnEvent::Interruption: {
-        // Cancel current TTS, LLM, and clear queue.
-        // LLM cancel is needed when user speaks during Thinking state —
-        // the worker thread is blocked in llm_->chat() and won't pick up
-        // new utterances until the current call returns.
-        tts_.cancel();
-        if (llm_) llm_->cancel();
+        // Audio thread (push_audio holds mutex_). Keep this path cheap.
+        //
+        // Synchronous, in-process work — bounded, microseconds:
+        //   - queue drain   : speech_queue_.cancel_all() must run before
+        //                     on_event_(ResponseInterrupted) so consumers
+        //                     that re-enter from the callback observe an
+        //                     empty queue.
+        //   - turn detector : set_agent_speaking(false), already under
+        //                     the mutex_ held by push_audio.
+        //   - state flip    : the per-chunk speak() lambda guard drops
+        //                     any further TTS chunks emitted before the
+        //                     dispatched cancel actually takes effect.
+        //
+        // Deferred, potentially slow work — posted to cancel_thread_:
+        //   - tts_.cancel(), llm_->cancel(): may block ~150ms on Ollama
+        //     HTTP socket close, WebSocket TTS, etc. Running them inline
+        //     here would stall mic frame delivery (push_audio holds
+        //     mutex_). The dispatcher runs them with no pipeline locks.
+        //
+        // Coalescing: cancel_pending_ is a bool, not a queue. Back-to-
+        // back Interruptions collapse to at most one in-flight cancel +
+        // one pending re-run; cancel() is documented thread-safe and
+        // idempotent on every shipped implementation.
         speech_queue_.cancel_all();
         turn_detector_.set_agent_speaking(false);
         state_.store(State::Listening);
+
+        {
+            std::lock_guard<std::mutex> clk(cancel_mutex_);
+            cancel_pending_ = true;
+        }
+        cancel_cv_.notify_one();
 
         PipelineEvent interrupted;
         interrupted.type = EventType::ResponseInterrupted;
@@ -597,6 +649,32 @@ void VoicePipeline::emit_error(const std::string& message) {
     error.type = EventType::Error;
     error.text = message;
     on_event_(error);
+}
+
+void VoicePipeline::cancel_loop() {
+    // Long-lived dispatcher for off-thread cancel() calls. Owns no
+    // pipeline locks across the third-party calls — that is the entire
+    // point. Order: LLM first, then TTS. LLM cancel is the user-visible
+    // latency driver because it unblocks the worker inside llm_->chat()
+    // so process_utterance can observe state_ != Thinking and return.
+    // TTS cancel is best-effort follow-up; the per-chunk state guard in
+    // speak()'s lambda already prevents stale chunks from reaching the
+    // platform. Exceptions out of cancel() are not contractually
+    // defined, but we must keep the loop alive — swallow and continue.
+    for (;;) {
+        std::unique_lock<std::mutex> lock(cancel_mutex_);
+        cancel_cv_.wait(lock, [this] {
+            return cancel_pending_ || cancel_shutdown_;
+        });
+        if (cancel_shutdown_) return;
+        cancel_pending_ = false;
+        lock.unlock();
+
+        if (llm_) {
+            try { llm_->cancel(); } catch (...) {}
+        }
+        try { tts_.cancel(); } catch (...) {}
+    }
 }
 
 }  // namespace speech_core

--- a/tests/test_pipeline_stress.cpp
+++ b/tests/test_pipeline_stress.cpp
@@ -568,12 +568,21 @@ void scenario_audio_thread_cancel_coupling(Outcome& out) {
     out.note("push_audio (with Interruption) returned in " +
              std::to_string(elapsed_ms) + " ms (cancel_block=150ms)");
 
-    // The audio thread is stalled by the slow cancel. Budget = cancel_block + slack.
-    // If the orchestration is changed to dispatch cancels off-thread, this
-    // budget can tighten dramatically.
-    constexpr int kBudgetMs = 400;
+    // The cancel dispatcher (cancel_thread_) decouples push_audio from
+    // tts_.cancel() / llm_->cancel(). On-thread work in the Interruption
+    // path is now just: speech_queue_.cancel_all, set_agent_speaking,
+    // state_.store, brief cancel_mutex_ + cv.notify, on_event_. The
+    // 150ms cancel block runs off-thread.
+    //
+    // 50ms gives 8x headroom over the on-thread observed cost while
+    // catching any regression that re-couples cancel to the audio
+    // thread. If this assertion regresses, look for a new call site
+    // that synchronously cancels TTS or LLM inside on_turn_event or
+    // push_audio.
+    constexpr int kBudgetMs = 50;
     CHECK(out, elapsed_ms < kBudgetMs,
-          "push_audio stalled > " + std::to_string(kBudgetMs) + " ms (= cancel coupling)");
+          "push_audio stalled > " + std::to_string(kBudgetMs) + " ms "
+          "(cancel coupling — dispatcher not decoupling correctly)");
 
     pipe.stop();
 }
@@ -963,6 +972,83 @@ void scenario_speech_queue_leak(Outcome& out) {
 }
 
 // ===========================================================================
+// SCENARIO 8: stop() during pending cancel dispatch — no deadlock, no UAF
+// ---------------------------------------------------------------------------
+// With cancel() dispatched off the audio thread, lifecycle safety hinges on
+// stop() joining the dispatcher AFTER its in-flight cancel call returns.
+// Fire an Interruption with a deliberately slow TTS cancel (200 ms), then
+// immediately call stop(). Asserts stop() returns within the cancel-block
+// budget + slack, and the pipeline cleanly shuts down (no crash, no hang).
+//
+// This is the key safety test for the off-thread dispatcher: if stop()
+// reordered the join to happen BEFORE the in-flight cancel completes, the
+// dispatcher thread would access tts_ / llm_ AFTER they may be destructed
+// (the references go dangling once their owners outlive the pipeline).
+// ===========================================================================
+
+void scenario_stop_during_pending_cancel(Outcome& out) {
+    StressSTT stt;
+    StressTTS tts;
+    tts.num_chunks = 50;
+    tts.chunk_interval = 5ms;
+    tts.cancel_block = 200ms;             // dispatcher will sit inside cancel()
+    StressVAD vad;
+
+    auto cfg = default_stress_config();
+    cfg.mode = AgentConfig::Mode::Echo;
+    cfg.vad.min_speech_duration = 0.064f;
+    cfg.min_interruption_duration = 0.0f;
+
+    SyncBarrier barrier;
+    tts.barrier = &barrier;
+
+    SequencedEventLog log;
+    VoicePipeline pipe(stt, tts, nullptr, vad, cfg,
+                       [&log](const PipelineEvent& e) { log.on_event(e); });
+    pipe.start();
+
+    // Trigger first utterance → enter Speaking.
+    vad.probs = concat(silence_probs(1), speech_probs(10), silence_probs(6));
+    vad.prob_index.store(0);
+    push_n_chunks(pipe, vad.probs.size());
+
+    if (!barrier.wait_for_count("tts:chunk_emitted", 1, 3000ms)) {
+        out.fail("tts never started");
+        pipe.stop();
+        return;
+    }
+
+    // Fire interrupting speech → posts cancel to dispatcher → dispatcher
+    // calls tts.cancel() which sleeps 200ms.
+    vad.probs = speech_probs(6);
+    vad.prob_index.store(0);
+    auto interrupt_audio = make_audio_for_chunks(6);
+    pipe.push_audio(interrupt_audio.data(), interrupt_audio.size());
+
+    // Give the dispatcher a moment to start the cancel.
+    if (!barrier.wait_for_count("tts:cancel_called", 1, 1000ms)) {
+        out.fail("dispatcher never called tts.cancel()");
+        pipe.stop();
+        return;
+    }
+
+    // stop() now — dispatcher is inside the 200ms sleep. stop() must
+    // join cleanly after the cancel finishes.
+    auto t0 = std::chrono::steady_clock::now();
+    pipe.stop();
+    auto elapsed = std::chrono::steady_clock::now() - t0;
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+
+    out.note("stop() during in-flight cancel returned in " +
+             std::to_string(elapsed_ms) + " ms");
+
+    // stop() budget: in-flight cancel (200ms) + stop's own synchronous
+    // cancel calls + join overhead. 600ms is generous for CI jitter.
+    CHECK(out, elapsed_ms < 600, "stop() during dispatched cancel exceeded budget");
+    CHECK(out, !pipe.is_running(), "pipeline running flag should be false after stop()");
+}
+
+// ===========================================================================
 // Test runner
 // ===========================================================================
 
@@ -979,6 +1065,7 @@ const Scenario kScenarios[] = {
     {"no_second_chat_after_interrupt_in_tool_loop", scenario_no_second_chat_after_interrupt_in_tool_loop},
     {"concurrent_push_audio_with_interrupts",      scenario_concurrent_push_audio_with_interrupts},
     {"speech_queue_leak",                          scenario_speech_queue_leak},
+    {"stop_during_pending_cancel",                 scenario_stop_during_pending_cancel},
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary

Frees `push_audio` from third-party cancel latency by dispatching `tts_.cancel()` and `llm_->cancel()` on a dedicated long-lived thread. Builds on the per-chunk `state_` guard added in #58, which removed the requirement that cancel finish before `state_` flips.

**Measured impact**: in `scenario_audio_thread_cancel_coupling`, `push_audio` under a 150 ms cancel block dropped from ~155 ms to **0 ms**. The on-thread Interruption path is now just a `cancel_all` + atomic store + brief `cancel_mutex_` acquisition + `notify_one`.

## What changed

**`src/pipeline/voice_pipeline.cpp`**

- New private `cancel_loop()` long-lived dispatcher. Holds only `cancel_mutex_` — never `mutex_` or `worker_mutex_`. Calls `llm_->cancel()` first (unblocks the worker inside `chat()` so `process_utterance` can observe `state_ != Thinking` and return), then `tts_.cancel()`. Both wrapped in `try/catch` so the dispatcher survives misbehaving impls.
- `on_turn_event(Interruption)` now does its synchronous, microsecond-bounded work (queue drain, `set_agent_speaking(false)`, `state_.store(Listening)`, `on_event_(ResponseInterrupted)`) and posts a coalesced `cancel_pending_` flag. Rapid barge-in collapses to at most one in-flight cancel + one pending re-run.
- `start()` resets `cancel_shutdown_` and `cancel_pending_` *before* spawning the dispatcher (critical fix flagged independently by both adversarial reviewers — without it, a `start()/stop()/start()` cycle leaves the new dispatcher dead-on-arrival).
- `start()` also defensively joins any prior `cancel_thread_` / `worker_thread_` that were unexpectedly left joinable, avoiding `std::thread` move-assign `std::terminate`.
- `stop()` tears down the dispatcher *after* the worker — the worker's `force_final` `speak()` path still calls `tts_.cancel()` inline on the worker thread, and we don't want it racing with dispatcher teardown.
- `stop()` itself preserves its synchronous `tts_.cancel()` / `llm_->cancel()` at lines 47–48: `stop()` is not on the audio thread, so the brief cost is fine, and it guarantees `worker_thread_.join()` does not hang waiting on a blocked `chat()` / `synthesize()`.

**`include/speech_core/pipeline/voice_pipeline.h`**

- 5 new private members (`cancel_thread_`, `cancel_mutex_`, `cancel_cv_`, `cancel_pending_`, `cancel_shutdown_`) plus the `cancel_loop()` declaration. No public API change, no struct layout change visible to consumers (everything at the bottom of the private section).

**`tests/test_pipeline_stress.cpp`**

- `scenario_audio_thread_cancel_coupling` budget tightened from **400 ms → 50 ms**. Observed: 0 ms. Comment notes the regression-detection intent: if it ever fires, look for a new call site that synchronously cancels on the audio thread.
- New `scenario_stop_during_pending_cancel`: fires an interrupt, waits for the dispatcher to enter a 200 ms cancel sleep, calls `stop()`, asserts it returns inside `cancel_block + slack` (600 ms budget) with the pipeline cleanly shut down. Proves the join-after-worker ordering doesn't deadlock or use-after-free on `tts_` / `llm_`.

## Locking discipline

Three mutexes, three independent domains, **never co-held**:

| Mutex | Protects | Held by |
|-------|----------|---------|
| `mutex_` | turn_detector_, enhance/aec buffers | push_audio + on_turn_event |
| `worker_mutex_` | pending_utterances_, worker_busy_, running_ store | worker_loop coordination |
| `cancel_mutex_` (new) | cancel_pending_, cancel_shutdown_ | on_turn_event(Interruption) post + cancel_loop wait |

Lock order: `mutex_ > cancel_mutex_` (`on_turn_event` briefly nests). `worker_mutex_` and `cancel_mutex_` are leaf mutexes that are *never* co-held — `on_turn_event` acquires them in disjoint switch arms; `stop()` acquires them sequentially.

`cancel_loop` releases `cancel_mutex_` before calling into `tts_` / `llm_`, so slow cancels cannot block any other pipeline path on a lock.

## What is intentionally NOT addressed

- **`stop()` can still hang if `cancel()` itself never returns.** Same hazard as on `main`; this PR shifts the stall window from the audio thread to the `stop()` thread without changing the underlying invariant. Documented in the dispatcher comment.
- **Worker's `force_final` `speak()` path still calls `tts_.cancel()` inline on the worker.** Intentional — it's not the audio thread, so blocking is fine, and routing it through the dispatcher would add complexity for no benefit. The TTS thread-safety contract permits concurrent cancel from worker + dispatcher.
- **Cancel order reversed inside the dispatcher** (LLM first, then TTS) is documented as a deliberate latency-driver choice. `stop()`'s synchronous path at lines 47–48 keeps the original order (TTS first, then LLM) because at `stop()` we need both cancelled before the worker can join cleanly, and the order is immaterial.

## Test plan

- [ ] `cmake --build build --target test_pipeline_stress && ./build/test_pipeline_stress` — all 8 scenarios pass.
- [ ] `for i in 1 2 3 4 5; do ./build/test_pipeline_stress || break; done` — deterministic across repeats.
- [ ] `cd build && ctest --output-on-failure` — all 14 tests pass (no regression vs main).
- [ ] `./build/test_pipeline_e2e` — full E2E suite unchanged.

## Rollback

Self-contained. `git revert <sha>` restores prior synchronous cancel. No public API or struct-layout change, so consumer repos (speech-android JNI, speech-swift, speech-cloud, examples/) require zero changes and do not need to be rebuilt to roll back — the static-lib internal linkage of `speech_core` means a single rebuild of speech-core suffices.

For an emergency 2-line minimal patch: delete the dispatcher post in `on_turn_event` and restore inline `tts_.cancel()` / `llm_->cancel()` there, while leaving the dispatcher thread members idle.