### PR TITLE
fix(fdb_bench): full-corpus iteration + IEEE Float WAV support

### DIFF
--- a/examples/fdb_bench/fdb_corpus.cpp
+++ b/examples/fdb_bench/fdb_corpus.cpp
@@ -81,6 +81,16 @@ std::vector<FdbSample> FdbCorpus::load(const FdbCorpusOptions& opts) {
         if (!fs::is_directory(category_dir, ec)) continue;
 
         std::vector<FdbSample> bucket;
+        // Use a separate ec for in-loop file existence probes so they don't
+        // contaminate the iterator's error state. Some libstdc++/libc++
+        // implementations set ec to "no such file or directory" when
+        // is_regular_file returns false for a missing path; without this
+        // separation, the very next iteration's `if (ec) break;` halts the
+        // entire category after the first sample whose optional companion
+        // file (e.g. transcription.json) is absent — which is precisely
+        // what bit candor_turn_taking and synthetic_user_interruption,
+        // categories whose samples ship without transcription.json.
+        std::error_code file_ec;
         for (auto& entry : fs::directory_iterator(category_dir, ec)) {
             if (ec) break;
             if (!entry.is_directory()) continue;
@@ -89,7 +99,7 @@ std::vector<FdbSample> FdbCorpus::load(const FdbCorpusOptions& opts) {
 
             fs::path sd = entry.path();
             fs::path wav = sd / "input.wav";
-            if (!fs::is_regular_file(wav, ec)) {
+            if (!fs::is_regular_file(wav, file_ec)) {
                 std::fprintf(stderr,
                     "fdb_corpus: missing input.wav under %s\n",
                     sd.string().c_str());
@@ -104,12 +114,12 @@ std::vector<FdbSample> FdbCorpus::load(const FdbCorpusOptions& opts) {
             s.input_wav_path    = wav.string();
             if (cd.annotation && cd.annotation[0]) {
                 fs::path ann = sd / cd.annotation;
-                if (fs::is_regular_file(ann, ec)) {
+                if (fs::is_regular_file(ann, file_ec)) {
                     s.annotation_path = ann.string();
                 }
             }
             fs::path tr = sd / "transcription.json";
-            if (fs::is_regular_file(tr, ec)) {
+            if (fs::is_regular_file(tr, file_ec)) {
                 s.transcription_path = tr.string();
             }
             bucket.push_back(std::move(s));

--- a/examples/fdb_bench/wav_io.cpp
+++ b/examples/fdb_bench/wav_io.cpp
@@ -76,26 +76,48 @@ bool load_wav_mono_pcm16(const std::string& path, WavData* out) {
         if (chunk_size & 1u) pos += 1;
     }
 
-    if (audio_format != 1 || bits_per_sample != 16 ||
-        channels < 1 || sample_rate <= 0 || pcm_data == nullptr) {
-        return false;
-    }
+    // FDB v1.0 ships two WAV flavours:
+    //   - PCM int16          (audio_format=1, bits=16)  — candor_pause_handling, icc_backchannel, synthetic_user_interruption
+    //   - IEEE Float 32-bit  (audio_format=3, bits=32)  — candor_turn_taking, synthetic_pause_handling
+    // The function name says pcm16 for historical reasons (PR #43), but the
+    // contract here is "mono float32 audio in [-1, 1], whatever the on-disk
+    // encoding was". Keeping the name avoids churn in all the call sites.
+    if (channels < 1 || sample_rate <= 0 || pcm_data == nullptr) return false;
 
-    const size_t bytes_per_frame = static_cast<size_t>(channels) * 2;
+    const bool is_pcm16   = (audio_format == 1 && bits_per_sample == 16);
+    const bool is_float32 = (audio_format == 3 && bits_per_sample == 32);
+    if (!is_pcm16 && !is_float32) return false;
+
+    const size_t bytes_per_sample = is_pcm16 ? 2u : 4u;
+    const size_t bytes_per_frame = static_cast<size_t>(channels) * bytes_per_sample;
     if (pcm_bytes < bytes_per_frame) return false;
     const size_t num_frames = pcm_bytes / bytes_per_frame;
 
     out->samples.resize(num_frames);
     out->sample_rate = sample_rate;
 
-    // Downmix to mono via averaging. PCM16 → float32 in [-1, 1].
-    const auto* sp = reinterpret_cast<const int16_t*>(pcm_data);
-    for (size_t i = 0; i < num_frames; ++i) {
-        int acc = 0;
-        for (int c = 0; c < channels; ++c) acc += sp[i * channels + c];
-        const float avg = static_cast<float>(acc) /
-                          static_cast<float>(channels);
-        out->samples[i] = avg / 32768.0f;
+    if (is_pcm16) {
+        const auto* sp = reinterpret_cast<const int16_t*>(pcm_data);
+        for (size_t i = 0; i < num_frames; ++i) {
+            int acc = 0;
+            for (int c = 0; c < channels; ++c) acc += sp[i * channels + c];
+            const float avg = static_cast<float>(acc) /
+                              static_cast<float>(channels);
+            out->samples[i] = avg / 32768.0f;
+        }
+    } else {
+        // Float32 PCM is already in [-1, 1] — read with memcpy so we don't
+        // assume the pcm_data pointer is 4-byte aligned (the chunk offset
+        // depends on prior chunk sizes and isn't guaranteed to be aligned).
+        for (size_t i = 0; i < num_frames; ++i) {
+            float acc = 0.0f;
+            for (int c = 0; c < channels; ++c) {
+                float v;
+                std::memcpy(&v, pcm_data + (i * channels + c) * 4, 4);
+                acc += v;
+            }
+            out->samples[i] = acc / static_cast<float>(channels);
+        }
     }
     return true;
 }

--- a/tests/test_fdb_bench_smoke.cpp
+++ b/tests/test_fdb_bench_smoke.cpp
@@ -237,6 +237,110 @@ void test_corpus_iterator_against_fdb_mini() {
     std::printf("  PASS: corpus_iterator_against_fdb_mini (4 samples)\n");
 }
 
+// Regression for the std::error_code contamination bug fixed alongside
+// IEEE Float WAV support. The FDB v1.0 corpus has two categories that
+// ship WITHOUT a transcription.json (candor_turn_taking,
+// synthetic_user_interruption). The original fdb_corpus.cpp used the same
+// std::error_code for both directory_iterator and the optional
+// is_regular_file probes inside the loop body; once the probe for
+// transcription.json returned false on the first sample, ec was set to
+// "not found", and the next iteration's `if (ec) break;` halted the
+// entire category — producing exactly 1 sample instead of 119/200.
+//
+// We rebuild a tiny on-disk fixture (no transcription.json, no
+// annotation) with 3 samples, and assert the iterator returns all three.
+// If the bug regresses, only the first sample comes back.
+void test_corpus_iterator_resilient_to_missing_aux_files() {
+    auto root = fs::temp_directory_path() /
+                ("fdb_iter_regress_" + std::to_string(::getpid()));
+    fs::create_directories(root);
+    // FdbCorpus iterates a fixed list of category dirs — reuse one that
+    // ships without an annotation file in the real corpus.
+    fs::path cat = root / "icc_backchannel";
+    fs::create_directories(cat);
+
+    // Generate three sample dirs each containing only input.wav — no
+    // transcription.json, no annotation. Each WAV is a 1 ms PCM16 tone
+    // (smallest valid file we can write).
+    for (int i = 1; i <= 3; ++i) {
+        fs::path sd = cat / std::to_string(i);
+        fs::create_directories(sd);
+        std::vector<float> tone(16, 0.0f);
+        bool ok = fdb_bench::write_wav_mono_pcm16(
+            (sd / "input.wav").string(),
+            tone.data(), tone.size(), 16000);
+        assert(ok);
+    }
+
+    fdb_bench::FdbCorpusOptions opts;
+    opts.corpus_root = root.string();
+    auto samples = fdb_bench::FdbCorpus::load(opts);
+    assert(samples.size() == 3 &&
+        "corpus iterator must not halt after the first sample whose "
+        "optional aux files are absent — see PR fixing FDB v1.0 "
+        "candor_turn_taking / synthetic_user_interruption truncation");
+    for (const auto& s : samples) {
+        assert(s.transcription_path.empty());
+        assert(s.annotation_path.empty());
+    }
+
+    std::error_code ec;
+    fs::remove_all(root, ec);
+    std::printf("  PASS: corpus_iterator_resilient_to_missing_aux_files\n");
+}
+
+// Regression for IEEE Float 32-bit WAV support. FDB v1.0 ships
+// candor_turn_taking + synthetic_pause_handling as audio_format=3
+// (IEEE Float, 32 bps); the original loader rejected anything other
+// than audio_format=1, bits=16, which left 256 of 727 samples unusable.
+void test_wav_io_loads_ieee_float32() {
+    constexpr int sr = 16000;
+    constexpr int n  = 256;
+    std::vector<float> in(n);
+    for (int i = 0; i < n; ++i) {
+        in[i] = 0.25f * std::sin(2.0f * 3.14159265f * 220.0f * i / sr);
+    }
+
+    // Hand-write a mono float32 WAV (IEEE float, audio_format=3). We
+    // can't reuse write_wav_mono_pcm16 because it always emits PCM16.
+    auto tmp = fs::temp_directory_path() / "fdb_smoke_float32.wav";
+    {
+        std::ofstream os(tmp, std::ios::binary);
+        assert(os);
+        auto u16 = [&](uint16_t v) {
+            char b[2] = {char(v & 0xff), char((v >> 8) & 0xff)};
+            os.write(b, 2);
+        };
+        auto u32 = [&](uint32_t v) {
+            char b[4] = {char(v & 0xff), char((v >> 8) & 0xff),
+                         char((v >> 16) & 0xff), char((v >> 24) & 0xff)};
+            os.write(b, 4);
+        };
+        const uint32_t data_bytes = static_cast<uint32_t>(n * 4);
+        os.write("RIFF", 4); u32(36 + data_bytes); os.write("WAVE", 4);
+        os.write("fmt ", 4); u32(16);
+        u16(3);              // audio_format = IEEE Float
+        u16(1);              // channels
+        u32(sr);             // sample rate
+        u32(sr * 4);         // byte rate
+        u16(4);              // block align
+        u16(32);             // bits per sample
+        os.write("data", 4); u32(data_bytes);
+        os.write(reinterpret_cast<const char*>(in.data()), data_bytes);
+    }
+
+    fdb_bench::WavData out;
+    bool loaded = fdb_bench::load_wav_mono_pcm16(tmp.string(), &out);
+    assert(loaded && "loader must accept IEEE Float 32-bit WAVs");
+    assert(out.sample_rate == sr);
+    assert(out.samples.size() == static_cast<size_t>(n));
+    for (size_t i = 0; i < out.samples.size(); ++i) {
+        assert(std::fabs(in[i] - out.samples[i]) < 1e-6f);
+    }
+    fs::remove(tmp);
+    std::printf("  PASS: wav_io_loads_ieee_float32\n");
+}
+
 void test_corpus_category_filter() {
     fdb_bench::FdbCorpusOptions opts;
     opts.corpus_root = SPEECH_CORE_FDB_MINI_DIR;
@@ -549,7 +653,9 @@ void test_real_models_integration() {
 int main() {
     std::printf("test_fdb_bench_smoke:\n");
     test_wav_io_roundtrip();
+    test_wav_io_loads_ieee_float32();
     test_corpus_iterator_against_fdb_mini();
+    test_corpus_iterator_resilient_to_missing_aux_files();
     test_corpus_category_filter();
     test_ground_truth_transcript_extraction();
     test_smoke_driver_with_mock_ollama();


### PR DESCRIPTION
## Summary

Two independent bugs blocked the FDB v1.0 full-corpus run (727 samples).
Together they truncated iteration to **410 samples** and silently errored the rest.

## Bugs

### 1) `fdb_corpus.cpp` — `std::error_code` contamination

The same `ec` variable was passed to both `directory_iterator` and the
optional `is_regular_file` probes for `transcription.json` / annotation
files. Under libc++/libstdc++ on macOS, `is_regular_file` sets `ec` to
*\"no such file or directory\"* when the probed file is absent — even
though that's the normal answer, not an error. The next iteration's
`if (ec) break;` then halted the entire category after the first sample
whose optional companions were missing.

FDB v1.0 `candor_turn_taking` (119 samples) and
`synthetic_user_interruption` (200 samples) ship without
`transcription.json`, so each yielded exactly **1 sample** instead of
the full bucket.

**Fix:** use a separate `file_ec` for optional probes; keep the outer
`ec` reserved for the iterator's own error state.

### 2) `wav_io.cpp` — IEEE Float 32-bit not supported

The loader rejected `audio_format != 1` or `bits_per_sample != 16`.
FDB v1.0 ships `candor_turn_taking` and `synthetic_pause_handling` as
IEEE Float (audio_format=3, 32 bps), so all **256** samples in those
two categories errored at load with `load_wav_mono_pcm16 failed`.

**Fix:** accept both PCM int16 and IEEE Float 32-bit; read float samples
via memcpy to avoid alignment assumptions on the data pointer. The
function name is kept for source-compat with existing call sites.

## Regression tests

Both bugs get pinned in `tests/test_fdb_bench_smoke.cpp`:

- `test_corpus_iterator_resilient_to_missing_aux_files` — builds a
  3-sample tree with no `transcription.json` and asserts all 3 come back
- `test_wav_io_loads_ieee_float32` — hand-writes a 256-sample IEEE Float
  WAV and asserts samples round-trip with `<1e-6` error

## Test plan

- [x] `ctest --output-on-failure` — all 18 tests pass
- [x] Standalone `FdbCorpus::load` against `/tmp/fdb_v1_0_corpus/v1_0`
      returns **727 / 727** samples (216 + 137 + 119 + 200 + 55)
- [x] `load_wav_mono_pcm16` accepts both IEEE Float WAVs
      (`synthetic_pause_handling/1`, `candor_turn_taking/1`) and PCM16
      WAVs (`candor_pause_handling/1`, `synthetic_user_interruption/1`)
- [ ] Re-run full FDB v1.0 corpus end-to-end and publish category-level
      TTFT / TOR numbers (follow-up after merge)