### PR TITLE
docs(voxcpm2-litert): reflect fp16 weights (INT8 decommissioned)

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -169,7 +169,7 @@ tts.synthesize("Hello world", "en", [](const float* samples, size_t length, bool
   - `audio-encoder`: 16 kHz PCM reference clip → conditioning features
   - `audio-decoder`: latent → 48 kHz PCM output
 - **Constructor** loads all four graphs via `LiteRTEngine` and verifies the tokenizer file exists; `synthesize()` runs the full pipeline (text-prefill → token-step ×N → audio-decoder) with the hand-rolled BPE tokenizer in [`voxcpm2_tokenizer.h`](../include/speech_core/models/voxcpm2_tokenizer.h). Reference-audio voice cloning isn't yet surfaced through `TTSInterface` (see the paragraph above).
-- Bundle is large (~4.6 GB total). Download with the dedicated script `scripts/download_voxcpm2_litert.sh`; we deliberately don't include it in `download_models_litert.sh` because the bundle blows the standard nightly's `actions/cache` budget.
+- Weights are **FP16**. INT8 weight quantization of the token-step breaks sibilants (tonal/metallic whistle — the autoregressive acoustic path needs ≥16-bit); the INT8 variant was decommissioned. Bundle is ~8.4 GB on disk, ~10 GiB RAM at load. Download with the dedicated script `scripts/download_voxcpm2_litert.sh`; we deliberately don't include it in `download_models_litert.sh` because the bundle blows the standard nightly's `actions/cache` budget.
 - Model files: [soniqo/VoxCPM2-LiteRT](https://huggingface.co/soniqo/VoxCPM2-LiteRT) — `voxcpm2-{text-prefill,token-step,audio-encoder,audio-decoder}.tflite`, `tokenizer.json`, `config.json`
 
 ## LiteRTWeSpeakerEmbedding
@@ -562,7 +562,7 @@ A separate `test_litert_models` target is added when `SPEECH_CORE_WITH_LITERT=ON
 ```bash
 scripts/fetch_litert.sh build/litert        # extracts libLiteRt from ai-edge-litert wheel
 scripts/download_models_litert.sh           # Silero + Parakeet
-scripts/download_voxcpm2_litert.sh          # VoxCPM2 bundle (~4.6 GB, optional)
+scripts/download_voxcpm2_litert.sh          # VoxCPM2 bundle (FP16, ~8.4 GB, optional)
 cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$PWD/build/litert
 cmake --build build
 SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure

--- a/include/speech_core/models/litert_engine.h
+++ b/include/speech_core/models/litert_engine.h
@@ -160,16 +160,16 @@ public:
         LiteRtModel m = nullptr;
         // LiteRT v2.1.5's LiteRtCreateModelFromFile fails on Windows for files
         // ≥ 2 GiB ("Failed to get file size" — 32-bit stat overflow). VoxCPM2's
-        // token-step graph is 2.04 GiB, so the file API can't load it. Use
+        // FP16 token-step graph is ~4.3 GiB, so the file API can't load it. Use
         // LiteRtCreateModelFromBuffer (size_t buffer_size is 64-bit) for big
         // files, falling back to the file API otherwise so most loads stay
         // unchanged. The buffer is zero-copy and must outlive the model, so
         // we retain it in the engine singleton. We also cache the buffer by
         // path: a test suite that reloads the same VoxCPM2 graphs across six
-        // wrapper instances would otherwise sink 6 × ~4.5 GiB ≈ 27 GiB of
+        // wrapper instances would otherwise sink 6 × ~8.4 GiB ≈ 50 GiB of
         // RAM (CI Linux runners have ~7 GiB and SIGKILL'd at 9 min). Caching
         // caps it at one copy per path. Threshold is well under 2 GiB so the
-        // prefill graph (1.94 GiB) also routes through the safer path on
+        // FP16 prefill graph (~4.1 GiB) also routes through the safer path on
         // Windows.
         constexpr std::uint64_t kBufferThreshold = std::uint64_t{1} << 30;  // 1 GiB
         std::ifstream f(path, std::ios::binary | std::ios::ate);
@@ -229,10 +229,10 @@ public:
     /// this path -- the model holds a zero-copy pointer into the buffer, so
     /// freeing the buffer while a model still references it is undefined
     /// behaviour. This is the lazy-unload path used by the VoxCPM2 wrapper
-    /// to drop the ~1.9 GiB text_prefill graph between synthesize() calls,
-    /// freeing ~2 GiB of node headroom on the prod CCX23 (16 GiB total,
-    /// otherwise too cramped to host inference + Postgres + NATS + MinIO +
-    /// realtime-worker side-by-side). No-op when `path` was below the
+    /// to drop the ~4.1 GiB FP16 text_prefill graph between synthesize()
+    /// calls, freeing node headroom (the FP16 bundle needs ~10 GiB resident;
+    /// servers run the ONNX/CUDA path instead, so LiteRT is the edge/desktop
+    /// path). No-op when `path` was below the
     /// CreateModelFromBuffer threshold (1 GiB) and therefore was never
     /// retained.
     void release_buffer(const std::string& path) {

--- a/scripts/download_voxcpm2_litert.sh
+++ b/scripts/download_voxcpm2_litert.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Download VoxCPM2 LiteRT model bundle (~4.6 GB) for the LiteRTVoxCPM2Tts
-# skeleton test. Kept separate from download_models_litert.sh because the
+# Download VoxCPM2 LiteRT model bundle (FP16, ~8.4 GB) for the LiteRTVoxCPM2Tts
+# skeleton test. Weights are FP16: INT8 broke sibilants (the AR acoustic path
+# needs >=16-bit), so the INT8 variant was decommissioned. Kept separate from
+# download_models_litert.sh because the
 # bundle is too large to fit comfortably in the nightly's actions/cache
 # budget (10 GB per repo, shared).
 #


### PR DESCRIPTION
## Summary

The VoxCPM2 LiteRT bundle on `soniqo/VoxCPM2-LiteRT` is now FP16. INT8 weight quantization broke sibilants (tonal/metallic whistle — the autoregressive acoustic path needs >=16-bit; measured spectral flatness 0.32 vs 0.45 for the reference voice). The INT8 variant and its `int8-legacy` rollback branch were removed from the repo. This PR updates the docs/comments to match.

## Changes
- `docs/models.md`: bundle is FP16, ~8.4 GB / ~10 GiB RAM (was "~4.6 GB"); note INT8 decommissioned and that servers run the ONNX/CUDA path while LiteRT is the edge/desktop path.
- `include/speech_core/models/litert_engine.h`: graph-size comments updated to FP16 (token-step ~4.3 GiB, prefill ~4.1 GiB). The >2 GiB buffer-load threshold logic is unchanged.
- `scripts/download_voxcpm2_litert.sh`: header size + FP16 note.

Docs/comments only — no code or behavior change.
