### PR TITLE
fix(models): point Parakeet download URL at the INT32-input v3 export

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -111,7 +111,7 @@ auto result = stt.transcribe(audio, length, 16000);
 - Greedy TDT decoding with per-frame duration prediction
 - Language detection via `<|xx|>` BPE tokens
 - Streaming supported via `begin_stream` / `push_chunk` / `end_stream` (accumulates audio and re-transcribes each chunk; not a true streaming decoder)
-- Model files: [soniqo/Parakeet-TDT-v3-ONNX](https://huggingface.co/soniqo/Parakeet-TDT-v3-ONNX) — `parakeet-encoder.onnx` (FP32, plus external `.onnx.data`) or `parakeet-encoder-int8.onnx` (~840 MB / ~100 MB INT8), `parakeet-decoder-joint.onnx` / `parakeet-decoder-joint-int8.onnx`, `vocab.json`
+- Model files: [soniqo/Parakeet-TDT-0.6B-ONNX](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-ONNX) — `parakeet-encoder.onnx` (FP32, plus external `.onnx.data`) or `parakeet-encoder-int8.onnx` (~840 MB / ~100 MB INT8), `parakeet-decoder-joint.onnx` / `parakeet-decoder-joint-int8.onnx`, `vocab.json`. Decoder-joint inputs `targets` + `target_length` are INT32; encoder length input stays INT64 — see `parakeet-encoder/decoder-joint` recent fixes for the v3 export contract.
 
 ## LiteRTSileroVad
 

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -14,9 +14,9 @@ mkdir -p "$OUT/voices"
 
 FILES=(
     "Silero-VAD-v5-ONNX/silero-vad.onnx"
-    "Parakeet-TDT-v3-ONNX/parakeet-encoder-int8.onnx"
-    "Parakeet-TDT-v3-ONNX/parakeet-decoder-joint-int8.onnx"
-    "Parakeet-TDT-v3-ONNX/vocab.json"
+    "Parakeet-TDT-0.6B-ONNX/parakeet-encoder-int8.onnx"
+    "Parakeet-TDT-0.6B-ONNX/parakeet-decoder-joint-int8.onnx"
+    "Parakeet-TDT-0.6B-ONNX/vocab.json"
     "Kokoro-82M-ONNX/kokoro-e2e.onnx"
     "Kokoro-82M-ONNX/kokoro-e2e.onnx.data"
     "Kokoro-82M-ONNX/vocab_index.json"


### PR DESCRIPTION
## Summary

\`scripts/download_models.sh\` was fetching Parakeet TDT v3 ONNX from \`soniqo/Parakeet-TDT-v3-ONNX\`, the OLD export with INT64 decoder-joint inputs. \`src/models/parakeet/parakeet_stt.cpp\` was updated (commits \`34bd8c8\` + \`40938f9\`) to send INT32 for \`targets\` + \`target_length\` matching the current NeMo v3 export hosted at \`soniqo/Parakeet-TDT-0.6B-ONNX\`. Mismatch surfaces as:

\`\`\`
ORT: Unexpected input data type. Actual: (tensor(int32)), expected: (tensor(int64))
\`\`\`

Repointing fetches at \`Parakeet-TDT-0.6B-ONNX\` restores the contract.

## Files

- \`scripts/download_models.sh\` — 3 lines (encoder + decoder-joint + vocab URLs)
- \`docs/models.md\` — Parakeet section URL + a one-line note that decoder-joint inputs are INT32

## Verified locally

\`\`\`
$ rm scripts/models/parakeet-*.onnx scripts/models/vocab.json
$ scripts/download_models.sh
[fetch] parakeet-encoder-int8.onnx
[fetch] parakeet-decoder-joint-int8.onnx
[fetch] vocab.json
$ ./build/fdb_bench --corpus-dir <real-speech> --stt parakeet \\
      --models-dir scripts/models --llm-model mock \\
      --llm-base-url http://127.0.0.1:18080
[speech] Parakeet vocab: 1024 tokens, 0 language tokens, blank=1024
[speech] STT: text='Can you guarantee that the replacement part will be shipped?' conf=0.9998
\`\`\`

Parakeet decodes real speech end-to-end.

## Follow-up surfaced

A separate VAD-prob-script edge case in \`fdb_bench\`'s \`make_vad_script_for_audio\` fires a spurious second \`SpeechStarted\` during long (>5s) real-speech samples, triggering a self-interrupt that cancels the LLM call. Visible only when both \`--stt parakeet\` AND a long input WAV are used; \`--stt mock\` or short inputs aren't affected. Will file as a separate fix PR.

## Rollback

\`git revert <sha>\`. No code change — just two URLs.