### PR TITLE
ort/trt: SPEECH_CORE_TRT_MIN_SUBGRAPH_SIZE for partition fragmenting

### DIFF
--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -620,6 +620,38 @@ private:
                 // Listing them up front routes those nodes straight to
                 // CUDA from the first analysis pass — smaller TRT
                 // subgraphs, less compile memory, no error spam.
+                // SPEECH_CORE_TRT_MIN_SUBGRAPH_SIZE — minimum node count
+                // for a TRT-eligible subgraph to actually compile into a
+                // TRT engine. Default 1 (= every run becomes its own
+                // engine). Useful range: 30-200.
+                //
+                // Why: when OP_TYPES_TO_EXCLUDE is non-trivial (e.g. for
+                // VoxCPM2 token-step with 119 excluded ScatterND/OneHot/
+                // Tile nodes scattered evenly across ~5500 nodes), the
+                // partitioner produces ~120 small TRT-eligible runs
+                // separated by single-node CUDA EP islands. With the
+                // default min_subgraph_size=1, every one of those tiny
+                // runs becomes its own TRT engine. The runtime cost is
+                // dominated by cross-stream synchronisation at each
+                // TRT↔CUDA boundary — empirically deadlocks at first
+                // Run() on autoregressive loops.
+                //
+                // Raising the threshold collapses sub-threshold runs back
+                // to CUDA EP, leaving only the LARGE TRT subgraphs the
+                // INT8 fusion actually pays off on. ORT's
+                // trt_min_subgraph_size option does exactly this — it was
+                // just not threaded through here. 50 is a sensible start
+                // for VoxCPM2 token-step (collapses ~55 mid-size runs).
+                std::string min_sg_str;
+                if (const char* msz = std::getenv("SPEECH_CORE_TRT_MIN_SUBGRAPH_SIZE")) {
+                    long long n = std::atoll(msz);
+                    if (n > 0) {
+                        min_sg_str = std::to_string(n);
+                        keys.push_back("trt_min_subgraph_size");
+                        vals.push_back(min_sg_str.c_str());
+                    }
+                }
+
                 if (const char* exc = std::getenv("SPEECH_CORE_TRT_OP_TYPES_TO_EXCLUDE")) {
                     if (exc[0] != '\0') {
                         keys.push_back("trt_op_types_to_exclude");


### PR DESCRIPTION
## Summary

Opt-in `SPEECH_CORE_TRT_MIN_SUBGRAPH_SIZE` threaded into TRT EP options at the same site as #63's workspace + opt-level knobs, #65's op-types-to-exclude, and #66's CUDA fallback.

## Why

The workflow analysis tonight pinpointed this. VoxCPM2 token-step is 5566 nodes; with `OP_TYPES_TO_EXCLUDE=ScatterND,OneHot,Tile`, 119 nodes route to CUDA EP scattered evenly (median gap 17 nodes, 0 clusters). Default `trt_min_subgraph_size=1` means each of the 120 TRT-eligible runs between excluded ops becomes its own TRT engine — 55 of them in the dangerous 7-19 node range. Boundary memcpy + stream sync overhead dominates; runtime hangs at first `Run()` (worker CPU ~1%, jobs picked up off NATS but never complete).

`trt_min_subgraph_size=50` collapses the 55 mid-size runs back to CUDA EP, leaving ~38 large TRT subgraphs that actually benefit from INT8 fusion. Far fewer cross-stream boundaries → no deadlock.

## Test plan

- [ ] Build green
- [ ] Existing TRT EP path (no env var set) unchanged
- [ ] VoxCPM2 synth on Salad with `MIN_SUBGRAPH_SIZE=50` + `OP_TYPES_TO_EXCLUDE=ScatterND,OneHot,Tile` + `WORKSPACE_MB=2048` + `OPT_LEVEL=0` serves end-to-end on TRT EP without runtime hang