### PR TITLE
feat(fdb): M2 — real Parakeet/Kokoro backends + opt-in integration test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,13 @@ if(SPEECH_CORE_BUILD_TESTS)
                 PRIVATE speech_core speech_core_llm_ollama)
             target_compile_definitions(test_fdb_bench_smoke PRIVATE
                 SPEECH_CORE_FDB_MINI_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data/fdb_mini/v1_0")
+            if(SPEECH_CORE_WITH_ONNX)
+                target_link_libraries(test_fdb_bench_smoke
+                    PRIVATE speech_core_models)
+                target_compile_definitions(test_fdb_bench_smoke PRIVATE
+                    SPEECH_CORE_FDB_WITH_ONNX
+                    SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+            endif()
             if(MSVC)
                 target_compile_definitions(test_fdb_bench_smoke PRIVATE
                     _USE_MATH_DEFINES NOMINMAX _WIN32_WINNT=0x0601)

--- a/docs/fdb-bench.md
+++ b/docs/fdb-bench.md
@@ -21,12 +21,15 @@ In:
 
 Out:
 
-- M2 — real STT/TTS (`--stt parakeet`, `--tts kokoro`) is wired but
-  requires `SPEECH_CORE_WITH_ONNX=ON` and model files; treated as a
-  follow-up.
 - M3 — per-run summary CSV.
 - M4 — bridge to the upstream Python eval scripts (CrisperWhisper +
   JSD / pause-handling metrics).
+
+M2 (done) — real STT/TTS (`--stt parakeet`, `--tts kokoro`) is now
+usable when built with `-DSPEECH_CORE_WITH_ONNX=ON`. Point at a flat
+models directory (the layout produced by `scripts/download_models.sh`)
+via `--models-dir`, or override per-family with `--parakeet-dir` /
+`--kokoro-dir`.
 
 ## What FDB is
 
@@ -101,7 +104,19 @@ CI-style mock run against the fixture:
         --out-dir /tmp/fdb_out \
         --llm-model llama3.2:1b
 
-One category through the full real pipeline:
+One category through the full real pipeline (single flat models dir
+matching `scripts/download_models.sh`):
+
+    ./build/fdb_bench \
+        --corpus-dir /path/to/v1_0 \
+        --out-dir /tmp/fdb_out \
+        --llm-model qwen2.5:7b \
+        --stt parakeet --tts kokoro \
+        --models-dir ./scripts/models \
+        --category candor_pause_handling \
+        --limit 50
+
+Or with separate per-family directories:
 
     ./build/fdb_bench \
         --corpus-dir /path/to/v1_0 \
@@ -113,6 +128,23 @@ One category through the full real pipeline:
         --limit 50
 
 Run `./build/fdb_bench --help` for the full flag list.
+
+## Smoke vs. real-models integration test
+
+`test_fdb_bench_smoke` always runs the mock-backend smoke (no model
+files, no ORT). When built with `-DSPEECH_CORE_WITH_ONNX=ON` it
+additionally compiles an opt-in `real_models_integration` block that
+loads Parakeet + Kokoro + Silero from `$SPEECH_MODEL_DIR` and runs a
+single real-speech sample (`tests/data/test_audio.wav`) through the
+same per-sample driver path. It is **skipped silently** unless both env
+vars are set:
+
+    SPEECH_FDB_BENCH_INTEGRATION=1 \
+    SPEECH_MODEL_DIR=$PWD/scripts/models \
+    ctest --test-dir build -R test_fdb_bench_smoke --output-on-failure
+
+Per-file skips also kick in if specific `.onnx` files are missing, so
+partial model installs don't fail the test.
 
 ## Output layout
 
@@ -154,10 +186,12 @@ Final stdout line:
 
     fdb_bench: samples_ok=N errors=M avg_ttft_ms=X out_dir=...
 
-## How M2-M4 layer on top
+## How M3-M4 layer on top
 
-- **M2** — drop `--stt parakeet` / `--tts kokoro` defaults once latency
-  and quality are validated against a small corpus subset. No CLI break.
+- **M2 (done)** — `--stt parakeet` / `--tts kokoro` build out when
+  `SPEECH_CORE_WITH_ONNX=ON`; `--models-dir` shortcut matches the
+  `scripts/download_models.sh` layout; opt-in `real_models_integration`
+  smoke test verifies the path.
 - **M3** — post-process `<out-dir>/*.json` into a single summary CSV
   (`fdb_summary.csv`) suitable for one-line CI assertions and trend
   tracking across runs.

--- a/examples/fdb_bench/fdb_bench.cpp
+++ b/examples/fdb_bench/fdb_bench.cpp
@@ -18,7 +18,6 @@
 #ifdef SPEECH_CORE_FDB_WITH_ONNX
 #  include "speech_core/models/parakeet_stt.h"
 #  include "speech_core/models/kokoro_tts.h"
-#  include "speech_core/models/silero_vad.h"
 #endif
 
 #include <atomic>
@@ -118,11 +117,20 @@ struct Args {
     std::string llm_base_url = "http://localhost:11434";
     std::string llm_model;
     size_t limit = 0;
-    std::string parakeet_dir;
-    std::string kokoro_dir;
+    std::string models_dir;     // flat scripts/models/ layout shortcut
+    std::string parakeet_dir;   // overrides models_dir for Parakeet files
+    std::string kokoro_dir;     // overrides models_dir for Kokoro files
     std::string kokoro_voice = "af_heart";
+    bool hw_accel = false;      // pass through to ORT models
     bool show_help = false;
 };
+
+std::string resolve_parakeet_dir(const Args& a) {
+    return a.parakeet_dir.empty() ? a.models_dir : a.parakeet_dir;
+}
+std::string resolve_kokoro_dir(const Args& a) {
+    return a.kokoro_dir.empty() ? a.models_dir : a.kokoro_dir;
+}
 
 void print_usage() {
     std::fprintf(stdout,
@@ -143,9 +151,14 @@ void print_usage() {
         "  --tts <backend>        mock | kokoro    (default: mock)\n"
         "  --llm-base-url <url>   default http://localhost:11434\n"
         "  --limit <N>            cap at first N samples after sort (default: no cap)\n"
-        "  --parakeet-dir <path>  required when --stt parakeet\n"
-        "  --kokoro-dir <path>    required when --tts kokoro\n"
+        "  --models-dir <path>    flat directory holding parakeet-encoder-int8.onnx,\n"
+        "                         parakeet-decoder-joint-int8.onnx, vocab.json,\n"
+        "                         kokoro-e2e.onnx (+ voices/), etc. — matches the\n"
+        "                         layout produced by scripts/download_models.sh\n"
+        "  --parakeet-dir <path>  override Parakeet location (--stt parakeet)\n"
+        "  --kokoro-dir <path>    override Kokoro location (--tts kokoro)\n"
         "  --kokoro-voice <name>  default af_heart (only --tts kokoro)\n"
+        "  --hw-accel             enable ORT hardware EP (default off, for repro)\n"
         "  -h, --help             this help\n");
 }
 
@@ -173,9 +186,11 @@ Args parse_args(int argc, char** argv) {
         else if (f == "--llm-base-url")  { a.llm_base_url = eat(i, "--llm-base-url"); }
         else if (f == "--llm-model")     { a.llm_model = eat(i, "--llm-model"); }
         else if (f == "--limit")         { a.limit = std::stoul(eat(i, "--limit")); }
+        else if (f == "--models-dir")    { a.models_dir = eat(i, "--models-dir"); }
         else if (f == "--parakeet-dir")  { a.parakeet_dir = eat(i, "--parakeet-dir"); }
         else if (f == "--kokoro-dir")    { a.kokoro_dir = eat(i, "--kokoro-dir"); }
         else if (f == "--kokoro-voice")  { a.kokoro_voice = eat(i, "--kokoro-voice"); }
+        else if (f == "--hw-accel")      { a.hw_accel = true; }
         else throw std::runtime_error("unknown flag: " + f);
     }
     return a;
@@ -190,7 +205,14 @@ void validate(const Args& a) {
         throw std::runtime_error("--stt must be mock or parakeet");
     if (a.tts != "mock" && a.tts != "kokoro")
         throw std::runtime_error("--tts must be mock or kokoro");
-#ifndef SPEECH_CORE_FDB_WITH_ONNX
+#ifdef SPEECH_CORE_FDB_WITH_ONNX
+    if (a.stt == "parakeet" && a.parakeet_dir.empty() && a.models_dir.empty())
+        throw std::runtime_error(
+            "--stt parakeet requires --parakeet-dir or --models-dir");
+    if (a.tts == "kokoro" && a.kokoro_dir.empty() && a.models_dir.empty())
+        throw std::runtime_error(
+            "--tts kokoro requires --kokoro-dir or --models-dir");
+#else
     if (a.stt == "parakeet")
         throw std::runtime_error("--stt parakeet requires SPEECH_CORE_WITH_ONNX=ON");
     if (a.tts == "kokoro")
@@ -463,9 +485,12 @@ int main(int argc, char** argv) {
         stt = std::make_unique<MockSTT>();
     } else {
 #ifdef SPEECH_CORE_FDB_WITH_ONNX
-        ParakeetStt::Config pcfg;
-        pcfg.model_dir = args.parakeet_dir;
-        stt = std::make_unique<ParakeetStt>(pcfg);
+        const std::string pdir = resolve_parakeet_dir(args);
+        stt = std::make_unique<ParakeetStt>(
+            pdir + "/parakeet-encoder-int8.onnx",
+            pdir + "/parakeet-decoder-joint-int8.onnx",
+            pdir + "/vocab.json",
+            args.hw_accel);
 #else
         std::fprintf(stderr, "fdb_bench: --stt parakeet built out\n");
         return 2;
@@ -478,10 +503,14 @@ int main(int argc, char** argv) {
         tts = std::make_unique<MockTTS>();
     } else {
 #ifdef SPEECH_CORE_FDB_WITH_ONNX
-        KokoroTts::Config kcfg;
-        kcfg.model_dir = args.kokoro_dir;
-        kcfg.voice = args.kokoro_voice;
-        tts = std::make_unique<KokoroTts>(kcfg);
+        const std::string kdir = resolve_kokoro_dir(args);
+        auto k = std::make_unique<KokoroTts>(
+            kdir + "/kokoro-e2e.onnx",
+            kdir + "/voices",
+            kdir,
+            args.hw_accel);
+        k->set_voice(args.kokoro_voice);
+        tts = std::move(k);
 #else
         std::fprintf(stderr, "fdb_bench: --tts kokoro built out\n");
         return 2;

--- a/tests/test_fdb_bench_smoke.cpp
+++ b/tests/test_fdb_bench_smoke.cpp
@@ -19,6 +19,12 @@
 #include "speech_core/llm/ollama_llm.h"
 #include "speech_core/pipeline/voice_pipeline.h"
 
+#ifdef SPEECH_CORE_FDB_WITH_ONNX
+#  include "speech_core/models/parakeet_stt.h"
+#  include "speech_core/models/kokoro_tts.h"
+#  include "speech_core/models/silero_vad.h"
+#endif
+
 #include "httplib.h"
 #include "nlohmann/json.hpp"
 
@@ -388,6 +394,156 @@ void test_smoke_driver_with_mock_ollama() {
                 samples.size(), server.request_count());
 }
 
+#ifdef SPEECH_CORE_FDB_WITH_ONNX
+// Opt-in integration test — loads real Parakeet STT + Kokoro TTS + Silero
+// VAD from SPEECH_MODEL_DIR and runs one real-speech sample through the
+// same per-sample driver path the unit smoke uses. Skipped silently
+// unless SPEECH_FDB_BENCH_INTEGRATION=1 is set and the model files
+// exist on disk.
+void test_real_models_integration() {
+    const char* enabled = std::getenv("SPEECH_FDB_BENCH_INTEGRATION");
+    if (!enabled || std::string(enabled) != "1") {
+        std::printf("  SKIP: real_models_integration "
+                    "(set SPEECH_FDB_BENCH_INTEGRATION=1 to enable)\n");
+        return;
+    }
+    const char* dir_env = std::getenv("SPEECH_MODEL_DIR");
+    std::string dir = dir_env ? dir_env : "";
+    if (dir.empty()) {
+        std::printf("  SKIP: real_models_integration — "
+                    "SPEECH_MODEL_DIR unset\n");
+        return;
+    }
+    const std::string enc   = dir + "/parakeet-encoder-int8.onnx";
+    const std::string dec   = dir + "/parakeet-decoder-joint-int8.onnx";
+    const std::string vocab = dir + "/vocab.json";
+    const std::string vad_m = dir + "/silero-vad.onnx";
+    const std::string kok_m = dir + "/kokoro-e2e.onnx";
+
+    auto path_exists = [](const std::string& p) {
+        std::error_code ec;
+        return fs::exists(p, ec);
+    };
+    if (!path_exists(enc) || !path_exists(dec) || !path_exists(vocab) ||
+        !path_exists(vad_m) || !path_exists(kok_m)) {
+        std::printf("  SKIP: real_models_integration — model files "
+                    "missing in %s\n", dir.c_str());
+        return;
+    }
+    const std::string sample_wav =
+        std::string(SPEECH_CORE_TEST_DATA_DIR) + "/test_audio.wav";
+    if (!path_exists(sample_wav)) {
+        std::printf("  SKIP: real_models_integration — %s missing\n",
+                    sample_wav.c_str());
+        return;
+    }
+
+    // Mock Ollama (real model integration is about STT/TTS, not LLM).
+    MockOllama server([](const nlohmann::json&, httplib::DataSink& sink) {
+        for (const char* d : {"ack", " response"}) {
+            write_json_line(sink, {
+                {"model", "test"},
+                {"message", {{"role", "assistant"}, {"content", d}}},
+                {"done", false}});
+        }
+        write_json_line(sink, {
+            {"model", "test"},
+            {"message", {{"role", "assistant"}, {"content", ""}}},
+            {"done", true}, {"done_reason", "stop"}});
+    });
+    OllamaLLM::Options lopts;
+    lopts.base_url = server.base_url();
+    lopts.model    = "test";
+    OllamaLLM llm(lopts);
+
+    // Build the real backends. Silero is constructed to verify it loads
+    // even though the orchestrator below consumes the deterministic
+    // ScriptedVAD trajectory — this keeps the unit smoke deterministic
+    // and the turn boundary predictable.
+    speech_core::ParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
+    speech_core::KokoroTts   tts(kok_m, dir + "/voices", dir,
+                                 /*hw_accel=*/false);
+    speech_core::SileroVad   real_vad(vad_m, /*hw_accel=*/false);
+    (void)real_vad;  // exercised by construction
+    ScriptedVAD vad;
+
+    fdb_bench::WavData wav;
+    assert(fdb_bench::load_wav_mono_pcm16(sample_wav, &wav));
+    std::vector<float> audio16k = (wav.sample_rate == 16000)
+        ? wav.samples
+        : Resampler::resample(wav.samples.data(), wav.samples.size(),
+                              wav.sample_rate, 16000);
+    vad.reset();
+    vad.probs = make_vad_script(audio16k.size(), vad.chunk_size());
+
+    AgentConfig cfg;
+    cfg.mode = AgentConfig::Mode::Pipeline;
+    cfg.warmup_stt = false;
+    cfg.eager_stt = false;
+    cfg.post_playback_guard = 0.0f;
+    cfg.min_interruption_duration = 0.0f;
+    cfg.max_response_duration = 60.0f;
+
+    std::vector<uint8_t> tts_pcm16;
+    std::string captured_transcript;
+    std::atomic<int> response_done{0};
+    std::atomic<int> errors{0};
+    auto cb = [&](const PipelineEvent& e) {
+        switch (e.type) {
+        case EventType::TranscriptionCompleted:
+            captured_transcript = e.text; break;
+        case EventType::ResponseAudioDelta:
+            tts_pcm16.insert(tts_pcm16.end(),
+                             e.audio_data.begin(), e.audio_data.end());
+            break;
+        case EventType::ResponseDone: response_done.fetch_add(1); break;
+        case EventType::Error:        errors.fetch_add(1); break;
+        default: break;
+        }
+    };
+
+    VoicePipeline pipe(stt, tts, &llm, vad, cfg, cb);
+    pipe.start();
+    const size_t chunk = vad.chunk_size();
+    for (size_t off = 0; off < audio16k.size(); off += chunk) {
+        size_t n = std::min(chunk, audio16k.size() - off);
+        pipe.push_audio(audio16k.data() + off, n);
+    }
+    std::vector<float> tail(chunk, 0.0f);
+    for (int i = 0; i < 12; ++i) {
+        pipe.push_audio(tail.data(), tail.size());
+    }
+    pipe.wait_idle();
+    pipe.stop();
+
+    assert(errors.load() == 0);
+    assert(response_done.load() == 1);
+    assert(!tts_pcm16.empty());
+    assert(!captured_transcript.empty() &&
+           "real Parakeet must produce a non-empty transcript");
+
+    // Round-trip the TTS output to disk to exercise the writer at the
+    // real backend's native rate.
+    auto out_dir = fs::temp_directory_path() /
+                   ("fdb_real_out_" + std::to_string(::getpid()));
+    fs::create_directories(out_dir);
+    auto float_audio = PCMCodec::pcm16_to_float(
+        tts_pcm16.data(), tts_pcm16.size());
+    std::string wav_out = (out_dir / "real_models_integration.wav").string();
+    assert(fdb_bench::write_wav_mono_pcm16(
+        wav_out, float_audio.data(), float_audio.size(),
+        tts.output_sample_rate()));
+    assert(fs::file_size(wav_out) > 44);
+
+    std::error_code ec;
+    fs::remove_all(out_dir, ec);
+
+    std::printf("  PASS: real_models_integration "
+                "(transcript=\"%s\", tts_bytes=%zu)\n",
+                captured_transcript.c_str(), tts_pcm16.size());
+}
+#endif  // SPEECH_CORE_FDB_WITH_ONNX
+
 }  // namespace
 
 int main() {
@@ -397,6 +553,9 @@ int main() {
     test_corpus_category_filter();
     test_ground_truth_transcript_extraction();
     test_smoke_driver_with_mock_ollama();
+#ifdef SPEECH_CORE_FDB_WITH_ONNX
+    test_real_models_integration();
+#endif
     std::printf("All fdb_bench smoke tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Swaps the M1 `SPEECH_CORE_FDB_WITH_ONNX` stubs in `fdb_bench.cpp` to the **real** `ParakeetStt` / `KokoroTts` constructors from `include/speech_core/models/`. With this PR a build that enables both `SPEECH_CORE_WITH_OLLAMA` and `SPEECH_CORE_WITH_ONNX` produces a working `--stt parakeet` / `--tts kokoro` driver suitable for real corpus runs.

## CLI changes

| Flag | Purpose |
|---|---|
| `--models-dir <path>` | **NEW** — flat directory matching `scripts/download_models.sh` layout. Single-flag shortcut. |
| `--parakeet-dir` / `--kokoro-dir` | preserved as per-family overrides |
| `--hw-accel` | **NEW** — pass through to ORT models. Default off for reproducibility. |
| `--llm-model`, `--llm-base-url`, `--limit`, `--category`, `--corpus-dir`, `--out-dir` | unchanged from M1 |

`validate()` now requires `--parakeet-dir OR --models-dir` when `--stt parakeet` (same for `--tts kokoro`) with clear error messages.

## What changed where

| File | Changes |
|---|---|
| `examples/fdb_bench/fdb_bench.cpp` | New flags + `resolve_*_dir` helpers + real ctors replacing the stubs (~80 LOC) |
| `tests/test_fdb_bench_smoke.cpp` | Opt-in `test_real_models_integration()` block (~120 LOC, gated on `SPEECH_CORE_FDB_WITH_ONNX`) |
| `CMakeLists.txt` | Link `speech_core_models` into `test_fdb_bench_smoke` when ONNX is on (~6 LOC) |
| `docs/fdb-bench.md` | M2 marked done; `--models-dir` invocation; new "Smoke vs. real-models integration test" section |

## Integration test gating

The new block follows the established pattern (see `test_models.cpp` and `test_ollama_llm.cpp`):

- Skips with a clear stdout line unless `SPEECH_FDB_BENCH_INTEGRATION=1`.
- Skips per-file if specific `.onnx` files are missing (partial downloads don't fail the test).
- Uses `tests/data/test_audio.wav` (real speech, already used by `test_models.cpp`) so Parakeet produces a real transcript.
- Asserts: captured transcript non-empty, TTS buffer non-empty, output WAV round-trips at the real backend's native rate.

To run locally:

    SPEECH_FDB_BENCH_INTEGRATION=1 \
    SPEECH_MODEL_DIR=$PWD/scripts/models \
    ctest --test-dir build -R test_fdb_bench_smoke --output-on-failure

## What is intentionally NOT in this PR

- **No nightly CI lane for `fdb_bench`** — the existing `nightly.yml` already caches the models for `test_models`, and M4 (Python scorer + weekly CI) is the right place to layer a full corpus run with regression assertions.
- **No real Silero VAD wired into the orchestrator** — the driver's `ScriptedVAD` deterministic envelope is what M1+ uses for repro. Real Silero is constructed in the integration test (to verify it loads) but the orchestrator still consumes the scripted probs. If real-VAD integration ever becomes needed, M3+ can add a `--vad silero` flag.
- **No M3 latency CSV / M4 Python scorer** — separate PRs.

## Verified locally

- **Default build (OLLAMA only, no ONNX)**: 17/17 ctests pass.
- **OLLAMA + ONNX build**: 17/17 ctests pass. Integration test SKIPs cleanly without the env var. `./fdb_bench --help` surfaces all new flags.
- **ASAN+UBSAN with OLLAMA on**: 15/15 ctests pass clean.
- **5×5 determinism** of `test_fdb_bench_smoke` under all three configs.

## Test plan

- [ ] `cmake -B build -DSPEECH_CORE_WITH_OLLAMA=ON && cmake --build build && (cd build && ctest)` — 17/17
- [ ] CI's 9 lanes (incl. `unit-tests-sanitizers`) stay green
- [ ] `./build/fdb_bench --help` shows the new flags
- [ ] Locally, set `SPEECH_FDB_BENCH_INTEGRATION=1 SPEECH_MODEL_DIR=/path/to/scripts/models` and confirm the integration test loads Parakeet + Kokoro + Silero and produces a non-empty transcript

## Rollback

`git revert <sha>`. Self-contained: the M1 stubs are recoverable; no public API changes.