### PR TITLE
ort/trt: SPEECH_CORE_TRT_DISABLED_MODELS per-session EP override

### DIFF
--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -545,7 +545,72 @@ private:
         const char* fname = path.c_str() + path.find_last_of('/') + 1;
         bool appended = false;
 
-        if (gpu_provider_ == OrtGpuProvider::TensorRT) {
+        // SPEECH_CORE_TRT_DISABLED_MODELS — comma-separated list of model
+        // filename basenames (with or without .onnx extension) that should
+        // load on CUDA EP even when ORT_PROVIDER=tensorrt. For sessions
+        // where IoBinding patterns or other runtime constraints make TRT
+        // EP incompatible even when the graph itself imports cleanly.
+        //
+        // Why this exists: TRT EP + IoBinding-with-CUDA-allocator deadlock
+        // in autoregressive loops. VoxCPM2's token-step wraps Run() in
+        // IoBinding pinned to OrtMemTypeDefault on a CUDA device. TRT
+        // subgraph outputs land in TRT's own allocator; the boundary memcpy
+        // back to the IoBinding-pinned CUDA buffer never gets established
+        // and Run() blocks on cudaStreamSynchronize forever. The other
+        // VoxCPM2 sessions (text_prefill, audio_encoder, audio_decoder)
+        // use plain api_->Run() without IoBinding so TRT EP is fine there.
+        //
+        // SPEECH_CORE_TRT_DISABLED_MODELS=voxcpm2-token-step lets
+        // text_prefill + audio_* benefit from TRT INT8 fusion while
+        // token_step stays on the IoBinding-friendly CUDA EP.
+        //
+        // Matching: case-sensitive exact basename match against `fname`,
+        // with optional .onnx extension on either side stripped before
+        // comparison. Comma-separated, whitespace-trimmed. The override
+        // is per-session (this call only) — gpu_provider_ stays
+        // OrtGpuProvider::TensorRT for subsequent loads.
+        OrtGpuProvider effective_provider = gpu_provider_;
+        if (effective_provider == OrtGpuProvider::TensorRT) {
+            if (const char* disabled = std::getenv("SPEECH_CORE_TRT_DISABLED_MODELS")) {
+                if (disabled[0] != '\0') {
+                    std::string fn(fname);
+                    std::string fn_stem = fn;
+                    if (fn_stem.size() > 5 &&
+                        fn_stem.compare(fn_stem.size() - 5, 5, ".onnx") == 0) {
+                        fn_stem.resize(fn_stem.size() - 5);
+                    }
+                    std::string list(disabled);
+                    size_t pos = 0;
+                    while (pos < list.size()) {
+                        size_t comma = list.find(',', pos);
+                        if (comma == std::string::npos) comma = list.size();
+                        std::string entry = list.substr(pos, comma - pos);
+                        while (!entry.empty() &&
+                               (entry.front() == ' ' || entry.front() == '\t')) {
+                            entry.erase(0, 1);
+                        }
+                        while (!entry.empty() &&
+                               (entry.back() == ' ' || entry.back() == '\t')) {
+                            entry.pop_back();
+                        }
+                        if (entry.size() > 5 &&
+                            entry.compare(entry.size() - 5, 5, ".onnx") == 0) {
+                            entry.resize(entry.size() - 5);
+                        }
+                        if (!entry.empty() && entry == fn_stem) {
+                            LOGI("TensorRT EP disabled for %s via "
+                                 "SPEECH_CORE_TRT_DISABLED_MODELS — "
+                                 "using CUDA EP", fname);
+                            effective_provider = OrtGpuProvider::Cuda;
+                            break;
+                        }
+                        pos = comma + 1;
+                    }
+                }
+            }
+        }
+
+        if (effective_provider == OrtGpuProvider::TensorRT) {
             OrtTensorRTProviderOptionsV2* trt = nullptr;
             OrtStatus* cs = api_->CreateTensorRTProviderOptions(&trt);
             if (cs == nullptr && trt != nullptr) {


### PR DESCRIPTION
## Summary

Opt-in `SPEECH_CORE_TRT_DISABLED_MODELS` env var. Comma-separated model filename basenames (with or without `.onnx`) that load on CUDA EP even when `SPEECH_CORE_ORT_PROVIDER=tensorrt`. Per-session override; `gpu_provider_` stays TensorRT for subsequent sessions.

## Why

The structural wall for TRT INT8 on VoxCPM2 specifically, and more generally for any transformer with an autoregressive IoBinding-pinned hot loop. token-step's `Run()` is wrapped in IoBinding (`onnx_voxcpm2_tts.cpp:551-552, 566`) pinned to a CUDA-device allocator. When TRT EP is layered on, TRT subgraph outputs land in TRT's allocator and the boundary memcpy back to the IoBinding buffer never gets established — `Run()` deadlocks on `cudaStreamSynchronize`.

Falsifiability-verified in prod tonight: `MIN_SUBGRAPH_SIZE=999` (sledgehammer — forces every TRT-eligible run in token-step back to CUDA EP since the median run is 16 nodes and largest is ~38) ALSO hung. Rules out partition topology, leaves IoBinding-allocator mismatch as the only standing explanation.

VoxCPM2's other 3 sessions use plain `api_->Run()` without IoBinding — they work fine on TRT EP. Per-session EP override is the right contract.

## How

In `try_append_gpu`, parse the env var once per call. On filename match, set a local `effective_provider = OrtGpuProvider::Cuda` for the rest of the function — skips TRT EP append, lands on CUDA EP (layered beneath unconditionally). Override is per-call.

## Test plan

- [ ] Build green
- [ ] With env var unset: no behaviour change
- [ ] With `SPEECH_CORE_TRT_DISABLED_MODELS=voxcpm2-token-step`: VoxCPM2 synth on Salad runs end-to-end with TRT INT8 on text_prefill + audio_encoder + audio_decoder, CUDA EP on token_step, no deadlock, jobs complete
- [ ] Log line `TensorRT EP disabled for voxcpm2-token-step.onnx via SPEECH_CORE_TRT_DISABLED_MODELS — using CUDA EP` in boot logs