### PR TITLE
ort/trt: SPEECH_CORE_TRT_OP_TYPES_TO_EXCLUDE partitioner skip-list

### DIFF
--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -539,6 +539,29 @@ private:
                     }
                 }
 
+                // SPEECH_CORE_TRT_OP_TYPES_TO_EXCLUDE — comma-separated
+                // list of ONNX op types the partitioner should NEVER
+                // attempt. Default: empty (try all).
+                //
+                // Why: TRT's ONNX importer probes every op type and
+                // raises UNSUPPORTED_NODE_ATTR for ones it can't handle
+                // (e.g. ScatterND with `reduction=` attribute, opset 16,
+                // used in VoxCPM2's KV-cache write path). ORT correctly
+                // falls those nodes back to CUDA EP, but each rejected
+                // import allocates + tears down a parser context first.
+                // For graphs with dozens of such nodes the cumulative
+                // host RAM trips the kernel OOM-killer before serving.
+                //
+                // Listing them up front routes those nodes straight to
+                // CUDA from the first analysis pass — smaller TRT
+                // subgraphs, less compile memory, no error spam.
+                if (const char* exc = std::getenv("SPEECH_CORE_TRT_OP_TYPES_TO_EXCLUDE")) {
+                    if (exc[0] != '\0') {
+                        keys.push_back("trt_op_types_to_exclude");
+                        vals.push_back(exc);
+                    }
+                }
+
                 OrtStatus* us = api_->UpdateTensorRTProviderOptions(
                     trt, keys.data(), vals.data(), keys.size());
                 if (us != nullptr) api_->ReleaseStatus(us);  // non-fatal: keep defaults


### PR DESCRIPTION
## Summary

Opt-in `SPEECH_CORE_TRT_OP_TYPES_TO_EXCLUDE` threaded into TRT EP options at the same site as #63's workspace + opt-level knobs. Comma-separated list of ONNX op types TRT's partitioner should never attempt.

## Why

VoxCPM2 prefill on TRT EP: engine build now completes (#63 + `SPEECH_CORE_DISABLE_QDQ_FOLD=1`), but partitioner attempts 50+ `ScatterND` nodes with the `reduction=` attribute (opset-16). Each `UNSUPPORTED_NODE_ATTR` rejection allocates a parser context before tear-down — cumulative host RAM trips the kernel OOM-killer mid-analysis. Empirically observed today: even with `WORKSPACE_MB=2048` + `OPT_LEVEL=0`, SIGKILL after ~2 min of ScatterND_51 → _52 → _53 → _54 import failures.

`trt_op_types_to_exclude` short-circuits this: nodes in the skip list never enter TRT's import path — straight to CUDA from analysis pass 1.

## Test plan

- [ ] Build green
- [ ] Existing TRT EP path (no env var set) unchanged
- [ ] VoxCPM2 synth on Salad with `OP_TYPES_TO_EXCLUDE=ScatterND` + `WORKSPACE_MB=2048` + `OPT_LEVEL=0` boots cleanly, no SIGKILL, serves end-to-end