### PR TITLE
fix(fdb_score): use wall-clock TTFT from fdb_bench JSON, not Whisper

### DIFF
--- a/scripts/fdb_score.py
+++ b/scripts/fdb_score.py
@@ -232,9 +232,22 @@ def _tor_for_sample(s: Sample) -> Optional[bool]:
 
 
 def _latency_for_sample(s: Sample) -> Optional[float]:
-    if s.error or s.asr_first_word_start_s is None:
+    """FDB latency = wall-clock time between user-turn-end and the agent's
+    first audio chunk. We use fdb_bench's recorded
+    timings_ms.ttft_first_audio_from_speech_end (the SpeechEnded ->
+    first ResponseAudioDelta delta), NOT the Whisper-derived first-word
+    timestamp inside output.wav — that WAV only contains the agent's
+    response and starts at sample 0, so the asr first-word timestamp is
+    always ~0 s and useless as a latency measure. This also makes the
+    metric available in --asr-mode metadata (no Whisper required), which
+    is what the weekly CI gate uses.
+    """
+    if s.error:
         return None
-    return float(s.asr_first_word_start_s)
+    ttft_ms = s.timings_ms.get("ttft_first_audio_from_speech_end")
+    if ttft_ms is None:
+        return None
+    return float(ttft_ms) / 1000.0
 
 
 def _aggregate(samples: list[Sample], higher_is_better: bool,


### PR DESCRIPTION
## Summary

Latency in \`fdb_score.py\` was computed as "first Whisper word inside output.wav" — but our output WAVs contain only the agent's response and start at sample 0, so that number is always ~0 s. The number we actually want is **wall-clock between user-turn-end and agent-first-audio**, which \`fdb_bench\` already records in every per-sample JSON as \`timings_ms.ttft_first_audio_from_speech_end\`. Switch the scorer to read that field.

## Before / after

Against the real upstream FDB samples we just ran (Parakeet + Kokoro + Ollama \`llama3.2:1b\`, Apple M-series CPU):

| Category | Latency (before fix) | Latency (after fix) |
|---|---|---|
| smooth_turn_taking | 0.000 s | **2.363 s** |
| user_interruption | 0.000 s | **6.583 s** |
| pause_handling | 0.000 s | — (Kokoro dropped agent audio) |

The 2.363 s / 6.583 s numbers match the \`timings_ms.ttft_first_audio_from_speech_end\` fields \`fdb_bench\` writes and the \`avg_ttft_ms\` stdout line.

## Side benefits

- **Works in \`--asr-mode metadata\`** — the weekly CI gate now gets a real latency signal without needing faster-whisper installed or the ~150 MB distil-small.en model.
- **The latency tolerance in \`tests/data/fdb_baseline.json\` actually bites.** Before this fix, latency_mean_s was 0.0 everywhere so the tolerance line was unused.

## What stays the same

- \`--self-test\` passes (canned samples already had populated \`timings_ms\`).
- \`tests/data/fdb_baseline.json\` is unchanged. The weekly CI run errors every sample (no Ollama in CI), so \`_latency_for_sample\` returns \`None\` and \`latency_mean\` still aggregates to 0.0. Gate stays green.
- TOR rule unchanged. Direction-aware regression detection unchanged.

## Follow-up flagged (M4.2)

In \`--asr-mode metadata\`, the TOR rule uses \`agent_transcript_input\` as a word-count proxy. That field actually holds the **STT output of the user's input**, not the agent's reply. Real metadata-mode TOR needs an \`agent_response_text\` field added to the \`fdb_bench\` per-sample JSON. Separate PR.

## Rollback

\`git revert <sha>\`. One-function change in one Python file.