### PR TITLE
feat(voxcpm2-onnx): collapse prefill+token into one unified decoder session

### DIFF
--- a/examples/onnx/voxcpm2_clone.cpp
+++ b/examples/onnx/voxcpm2_clone.cpp
@@ -14,8 +14,9 @@
 //   speech_voxcpm2_clone_onnx <bundle_dir> <ref.wav> "<text>" <out.wav> \
 //       [instruction] [max_steps] [seed]
 //
-//   bundle_dir : directory with voxcpm2-{text-prefill,token-step,audio-encoder,
-//                audio-decoder}.onnx (+ external *.onnx.data) + tokenizer.json
+//   bundle_dir : directory with voxcpm2-{decoder,audio-encoder,audio-decoder}.onnx
+//                (+ external *.onnx.data) + tokenizer.json. voxcpm2-decoder.onnx
+//                is the unified prefill+token-step graph (merged export).
 //   ref.wav    : reference speaker clip (16-bit PCM WAV; "none" for plain TTS)
 //   seed       : optional RNG seed for bit-reproducible renders
 
@@ -163,8 +164,7 @@ int main(int argc, char** argv) {
 
     try {
         speech_core::OnnxVoxCPM2Tts tts(
-            bundle + "/voxcpm2-text-prefill.onnx",
-            bundle + "/voxcpm2-token-step.onnx",
+            bundle + "/voxcpm2-decoder.onnx",
             bundle + "/voxcpm2-audio-encoder.onnx",
             bundle + "/voxcpm2-audio-decoder.onnx",
             bundle + "/tokenizer.json",

--- a/include/speech_core/models/onnx_voxcpm2_tts.h
+++ b/include/speech_core/models/onnx_voxcpm2_tts.h
@@ -32,20 +32,29 @@ namespace speech_core {
 /// reads back from the returned OrtValues' GetTensorMutableData pointers —
 /// the same idiom ParakeetStt uses.
 ///
-/// Pipeline (four ONNX graphs orchestrated here):
+/// Pipeline (three ONNX graphs orchestrated here):
 ///   audio_encoder  : (audio [1, 102400] = 6.4 s @ 16 kHz)
 ///                    → (audio_feats [1, 40, 4, 64])    — cloning only
-///   text_prefill   : (tokens, masks, audio_feats, audio_mask, context_len)
-///                    → (lm_hidden, residual_hidden, prefix_feat_cond, base_cache, residual_cache)
-///   token_step ×N  : (lm_hidden, residual_hidden, prefix_feat_cond, base_cache,
-///                     residual_cache, position_id, noise)
-///                    → (pred_feat, stop_logits, next_lm_hidden, next_residual_hidden,
-///                       base_cache, residual_cache)
+///   decoder        : UNIFIED prefill + token-step graph (the merged export).
+///     prefill mode  : (text_tokens, text_mask, audio_feats, audio_mask, ctx_len)
+///                     → (lm_hidden, residual_hidden, prefix_feat_cond, base_cache, residual_cache)
+///     token mode ×N : (ts_lm_hidden, ts_residual_hidden, ts_prefix_feat_cond, ts_base_cache,
+///                      ts_residual_cache, ts_position_id, ts_noise)
+///                     → (ts_pred_feat, ts_stop_logits, ts_next_lm, ts_next_resid,
+///                        ts_next_base_cache, ts_next_resid_cache)
 ///   audio_decoder  : (latent [1, 64, 256]) → PCM [1, 491520] (10.24 s @ 48 kHz)
+///
+/// The prefill and token-step graphs share one 2B transformer; exporting them
+/// as one graph stores those weights ONCE, ~halving GPU weight residency vs two
+/// separate sessions (measured 19.0→10.8 GB on the prefill+token portion). Both
+/// modes live in `decoder_session_`; each Run requests only its mode's outputs
+/// (ORT executes just that subgraph) but must still supply every graph input,
+/// so the idle mode's inputs are fed cheap zero dummies (built per call).
 class OnnxVoxCPM2Tts : public TTSInterface {
 public:
-    OnnxVoxCPM2Tts(const std::string& text_prefill_path,
-                   const std::string& token_step_path,
+    /// `decoder_path` is the unified prefill+token-step graph
+    /// (voxcpm2-decoder.onnx). audio_encoder/decoder + tokenizer as before.
+    OnnxVoxCPM2Tts(const std::string& decoder_path,
                    const std::string& audio_encoder_path,
                    const std::string& audio_decoder_path,
                    const std::string& tokenizer_path,
@@ -122,11 +131,14 @@ private:
 
     const OrtApi* api_ = nullptr;
 
-    OrtSession* text_prefill_session_  = nullptr;
-    OrtSession* token_step_session_    = nullptr;
+    // One session for the unified prefill+token graph (weights resident once).
+    OrtSession* decoder_session_       = nullptr;
     OrtSession* audio_encoder_session_ = nullptr;
     OrtSession* audio_decoder_session_ = nullptr;
 
+    // The unified graph's I/O split by the "ts_" prefix: prefill_io_ holds the
+    // prefill names (text_tokens…→lm_hidden…), step_io_ the token-step names
+    // (ts_lm_hidden…→ts_pred_feat…). Each is a subset of decoder_session_'s I/O.
     IoNames prefill_io_;
     IoNames step_io_;
     IoNames encoder_io_;

--- a/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
+++ b/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
@@ -100,8 +100,7 @@ int OnnxVoxCPM2Tts::query_prefill_context(OrtSession* session) {
 // Constructor / destructor
 // ---------------------------------------------------------------------------
 
-OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& text_prefill_path,
-                                const std::string& token_step_path,
+OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& decoder_path,
                                 const std::string& audio_encoder_path,
                                 const std::string& audio_decoder_path,
                                 const std::string& tokenizer_path,
@@ -109,22 +108,36 @@ OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& text_prefill_path,
 {
     auto& engine = OnnxEngine::get();
     api_ = engine.api();
-    text_prefill_session_  = engine.load(text_prefill_path,  hw_accel);
-    // token_step runs 25-60 times per utterance with fixed shapes — the
-    // canonical CUDA Graph capture target. Opt this session into graph
-    // capture when SPEECH_CORE_CUDA_GRAPH=1 is set in the environment.
-    token_step_session_    = engine.load(token_step_path,    hw_accel,
+    // The unified graph runs both the one-shot prefill and the 25-60 per-step
+    // token decodes. Token-step shapes are fixed, so this is still the CUDA
+    // Graph capture target (SPEECH_CORE_CUDA_GRAPH=1).
+    decoder_session_       = engine.load(decoder_path, hw_accel,
                                          engine.cuda_graph_enabled());
     audio_encoder_session_ = engine.load(audio_encoder_path, hw_accel);
     audio_decoder_session_ = engine.load(audio_decoder_path, hw_accel);
 
-    query_io_names(text_prefill_session_,  prefill_io_);
-    query_io_names(token_step_session_,    step_io_);
+    // Split the unified graph's I/O into prefill (no prefix) and token (ts_).
+    IoNames full;
+    query_io_names(decoder_session_, full);
+    auto is_ts = [](const std::string& s) { return s.rfind("ts_", 0) == 0; };
+    for (auto& s : full.in_names_str)
+        (is_ts(s) ? step_io_ : prefill_io_).in_names_str.push_back(s);
+    for (auto& s : full.out_names_str)
+        (is_ts(s) ? step_io_ : prefill_io_).out_names_str.push_back(s);
+    auto rebuild = [](IoNames& io) {
+        io.in_names.clear();
+        for (auto& s : io.in_names_str) io.in_names.push_back(s.c_str());
+        io.out_names.clear();
+        for (auto& s : io.out_names_str) io.out_names.push_back(s.c_str());
+    };
+    rebuild(prefill_io_);
+    rebuild(step_io_);
+
     query_io_names(audio_encoder_session_, encoder_io_);
     query_io_names(audio_decoder_session_, decoder_io_);
 
-    // Context window comes from the prefill graph; cache sizes follow.
-    max_text_                = query_prefill_context(text_prefill_session_);
+    // Context window comes from the prefill graph's rank-4 audio_feats input.
+    max_text_                = query_prefill_context(decoder_session_);
     full_seq_                = max_text_ + kMaxGenerated;
     base_cache_floats_       = 2L * kBaseLayers     * kKvHeads * full_seq_ * kHeadDim;
     residual_cache_floats_   = 2L * kResidualLayers * kKvHeads * full_seq_ * kHeadDim;
@@ -144,8 +157,7 @@ OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& text_prefill_path,
 OnnxVoxCPM2Tts::~OnnxVoxCPM2Tts() {
     if (audio_decoder_session_)  api_->ReleaseSession(audio_decoder_session_);
     if (audio_encoder_session_)  api_->ReleaseSession(audio_encoder_session_);
-    if (token_step_session_)     api_->ReleaseSession(token_step_session_);
-    if (text_prefill_session_)   api_->ReleaseSession(text_prefill_session_);
+    if (decoder_session_)        api_->ReleaseSession(decoder_session_);
 }
 
 void OnnxVoxCPM2Tts::cancel() {
@@ -333,7 +345,25 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
 
     auto* mem = OnnxEngine::get().cpu_memory();
 
-    // --- 2. text_prefill → initial hiddens + caches.
+    // The unified graph exposes both modes' inputs; ORT requires every graph
+    // input in each Run even though we request only one mode's outputs (it
+    // executes just that subgraph). make_dummy mints a zero tensor for an idle
+    // input — minimal shape, since the nodes that read it are never run.
+    auto make_dummy = [&](const int64_t* shape, int rank,
+                          ONNXTensorElementDataType dt,
+                          std::vector<std::vector<uint8_t>>& bufs,
+                          std::vector<OrtValue*>& vals) {
+        size_t elems = 1;
+        for (int i = 0; i < rank; ++i) elems *= static_cast<size_t>(shape[i] > 0 ? shape[i] : 1);
+        const size_t esz = (dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) ? 8u : 4u;
+        bufs.emplace_back(elems * esz, 0);
+        OrtValue* v = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, bufs.back().data(), bufs.back().size(), shape, rank, dt, &v));
+        vals.push_back(v);
+    };
+
+    // --- 2. prefill mode → initial hiddens + caches.
     //
     // TODO: text_prefill ONNX graph does not yet exist with real weights.
     // The speech-models export at facca69 only emits a tiny-random-init
@@ -376,13 +406,37 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
             mem, const_cast<int64_t*>(&context_length_scalar), sizeof(int64_t),
             s_ctxlen, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_ctxlen));
 
-        OrtValue* prefill_in[5]  = {t_tokens, t_tmask, t_afeats, t_amask, t_ctxlen};
-        OrtValue* prefill_out[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+        // Idle (token-step) inputs: minimal-shape zero dummies, in step_io_
+        // input order (ts_lm, ts_resid, ts_pfc, ts_base, ts_rcache, ts_pos, ts_noise).
+        const int64_t d_lm[2]     = {1, kHidden};
+        const int64_t d_pfc[3]    = {1, kPatchSize, kFeatDim};
+        const int64_t d_bcache[6] = {2, kBaseLayers,     1, kKvHeads, 1, kHeadDim};
+        const int64_t d_rcache[6] = {2, kResidualLayers, 1, kKvHeads, 1, kHeadDim};
+        const int64_t* d_scalar   = nullptr;
+        const int64_t d_noise[3]  = {1, kFeatDim, kPatchSize};
+        std::vector<std::vector<uint8_t>> ts_dummy_bufs;
+        std::vector<OrtValue*>            ts_dummy_vals;
+        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_pfc,    3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_scalar, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_noise,  3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
 
+        // Full input set = real prefill (prefill_io_ order) + ts_ dummies.
+        std::vector<const char*> in_names = prefill_io_.in_names;
+        in_names.insert(in_names.end(), step_io_.in_names.begin(), step_io_.in_names.end());
+        std::vector<OrtValue*> in_vals = {t_tokens, t_tmask, t_afeats, t_amask, t_ctxlen};
+        in_vals.insert(in_vals.end(), ts_dummy_vals.begin(), ts_dummy_vals.end());
+
+        OrtValue* prefill_out[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
         ort_check(api_, api_->Run(
-            text_prefill_session_, nullptr,
-            prefill_io_.in_names.data(),  prefill_in,  prefill_io_.in_names.size(),
+            decoder_session_, nullptr,
+            in_names.data(),  in_vals.data(), in_names.size(),
             prefill_io_.out_names.data(), prefill_io_.out_names.size(), prefill_out));
+
+        for (OrtValue* v : ts_dummy_vals) api_->ReleaseValue(v);
 
         auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
             void* p = nullptr;
@@ -468,6 +522,22 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
     const int64_t s_dec_in [3] = {1, kFramesPerChunk, kPredFeatFloats};
     (void)s_dec_in;  // referenced by the decoder Run below
 
+    // Idle (prefill) inputs for every token-step Run: zero dummies in
+    // prefill_io_ input order, created once and reused each step. Prefill input
+    // shapes are fixed (not dynamic), so the dummies use the real dimensions.
+    const int64_t pd_tokens[2] = {1, max_text_};
+    const int64_t pd_mask[2]   = {1, max_text_};
+    const int64_t pd_afeats[4] = {1, max_text_, kPatchSize, kFeatDim};
+    const int64_t pd_amask[2]  = {1, max_text_};
+    const int64_t* pd_ctx      = nullptr;
+    std::vector<std::vector<uint8_t>> prefill_dummy_bufs;
+    std::vector<OrtValue*>            prefill_dummy_vals;
+    make_dummy(pd_tokens, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_mask,   2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_afeats, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_amask,  2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_ctx,    0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+
     auto flush_decoder = [&](size_t valid_steps, bool is_final) {
         std::fill(decoder_input.begin(), decoder_input.end(), 0.0f);
         const size_t cap_steps = std::min<size_t>(
@@ -551,7 +621,7 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
         OrtStatus* s = api_->CreateMemoryInfo(
             "Cuda", OrtDeviceAllocator, 0, OrtMemTypeDefault, &cuda_mem);
         if (s == nullptr) {
-            s = api_->CreateAllocator(token_step_session_, cuda_mem, &cuda_alloc);
+            s = api_->CreateAllocator(decoder_session_, cuda_mem, &cuda_alloc);
         }
         if (s != nullptr) {
             // Session was created on CPU (e.g. hw_accel=false) — drop back
@@ -563,7 +633,7 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
     }
 
     if (use_gpu_bind) {
-        ort_check(api_, api_->CreateIoBinding(token_step_session_, &binding));
+        ort_check(api_, api_->CreateIoBinding(decoder_session_, &binding));
 
         auto alloc_gpu = [&](const int64_t* shape, int rank, OrtValue** out) {
             ort_check(api_, api_->CreateTensorAsOrtValue(
@@ -615,14 +685,20 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
             mem, noise.data(), noise.size() * sizeof(float),
             s_noise, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_noise));
 
-        // Input order mirrors the LiteRT graph: lm_hidden, residual_hidden,
-        // prefix_feat_cond, base_cache, residual_cache, position_id, noise.
-        OrtValue* step_in[7]  = {t_lm, t_resid, t_pfc, t_bcache, t_rcache, t_pos, t_noise};
-        OrtValue* step_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+        // Input order mirrors the graph: ts_lm_hidden, ts_residual_hidden,
+        // ts_prefix_feat_cond, ts_base_cache, ts_residual_cache, ts_position_id,
+        // ts_noise — plus the idle prefill dummies (ORT needs every input).
+        std::vector<const char*> step_in_names = step_io_.in_names;
+        step_in_names.insert(step_in_names.end(),
+                             prefill_io_.in_names.begin(), prefill_io_.in_names.end());
+        std::vector<OrtValue*> step_in_vals = {t_lm, t_resid, t_pfc, t_bcache, t_rcache, t_pos, t_noise};
+        step_in_vals.insert(step_in_vals.end(),
+                            prefill_dummy_vals.begin(), prefill_dummy_vals.end());
 
+        OrtValue* step_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
         ort_check(api_, api_->Run(
-            token_step_session_, nullptr,
-            step_io_.in_names.data(),  step_in,  step_io_.in_names.size(),
+            decoder_session_, nullptr,
+            step_in_names.data(),  step_in_vals.data(), step_in_names.size(),
             step_io_.out_names.data(), step_io_.out_names.size(), step_out));
 
         // Output order mirrors LiteRT: pred_feat, stop_logits, next_lm,
@@ -722,6 +798,11 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
             step == 0 ? in_rcache : gpu_rcache[slot_in]));
         ort_check(api_, api_->BindInput(binding, in_n[5], t_pos));
         ort_check(api_, api_->BindInput(binding, in_n[6], t_noise));
+        // Idle prefill inputs — bound to the persistent zero dummies so the
+        // unified graph has every input present (the prefill subgraph isn't run).
+        for (size_t i = 0; i < prefill_io_.in_names.size(); ++i)
+            ort_check(api_, api_->BindInput(
+                binding, prefill_io_.in_names[i], prefill_dummy_vals[i]));
 
         // Output layout: 0=pred_feat, 1=stop_logits, 2=next_lm_hidden,
         // 3=next_residual_hidden, 4=base_cache, 5=residual_cache.
@@ -733,7 +814,7 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
         ort_check(api_, api_->BindOutput(binding, out_n[4], gpu_base[slot_out]));
         ort_check(api_, api_->BindOutput(binding, out_n[5], gpu_rcache[slot_out]));
 
-        ort_check(api_, api_->RunWithBinding(token_step_session_, nullptr, binding));
+        ort_check(api_, api_->RunWithBinding(decoder_session_, nullptr, binding));
         // CPU-bound outputs (pred_feat, stop_logits) need an explicit
         // device->host sync; GPU-bound outputs stay on device.
         ort_check(api_, api_->SynchronizeBoundOutputs(binding));
@@ -795,6 +876,8 @@ void OnnxVoxCPM2Tts::synthesize(const std::string& text,
         if (cuda_alloc) api_->ReleaseAllocator(cuda_alloc);
         if (cuda_mem)   api_->ReleaseMemoryInfo(cuda_mem);
     }
+
+    for (OrtValue* v : prefill_dummy_vals) api_->ReleaseValue(v);
 
     if (steps_in_chunk > 0) {
         flush_decoder(static_cast<size_t>(steps_in_chunk), /*is_final=*/true);

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -335,19 +335,18 @@ void bench_nemotron(const std::string& dir) {
 void bench_voxcpm2(const std::string& /*dir*/) {
     const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
     std::string vox = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
-    std::string prefill = vox + "/voxcpm2-text-prefill.onnx";
-    std::string step    = vox + "/voxcpm2-token-step.onnx";
+    std::string decoder = vox + "/voxcpm2-decoder.onnx";
     std::string enc     = vox + "/voxcpm2-audio-encoder.onnx";
     std::string dec     = vox + "/voxcpm2-audio-decoder.onnx";
     std::string tok     = vox + "/tokenizer.json";
-    if (!file_exists(prefill) || !file_exists(step) || !file_exists(enc)
+    if (!file_exists(decoder) || !file_exists(enc)
         || !file_exists(dec) || !file_exists(tok)) {
         std::fprintf(stderr, "[skip] voxcpm2 bundle\n");
         return;
     }
 
     auto t_load = clk::now();
-    speech_core::OnnxVoxCPM2Tts tts(prefill, step, enc, dec, tok,
+    speech_core::OnnxVoxCPM2Tts tts(decoder, enc, dec, tok,
                                      /*hw_accel=*/true);
     double load_ms = ms_since(t_load);
     if (tts.max_text_tokens() < 256) {

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -529,13 +529,12 @@ void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
     // output exactly: voxcpm2-{graph}.onnx (the speech-cloud LiteRT bundle uses
     // the same prefix on the .tflite side too, so the wrapper file naming
     // stays parallel between backends).
-    std::string text_prefill  = vox_dir + "/voxcpm2-text-prefill.onnx";
-    std::string token_step    = vox_dir + "/voxcpm2-token-step.onnx";
+    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
     std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
     std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
     std::string tokenizer     = vox_dir + "/tokenizer.json";
 
-    if (!file_exists(text_prefill) || !file_exists(token_step)
+    if (!file_exists(decoder)
         || !file_exists(audio_encoder) || !file_exists(audio_decoder)
         || !file_exists(tokenizer))
     {
@@ -548,7 +547,7 @@ void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
     // Phase 1 (always): construct + introspect. Confirms all four ORT
     // sessions load, the tokenizer parses, and the I/O introspection paths
     // don't throw.
-    speech_core::OnnxVoxCPM2Tts tts(text_prefill, token_step,
+    speech_core::OnnxVoxCPM2Tts tts(decoder,
                                      audio_encoder, audio_decoder,
                                      tokenizer, /*hw_accel=*/false);
     REQUIRE(tts.output_sample_rate() == 48000);
@@ -610,8 +609,7 @@ void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
     const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
     std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
 
-    std::string text_prefill  = vox_dir + "/voxcpm2-text-prefill.onnx";
-    std::string token_step    = vox_dir + "/voxcpm2-token-step.onnx";
+    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
     std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
     std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
     std::string tokenizer     = vox_dir + "/tokenizer.json";
@@ -619,7 +617,7 @@ void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
     std::string parakeet_dec  = dir + "/parakeet-decoder-joint-int8.onnx";
     std::string parakeet_voc  = dir + "/vocab.json";
 
-    if (!file_exists(text_prefill) || !file_exists(token_step)
+    if (!file_exists(decoder)
         || !file_exists(audio_encoder) || !file_exists(audio_decoder)
         || !file_exists(tokenizer)
         || !file_exists(parakeet_enc) || !file_exists(parakeet_dec)
@@ -629,7 +627,7 @@ void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
         return;
     }
 
-    speech_core::OnnxVoxCPM2Tts tts(text_prefill, token_step,
+    speech_core::OnnxVoxCPM2Tts tts(decoder,
                                      audio_encoder, audio_decoder,
                                      tokenizer, /*hw_accel=*/true);
     if (tts.max_text_tokens() < 256) {
@@ -726,8 +724,7 @@ static std::vector<std::string> tokenize_lower(const std::string& s) {
 void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
     const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
     std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
-    std::string text_prefill  = vox_dir + "/voxcpm2-text-prefill.onnx";
-    std::string token_step    = vox_dir + "/voxcpm2-token-step.onnx";
+    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
     std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
     std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
     std::string tokenizer     = vox_dir + "/tokenizer.json";
@@ -735,7 +732,7 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
     std::string parakeet_dec  = dir + "/parakeet-decoder-joint-int8.onnx";
     std::string parakeet_voc  = dir + "/vocab.json";
 
-    if (!file_exists(text_prefill) || !file_exists(token_step)
+    if (!file_exists(decoder)
         || !file_exists(audio_encoder) || !file_exists(audio_decoder)
         || !file_exists(tokenizer)
         || !file_exists(parakeet_enc) || !file_exists(parakeet_dec)
@@ -745,7 +742,7 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
         return;
     }
 
-    speech_core::OnnxVoxCPM2Tts tts(text_prefill, token_step,
+    speech_core::OnnxVoxCPM2Tts tts(decoder,
                                      audio_encoder, audio_decoder,
                                      tokenizer, /*hw_accel=*/true);
     if (tts.max_text_tokens() < 256) {


### PR DESCRIPTION
## Summary
Drive the merged `voxcpm2-decoder` graph from a **single** ORT session instead of separate `text_prefill` + `token_step` sessions, halving GPU weight residency at identical quality.

## What changed
- Constructor now takes `(decoder, audio_encoder, audio_decoder, tokenizer, hw_accel)`. The unified graph's I/O is split by the `ts_` prefix into `prefill_io_` / `step_io_`.
- Each `Run` requests only its mode's outputs (ORT executes just that subgraph) and feeds minimal **zero dummies** for the idle mode's inputs (ORT requires every graph input present). A `make_dummy` helper mints them.
- The IOBinding decode loop additionally binds the persistent prefill dummies; the ping-pong GPU-KV path is otherwise unchanged.
- CLI (`examples/onnx/voxcpm2_clone.cpp`), `test_models`, and `bench_ort_models` updated to the new constructor.

## Why
The two graphs share one 2B transformer; loading them as two sessions duplicated ~3.8 GB of weights. One session stores them once and shares a single ORT arena → prefill+token GPU residency **19.0 → 10.8 GB**, full pipeline ~19.4 → ~11–12 GB (fits 16 GB cards) at **full fp16 quality**.

## Requires
The unified bundle: `voxcpm2-decoder.onnx` from speech-models `--graphs unified` (soniqo/speech-models#45). The old `voxcpm2-text-prefill.onnx` / `voxcpm2-token-step.onnx` files are no longer loaded.

## Test plan
- Compiles clean on the CUDA build (`speech_core_models`, CLI, `test_models`).
- **CUDA smoke test** on the real 2B unified graph: loads one session, prefill mode → sane hiddens, token mode via IOBinding → sane acoustics, stop fired at step 17, wrote 2.88 s of 48 kHz audio.
- Core default-build suite green (no regression; the merge touches only the ONNX path).
