### PR TITLE
feat(fdb): M3 — fdb_summary post-processor + sample-id collision fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,8 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_litert_voxcpm2_clone_cli"
            OR TEST_NAME STREQUAL "test_ollama_llm"
            OR TEST_NAME STREQUAL "test_pipeline_ollama_e2e"
-           OR TEST_NAME STREQUAL "test_fdb_bench_smoke")
+           OR TEST_NAME STREQUAL "test_fdb_bench_smoke"
+           OR TEST_NAME STREQUAL "test_fdb_summary")
             continue()
         endif()
         add_executable(${TEST_NAME} ${TEST_SRC})
@@ -513,6 +514,39 @@ if(SPEECH_CORE_BUILD_TESTS)
                 target_link_libraries(test_fdb_bench_smoke PRIVATE ws2_32)
             endif()
             add_test(NAME test_fdb_bench_smoke COMMAND test_fdb_bench_smoke)
+        endif()
+    endif()
+
+    # fdb_summary — M3 post-processor that reads <out-dir>/*.json from
+    # fdb_bench and emits a single per-bucket CSV (p50/p90/p99 of
+    # stt/llm/tts/ttft/total). Gated identically to fdb_bench.
+    if(SPEECH_CORE_WITH_OLLAMA AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/examples/fdb_bench/fdb_summary.cpp)
+        add_executable(fdb_summary
+            examples/fdb_bench/fdb_summary.cpp
+            examples/fdb_bench/fdb_summary_lib.cpp
+        )
+        target_include_directories(fdb_summary PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/examples/fdb_bench
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+        target_link_libraries(fdb_summary PRIVATE speech_core)
+        if(MSVC)
+            target_compile_definitions(fdb_summary PRIVATE
+                _USE_MATH_DEFINES NOMINMAX _WIN32_WINNT=0x0601)
+        endif()
+
+        if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_fdb_summary.cpp)
+            add_executable(test_fdb_summary
+                tests/test_fdb_summary.cpp
+                examples/fdb_bench/fdb_summary_lib.cpp)
+            target_include_directories(test_fdb_summary PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/examples/fdb_bench
+                ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+            target_link_libraries(test_fdb_summary PRIVATE speech_core)
+            if(MSVC)
+                target_compile_definitions(test_fdb_summary PRIVATE
+                    _USE_MATH_DEFINES NOMINMAX _WIN32_WINNT=0x0601)
+            endif()
+            add_test(NAME test_fdb_summary COMMAND test_fdb_summary)
         endif()
     endif()
 endif()

--- a/docs/fdb-bench.md
+++ b/docs/fdb-bench.md
@@ -21,7 +21,6 @@ In:
 
 Out:
 
-- M3 — per-run summary CSV.
 - M4 — bridge to the upstream Python eval scripts (CrisperWhisper +
   JSD / pause-handling metrics).
 
@@ -30,6 +29,10 @@ usable when built with `-DSPEECH_CORE_WITH_ONNX=ON`. Point at a flat
 models directory (the layout produced by `scripts/download_models.sh`)
 via `--models-dir`, or override per-family with `--parakeet-dir` /
 `--kokoro-dir`.
+
+M3 (done) — `fdb_summary` reads an out-dir of `<category>__<id>.json`
+files and writes a single CSV with per-bucket sample / error counts
+and p50/p90/p99 of stt / llm / tts / ttft / total_wall.
 
 ## What FDB is
 
@@ -150,9 +153,11 @@ partial model installs don't fail the test.
 
 For each input sample `<id>`, the driver writes:
 
-- `<out-dir>/<id>.wav` — the agent's TTS response audio (PCM16 mono at
-  the TTS backend's native rate; mock TTS = 24 kHz).
-- `<out-dir>/<id>.json` — per-sample record:
+- `<out-dir>/<category_dir>__<id>.wav` — the agent's TTS response
+  audio (PCM16 mono at the TTS backend's native rate; mock TTS =
+  24 kHz). The `<category_dir>__` prefix prevents collisions because
+  FDB v1.0 reuses `1/`, `2/`, … under every category directory.
+- `<out-dir>/<category_dir>__<id>.json` — per-sample record:
 
       {
         "sample_id": "1",
@@ -186,15 +191,31 @@ Final stdout line:
 
     fdb_bench: samples_ok=N errors=M avg_ttft_ms=X out_dir=...
 
-## How M3-M4 layer on top
+## Summarizing a run
+
+After `fdb_bench` writes per-sample JSONs, run `fdb_summary` to roll
+them up into a single CSV with per-bucket percentiles:
+
+    ./build/fdb_bench   --corpus-dir /path/to/v1_0 \
+                        --out-dir /tmp/fdb_out \
+                        --llm-model llama3.2:3b
+    ./build/fdb_summary --in-dir   /tmp/fdb_out \
+                        --out-csv  /tmp/fdb_summary.csv
+
+The CSV is sorted by `(category, stt_backend, tts_backend, llm_model)`
+so two runs against different model configurations diff cleanly. Errored
+samples are counted in `samples` and `errors` but excluded from the
+timing percentiles. Pass `-` as `--out-csv` to stream to stdout.
+
+## How M4 layers on top
 
 - **M2 (done)** — `--stt parakeet` / `--tts kokoro` build out when
   `SPEECH_CORE_WITH_ONNX=ON`; `--models-dir` shortcut matches the
   `scripts/download_models.sh` layout; opt-in `real_models_integration`
   smoke test verifies the path.
-- **M3** — post-process `<out-dir>/*.json` into a single summary CSV
-  (`fdb_summary.csv`) suitable for one-line CI assertions and trend
-  tracking across runs.
+- **M3 (done)** — `fdb_summary` reads `<out-dir>/*.json` and emits a
+  single CSV with per-bucket sample / error counts and p50/p90/p99 of
+  stt / llm / tts / ttft / total_wall.
 - **M4** — bridge `<out-dir>/<id>.wav` files to the upstream
   `eval_*.py` scripts (CrisperWhisper output transcripts + JSD /
   pause-handling metrics) and a weekly workflow that pulls the corpus

--- a/examples/fdb_bench/fdb_bench.cpp
+++ b/examples/fdb_bench/fdb_bench.cpp
@@ -409,7 +409,8 @@ SampleResult process_one_sample(
         tts_pcm16.data(), tts_pcm16.size());
     int out_rate = tts.output_sample_rate();
     fs::create_directories(out_dir);
-    std::string wav_out = out_dir + "/" + s.sample_id + ".wav";
+    std::string wav_out = out_dir + "/" + s.category_dir_name +
+                          "__" + s.sample_id + ".wav";
     fdb_bench::write_wav_mono_pcm16(wav_out, float_audio.data(),
                                     float_audio.size(), out_rate);
 
@@ -447,7 +448,9 @@ void write_sample_json(const std::string& path,
             << json_escape(fdb_bench::FdbCorpus::extract_ground_truth_transcript(s.transcription_path))
             << "\",\n"
        << "  \"agent_transcript_input\": \"" << json_escape(r.agent_transcript_input) << "\",\n"
-       << "  \"output_wav\": \""       << json_escape(s.sample_id + ".wav") << "\",\n"
+       << "  \"output_wav\": \""
+            << json_escape(s.category_dir_name + "__" + s.sample_id + ".wav")
+            << "\",\n"
        << "  \"output_duration_sec\": " << r.output_duration_sec << ",\n"
        << "  \"output_sample_rate\": "  << r.output_sample_rate << ",\n"
        << "  \"timings_ms\": {\n"
@@ -571,7 +574,8 @@ int main(int argc, char** argv) {
                          r.error.empty() ? "(no error message)" : r.error.c_str());
         }
 
-        std::string json_out = args.out_dir + "/" + s.sample_id + ".json";
+        std::string json_out = args.out_dir + "/" + s.category_dir_name +
+                               "__" + s.sample_id + ".json";
         write_sample_json(json_out, s, r, args.stt, args.tts, args.llm_model,
                           in_dur);
     }

--- a/examples/fdb_bench/fdb_summary.cpp
+++ b/examples/fdb_bench/fdb_summary.cpp
@@ -1,0 +1,66 @@
+// fdb_summary CLI — thin wrapper around fdb_summary::process_dir.
+// The implementation lives in fdb_summary_lib.cpp so the smoke test can
+// link the same code without spawning a subprocess.
+
+#include "fdb_summary.h"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void print_usage() {
+    std::fprintf(stdout,
+        "fdb_summary — aggregate fdb_bench JSON output into a single CSV\n"
+        "\n"
+        "Usage: fdb_summary --in-dir <path> --out-csv <path|->\n"
+        "\n"
+        "Reads every <sample_id>.json file produced by fdb_bench, buckets\n"
+        "samples by (category, stt_backend, tts_backend, llm_model), and\n"
+        "writes a CSV with sample count, error count, and p50/p90/p99 of\n"
+        "stt/llm/tts/ttft/total timings per bucket.\n"
+        "\n"
+        "Options:\n"
+        "  --in-dir <path>     directory of fdb_bench *.json files (required)\n"
+        "  --out-csv <path|->  output CSV path; '-' for stdout (required)\n"
+        "  -h, --help          this help\n");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::string in_dir;
+    std::string out_csv;
+    bool help = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string f = argv[i];
+        if (f == "-h" || f == "--help") help = true;
+        else if (f == "--in-dir"  && i + 1 < argc) in_dir  = argv[++i];
+        else if (f == "--out-csv" && i + 1 < argc) out_csv = argv[++i];
+        else {
+            std::fprintf(stderr, "fdb_summary: unknown flag %s\n", f.c_str());
+            print_usage();
+            return 2;
+        }
+    }
+    if (help) { print_usage(); return 0; }
+    if (in_dir.empty() || out_csv.empty()) {
+        std::fprintf(stderr,
+            "fdb_summary: --in-dir and --out-csv are required\n");
+        print_usage();
+        return 2;
+    }
+
+    if (out_csv == "-") {
+        return fdb_summary::process_dir(in_dir, std::cout) ? 0 : 1;
+    }
+    std::ofstream os(out_csv);
+    if (!os) {
+        std::fprintf(stderr, "fdb_summary: cannot write %s\n",
+                     out_csv.c_str());
+        return 1;
+    }
+    return fdb_summary::process_dir(in_dir, os) ? 0 : 1;
+}

--- a/examples/fdb_bench/fdb_summary.h
+++ b/examples/fdb_bench/fdb_summary.h
@@ -1,0 +1,20 @@
+// Public surface of fdb_summary so the smoke test can drive the same
+// implementation without spawning a process. Vendored under examples/
+// (not in include/speech_core/) because the post-processor is a tool,
+// not a library API.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+
+namespace fdb_summary {
+
+/// Read every *.json file under `in_dir`, bucket samples by
+/// (category, stt_backend, tts_backend, llm_model), and write the
+/// summary CSV to `csv`. Returns true on success. Skips unparseable
+/// files with a warning to stderr; returns false only on argument
+/// errors (e.g. in_dir does not exist).
+bool process_dir(const std::string& in_dir, std::ostream& csv);
+
+}  // namespace fdb_summary

--- a/examples/fdb_bench/fdb_summary_lib.cpp
+++ b/examples/fdb_bench/fdb_summary_lib.cpp
@@ -1,0 +1,169 @@
+// Implementation of fdb_summary::process_dir — factored out so both
+// the binary (examples/fdb_bench/fdb_summary.cpp) and the smoke test
+// (tests/test_fdb_summary_smoke.cpp) can link the same code without
+// the test having to spawn a subprocess.
+
+#include "fdb_summary.h"
+
+#include "nlohmann/json.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+struct BucketKey {
+    std::string category;
+    std::string stt_backend;
+    std::string tts_backend;
+    std::string llm_model;
+    bool operator<(const BucketKey& o) const {
+        if (category    != o.category)    return category    < o.category;
+        if (stt_backend != o.stt_backend) return stt_backend < o.stt_backend;
+        if (tts_backend != o.tts_backend) return tts_backend < o.tts_backend;
+        return llm_model < o.llm_model;
+    }
+};
+
+struct Bucket {
+    size_t sample_count = 0;
+    size_t error_count  = 0;
+    std::vector<long long> stt_ms;
+    std::vector<long long> llm_ms;
+    std::vector<long long> tts_ms;
+    std::vector<long long> ttft_ms;
+    std::vector<long long> total_ms;
+};
+
+// Percentile via std::nth_element on a copy. p in [0, 100]. Uses the
+// "nearest-rank" method: idx = ceil(p/100 * n) - 1. So for 10 samples
+// p50 -> index 4 (the 5th value), p90 -> 8, p99 -> 9. Returns 0 for an
+// empty input rather than throwing — buckets that are all errors then
+// surface as zero rows in the CSV without crashing.
+long long percentile(std::vector<long long> v, double p) {
+    if (v.empty()) return 0;
+    if (p < 0.0)   p = 0.0;
+    if (p > 100.0) p = 100.0;
+    double rank = (p / 100.0) * static_cast<double>(v.size());
+    size_t idx = (rank <= 0.0)
+        ? 0
+        : static_cast<size_t>(rank + (rank == std::floor(rank) ? 0.0 : 1.0)) - 1;
+    if (idx >= v.size()) idx = v.size() - 1;
+    std::nth_element(v.begin(), v.begin() + idx, v.end());
+    return v[idx];
+}
+
+std::string get_str(const nlohmann::json& j, const char* k,
+                    const std::string& def = "") {
+    auto it = j.find(k);
+    if (it == j.end() || !it->is_string()) return def;
+    return it->get<std::string>();
+}
+
+long long get_i64(const nlohmann::json& j, const char* k,
+                  long long def = 0) {
+    auto it = j.find(k);
+    if (it == j.end() || !it->is_number()) return def;
+    return it->get<long long>();
+}
+
+}  // namespace
+
+namespace fdb_summary {
+
+bool process_dir(const std::string& in_dir, std::ostream& csv) {
+    std::error_code ec;
+    if (!fs::is_directory(in_dir, ec)) {
+        std::fprintf(stderr, "fdb_summary: not a directory: %s\n",
+                     in_dir.c_str());
+        return false;
+    }
+
+    std::map<BucketKey, Bucket> buckets;
+
+    for (auto& entry : fs::directory_iterator(in_dir, ec)) {
+        if (ec) break;
+        if (!entry.is_regular_file()) continue;
+        if (entry.path().extension() != ".json") continue;
+
+        std::ifstream is(entry.path());
+        if (!is) {
+            std::fprintf(stderr, "fdb_summary: cannot open %s\n",
+                         entry.path().string().c_str());
+            continue;
+        }
+        nlohmann::json j;
+        try {
+            is >> j;
+        } catch (const std::exception& ex) {
+            std::fprintf(stderr, "fdb_summary: bad json in %s: %s\n",
+                         entry.path().string().c_str(), ex.what());
+            continue;
+        }
+
+        BucketKey key;
+        key.category    = get_str(j, "category");
+        key.stt_backend = get_str(j, "stt_backend");
+        key.tts_backend = get_str(j, "tts_backend");
+        key.llm_model   = get_str(j, "llm_model");
+
+        Bucket& b = buckets[key];
+        b.sample_count++;
+        const std::string err = get_str(j, "error");
+        if (!err.empty()) {
+            b.error_count++;
+            continue;
+        }
+        auto tit = j.find("timings_ms");
+        if (tit == j.end() || !tit->is_object()) continue;
+        b.stt_ms  .push_back(get_i64(*tit, "stt"));
+        b.llm_ms  .push_back(get_i64(*tit, "llm"));
+        b.tts_ms  .push_back(get_i64(*tit, "tts"));
+        b.ttft_ms .push_back(get_i64(*tit, "ttft_first_audio_from_speech_end"));
+        b.total_ms.push_back(get_i64(*tit, "total_wall"));
+    }
+
+    csv << "category,stt_backend,tts_backend,llm_model,"
+        << "samples,errors,"
+        << "p50_stt_ms,p90_stt_ms,p99_stt_ms,"
+        << "p50_llm_ms,p90_llm_ms,p99_llm_ms,"
+        << "p50_tts_ms,p90_tts_ms,p99_tts_ms,"
+        << "p50_ttft_ms,p90_ttft_ms,p99_ttft_ms,"
+        << "p50_total_ms,p90_total_ms,p99_total_ms\n";
+
+    for (const auto& [k, b] : buckets) {
+        csv << k.category    << ','
+            << k.stt_backend << ','
+            << k.tts_backend << ','
+            << k.llm_model   << ','
+            << b.sample_count << ','
+            << b.error_count  << ','
+            << percentile(b.stt_ms,  50) << ','
+            << percentile(b.stt_ms,  90) << ','
+            << percentile(b.stt_ms,  99) << ','
+            << percentile(b.llm_ms,  50) << ','
+            << percentile(b.llm_ms,  90) << ','
+            << percentile(b.llm_ms,  99) << ','
+            << percentile(b.tts_ms,  50) << ','
+            << percentile(b.tts_ms,  90) << ','
+            << percentile(b.tts_ms,  99) << ','
+            << percentile(b.ttft_ms, 50) << ','
+            << percentile(b.ttft_ms, 90) << ','
+            << percentile(b.ttft_ms, 99) << ','
+            << percentile(b.total_ms, 50) << ','
+            << percentile(b.total_ms, 90) << ','
+            << percentile(b.total_ms, 99) << '\n';
+    }
+    return true;
+}
+
+}  // namespace fdb_summary

--- a/tests/test_fdb_summary.cpp
+++ b/tests/test_fdb_summary.cpp
@@ -1,0 +1,259 @@
+// Smoke tests for the M3 fdb_summary post-processor. Writes canned
+// per-sample JSON files to a temp dir, calls process_dir() directly
+// (linked from fdb_summary_lib.cpp), and parses the resulting CSV
+// to verify the header + per-bucket percentiles.
+
+// Force asserts on even under RelWithDebInfo / sanitizer builds.
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "fdb_summary.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct CsvRow {
+    std::vector<std::string> cells;
+    const std::string& at(size_t i) const { return cells.at(i); }
+    long long ll(size_t i) const { return std::stoll(cells.at(i)); }
+};
+
+std::vector<CsvRow> parse_csv(const std::string& text) {
+    std::vector<CsvRow> rows;
+    std::istringstream is(text);
+    std::string line;
+    while (std::getline(is, line)) {
+        if (line.empty()) continue;
+        CsvRow r;
+        std::string cell;
+        std::istringstream ls(line);
+        while (std::getline(ls, cell, ',')) r.cells.push_back(cell);
+        rows.push_back(std::move(r));
+    }
+    return rows;
+}
+
+void write_sample(const fs::path& dir, const std::string& id,
+                  const std::string& category,
+                  const std::string& stt, const std::string& tts,
+                  const std::string& llm_model,
+                  long long stt_ms, long long llm_ms, long long tts_ms,
+                  long long ttft_ms, long long total_ms,
+                  const std::string& error = "")
+{
+    fs::create_directories(dir);
+    std::ofstream os(dir / (id + ".json"));
+    os << "{\n"
+       << "  \"sample_id\": \"" << id << "\",\n"
+       << "  \"category\": \"" << category << "\",\n"
+       << "  \"category_dir\": \"" << category << "\",\n"
+       << "  \"input_wav\": \"/tmp/x.wav\",\n"
+       << "  \"input_duration_sec\": 1.0,\n"
+       << "  \"ground_truth_transcript\": \"hi\",\n"
+       << "  \"agent_transcript_input\": \"hi\",\n"
+       << "  \"output_wav\": \"" << id << ".wav\",\n"
+       << "  \"output_duration_sec\": 0.5,\n"
+       << "  \"output_sample_rate\": 24000,\n"
+       << "  \"timings_ms\": {\n"
+       << "    \"stt\": " << stt_ms << ",\n"
+       << "    \"llm\": " << llm_ms << ",\n"
+       << "    \"tts\": " << tts_ms << ",\n"
+       << "    \"ttft_first_audio_from_speech_end\": " << ttft_ms << ",\n"
+       << "    \"total_wall\": " << total_ms << "\n"
+       << "  },\n"
+       << "  \"stt_backend\": \"" << stt << "\",\n"
+       << "  \"tts_backend\": \"" << tts << "\",\n"
+       << "  \"llm_model\": \"" << llm_model << "\",\n"
+       << "  \"error\": \"" << error << "\"\n"
+       << "}\n";
+}
+
+fs::path scratch_dir() {
+    static auto suffix = std::to_string(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    return fs::temp_directory_path() / ("fdb_summary_smoke_" + suffix);
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+void test_header_matches_schema() {
+    auto dir = scratch_dir() / "header";
+    fs::create_directories(dir);
+    write_sample(dir, "1", "candor_pause_handling", "mock", "mock",
+                 "llama3.2:1b", 10, 20, 30, 40, 50);
+
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 2);  // header + one bucket row
+
+    const auto& h = rows[0].cells;
+    assert(h.size() == 21);
+    assert(h[0]  == "category");
+    assert(h[1]  == "stt_backend");
+    assert(h[2]  == "tts_backend");
+    assert(h[3]  == "llm_model");
+    assert(h[4]  == "samples");
+    assert(h[5]  == "errors");
+    assert(h[6]  == "p50_stt_ms");
+    assert(h[7]  == "p90_stt_ms");
+    assert(h[8]  == "p99_stt_ms");
+    assert(h[20] == "p99_total_ms");
+
+    fs::remove_all(dir);
+    std::printf("  PASS: header_matches_schema\n");
+}
+
+void test_single_sample_bucket_degenerate() {
+    auto dir = scratch_dir() / "single";
+    fs::create_directories(dir);
+    write_sample(dir, "1", "smooth_turn_taking", "mock", "mock",
+                 "llama3.2:1b", 7, 13, 17, 19, 23);
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 2);
+    const auto& r = rows[1];
+    assert(r.at(0) == "smooth_turn_taking");
+    assert(r.at(4) == "1");  // sample_count
+    assert(r.at(5) == "0");  // error_count
+    // Every percentile collapses to the single value.
+    assert(r.ll(6) == 7);   assert(r.ll(7) == 7);   assert(r.ll(8) == 7);
+    assert(r.ll(9) == 13);  assert(r.ll(10) == 13); assert(r.ll(11) == 13);
+    assert(r.ll(12) == 17); assert(r.ll(13) == 17); assert(r.ll(14) == 17);
+    assert(r.ll(15) == 19); assert(r.ll(16) == 19); assert(r.ll(17) == 19);
+    assert(r.ll(18) == 23); assert(r.ll(19) == 23); assert(r.ll(20) == 23);
+    fs::remove_all(dir);
+    std::printf("  PASS: single_sample_bucket_degenerate\n");
+}
+
+void test_percentiles_over_ten_samples() {
+    auto dir = scratch_dir() / "ten";
+    fs::create_directories(dir);
+    // 10 samples in one bucket with total_wall = 10, 20, 30 ... 100.
+    // p50 should be 50, p90 = 90, p99 = 100.
+    for (int i = 1; i <= 10; ++i) {
+        write_sample(dir, std::to_string(i),
+                     "candor_pause_handling", "mock", "mock", "m",
+                     /*stt*/ i * 1, /*llm*/ i * 2, /*tts*/ i * 3,
+                     /*ttft*/ i * 5, /*total*/ i * 10);
+    }
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 2);
+    const auto& r = rows[1];
+    assert(r.at(4) == "10");
+    assert(r.at(5) == "0");
+    // total_wall percentiles (positions 18, 19, 20)
+    assert(r.ll(18) == 50);
+    assert(r.ll(19) == 90);
+    assert(r.ll(20) == 100);
+    // stt percentiles (6, 7, 8): values 1..10 → p50=5, p90=9, p99=10
+    assert(r.ll(6) == 5);
+    assert(r.ll(7) == 9);
+    assert(r.ll(8) == 10);
+    fs::remove_all(dir);
+    std::printf("  PASS: percentiles_over_ten_samples\n");
+}
+
+void test_all_errors_bucket() {
+    auto dir = scratch_dir() / "errors";
+    fs::create_directories(dir);
+    for (int i = 0; i < 3; ++i) {
+        write_sample(dir, std::to_string(i),
+                     "user_interruption", "mock", "mock", "m",
+                     0, 0, 0, 0, 0,
+                     "LLM failed: connection refused");
+    }
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 2);
+    const auto& r = rows[1];
+    assert(r.at(4) == "3");
+    assert(r.at(5) == "3");
+    // All percentile cells should be 0 (no successful samples).
+    for (size_t i = 6; i <= 20; ++i) assert(r.ll(i) == 0);
+    fs::remove_all(dir);
+    std::printf("  PASS: all_errors_bucket\n");
+}
+
+void test_multiple_buckets_sorted() {
+    auto dir = scratch_dir() / "multi";
+    fs::create_directories(dir);
+    // Two buckets distinguished by category.
+    write_sample(dir, "1", "smooth_turn_taking", "mock", "mock", "m",
+                 1, 1, 1, 1, 100);
+    write_sample(dir, "2", "candor_pause_handling", "mock", "mock", "m",
+                 1, 1, 1, 1, 200);
+    write_sample(dir, "3", "candor_pause_handling", "mock", "mock", "m",
+                 1, 1, 1, 1, 300);
+
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 3);  // header + 2 buckets
+    // std::map orders buckets by (category, ...); "candor..." < "smooth..."
+    assert(rows[1].at(0) == "candor_pause_handling");
+    assert(rows[1].at(4) == "2");
+    assert(rows[2].at(0) == "smooth_turn_taking");
+    assert(rows[2].at(4) == "1");
+    fs::remove_all(dir);
+    std::printf("  PASS: multiple_buckets_sorted\n");
+}
+
+void test_skips_unparseable_files() {
+    auto dir = scratch_dir() / "bad";
+    fs::create_directories(dir);
+    write_sample(dir, "1", "candor_pause_handling", "mock", "mock", "m",
+                 5, 5, 5, 5, 50);
+    // Write a junk file alongside.
+    {
+        std::ofstream os(dir / "junk.json");
+        os << "this is not json {";
+    }
+    std::ostringstream csv;
+    assert(fdb_summary::process_dir(dir.string(), csv));
+    auto rows = parse_csv(csv.str());
+    assert(rows.size() == 2);
+    assert(rows[1].at(4) == "1");
+    fs::remove_all(dir);
+    std::printf("  PASS: skips_unparseable_files\n");
+}
+
+void test_missing_dir_returns_false() {
+    std::ostringstream csv;
+    assert(!fdb_summary::process_dir(
+        "/this/path/should/not/exist/anywhere", csv));
+    std::printf("  PASS: missing_dir_returns_false\n");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("test_fdb_summary:\n");
+    test_header_matches_schema();
+    test_single_sample_bucket_degenerate();
+    test_percentiles_over_ten_samples();
+    test_all_errors_bucket();
+    test_multiple_buckets_sorted();
+    test_skips_unparseable_files();
+    test_missing_dir_returns_false();
+    std::printf("All fdb_summary smoke tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

`fdb_summary` — a tiny standalone tool that walks an `fdb_bench` output directory, parses every per-sample JSON, and writes a single CSV with per-bucket sample / error counts and p50/p90/p99 of `stt / llm / tts / ttft / total_wall`. Suitable for one-line CI assertions and trend tracking across runs.

Also fixes a real M1 bug surfaced while testing M3 end-to-end: `fdb_bench` was writing `<out-dir>/<sample_id>.{wav,json}`, but FDB v1.0 reuses `1/`, `2/`, … inside every category directory, so files from different categories collided. Output now uses `<category_dir>__<sample_id>` to namespace them.

## What changed

| File | Purpose |
|---|---|
| `examples/fdb_bench/fdb_summary.cpp` | CLI wrapper |
| `examples/fdb_bench/fdb_summary.h` | `process_dir` declaration |
| `examples/fdb_bench/fdb_summary_lib.cpp` | Aggregation impl |
| `examples/fdb_bench/fdb_bench.cpp` | Fix output filename collision |
| `tests/test_fdb_summary.cpp` | 7-scenario smoke test |
| `CMakeLists.txt` | New target + test gating |
| `docs/fdb-bench.md` | M3 done, summarizing-a-run section |

## CSV schema

`category,stt_backend,tts_backend,llm_model,samples,errors,p50_stt_ms,p90_stt_ms,p99_stt_ms,p50_llm_ms,p90_llm_ms,p99_llm_ms,p50_tts_ms,p90_tts_ms,p99_tts_ms,p50_ttft_ms,p90_ttft_ms,p99_ttft_ms,p50_total_ms,p90_total_ms,p99_total_ms`

Rows sorted by `(category, stt_backend, tts_backend, llm_model)` so runs against different model configs diff cleanly. Errored samples count toward `samples` and `errors` but are excluded from timing percentiles. `--out-csv -` streams to stdout.

## Percentile method

Nearest-rank: `idx = ceil(p/100 * n) - 1`. For 10 samples p50 returns the 5th value (idx 4), p90 returns the 9th (idx 8), p99 returns the 10th (idx 9). Empty buckets emit zeros rather than throwing.

## Smoke test scenarios

1. Header matches schema (21 columns, fixed order)
2. Single-sample bucket degenerates correctly (all percentiles == the one value)
3. 10-sample bucket — p50/p90/p99 of `[10, 20, …, 100]` = `50, 90, 100` ✓
4. All-errors bucket: percentiles = 0, counts populated
5. Multiple buckets sorted by category
6. Skips unparseable JSON files with stderr warning
7. Missing dir returns false (no throw)

## Verified locally

- Default build (OLLAMA only): **18/18** ctests pass.
- ASAN+UBSAN: **16/16** ctests pass clean.
- End-to-end smoke: `fdb_bench` against `tests/data/fdb_mini/v1_0` writes 4 distinct `<category>__1.{wav,json}` files; `fdb_summary` aggregates them into 4 CSV rows (one per category) as expected. Before the M1 collision fix, this was emitting only 1 row.

## Test plan

- [ ] `cmake -B build -DSPEECH_CORE_WITH_OLLAMA=ON && cmake --build build && (cd build && ctest)` — 18/18
- [ ] CI's 9 lanes (incl. sanitizers) stay green
- [ ] End-to-end demo: `./build/fdb_bench --corpus-dir tests/data/fdb_mini/v1_0 --out-dir /tmp/fdb_demo --llm-model x && ./build/fdb_summary --in-dir /tmp/fdb_demo --out-csv -` shows 4 rows

## Rollback

`git revert <sha>`. The collision fix is contained; the new `fdb_summary` is purely additive.