### PR TITLE
fix(fdb_bench): disable max_utterance_duration force-split

### DIFF
--- a/examples/fdb_bench/fdb_bench.cpp
+++ b/examples/fdb_bench/fdb_bench.cpp
@@ -333,6 +333,15 @@ SampleResult process_one_sample(
     cfg.min_interruption_duration = 0.0f;
     cfg.post_playback_guard = 0.0f;
     cfg.max_response_duration = 60.0f;
+    // Disable max-utterance force-split. FDB samples can run 20-30 s of
+    // real speech (Candor monologues, long interruption contexts); the
+    // default 15 s force-split would emit a spurious second
+    // UserSpeechStarted via streaming_vad_ reset, and the next worker-
+    // thread set_agent_speaking(true) inside process_utterance would
+    // arm the retroactive interruption path and cancel the LLM call.
+    // Benchmark replay has a known-bounded input length, so we don't
+    // need force-split protection here.
+    cfg.max_utterance_duration = 0.0f;
 
     vad.reset();
     vad.probs = make_vad_script_for_audio(audio16k.size(), vad.chunk_size());


### PR DESCRIPTION
## Summary

\`fdb_bench\` was using \`AgentConfig::max_utterance_duration = 15.0f\` (the default). For FDB samples longer than 15s — Candor monologues, synthetic_user_interruption context recordings often run 20-30s — \`TurnDetector::force_end_utterance\` kicks in mid-speech, emits \`UserSpeechEnded\` with the partial audio, and **resets \`streaming_vad_\`**. The continuing 0.85 VAD prob then re-enters PendingSpeech and fires a *second* \`UserSpeechStarted\`, this time with \`in_speech_ = true\`.

When the worker thread later finishes STT and \`process_utterance\` calls \`set_agent_speaking(true)\` before the LLM call, the retroactive-interruption arm at \`turn_detector.cpp:245\` sees \`(agent_speaking_=true && in_speech_=true && min_interruption_duration=0)\` and fires Interruption synchronously. This cancels the in-flight LLM HTTP request before it ever leaves \`OllamaLLM\`, and the cascade returns with empty \`response_text\` — no TTS, no output WAV, \`samples_ok=1\` but zero useful work done.

## Symptom

With \`--stt parakeet\` on a 20s real-speech sample, per-sample JSON had \`stt_ms=756\` but \`llm_ms = tts_ms = total_wall = output_duration_sec = 0\` and the mock Ollama server saw zero HTTP requests. With \`--stt mock\` (instant STT) the bug doesn't manifest because by the time \`set_agent_speaking(true)\` runs, the audio thread has finished pushing and \`in_speech_\` is back to false.

## Fix

One-line driver change: \`cfg.max_utterance_duration = 0.0f\`. Benchmark replay has a known-bounded input length; we don't need the runaway-utterance guard here.

## Verified

**Standalone TurnDetector repro** (script: 1 prime silence + 626 speech + 10 silence-tail + 12 default-0 probs, simulating 20s):

\`\`\`
before: UserSpeechStarted #1, UserSpeechEnded, UserSpeechStarted #2
after : UserSpeechStarted #1, UserSpeechEnded (single utterance)
\`\`\`

**End-to-end cascade** (real Parakeet + real Kokoro + mock Ollama against \`tests/data/test_audio.wav\`, 20s):

\`\`\`
[speech] STT: text='Can you guarantee that the replacement part will be shipped?' conf=0.9998
[speech] TTS: text='Got it. Yes, I can help.' tokens=24
fdb_bench: samples_ok=1 errors=0 avg_ttft_ms=2632.0
\`\`\`

Per-sample JSON \`timings_ms\`:

| stage | ms |
|---|---|
| stt (real Parakeet INT8) | 1,014 |
| llm (mock HTTP) | 1 |
| tts (real Kokoro 82M) | 1,617 |
| ttft (speech-end → first audio) | 2,632 |
| total wall | 2,634 |

Mock Ollama server logged exactly 1 \`/api/chat\` request.

## Scope

- \`examples/fdb_bench/fdb_bench.cpp\`: one line + comment.
- No library code touched. The \`force_end_utterance\` path in \`TurnDetector\` remains correct for interactive use, where 15-30s runaway-utterance protection is the right default.

## Rollback

\`git revert <sha>\`. Single-line driver-only change.