### PR TITLE
Add SupertonicTTS-3 as a LiteRT TTSInterface model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,20 @@ if(SPEECH_CORE_WITH_LITERT)
     endif()
     get_filename_component(LITERT_DIR "${LITERT_DIR}" ABSOLUTE)
 
+    # utf8proc — Unicode NFKD for the SupertonicTTS G2P-free front-end (the keystone that
+    # decomposes accents/Hangul into in-vocab codepoints). MIT-licensed, no GPL in the TTS path.
+    # Prefer a system copy; otherwise fetch a pinned release. Linked PRIVATE: the C ABI hides it.
+    find_package(utf8proc QUIET)
+    if(NOT utf8proc_FOUND)
+        include(FetchContent)
+        FetchContent_Declare(utf8proc
+            GIT_REPOSITORY https://github.com/JuliaStrings/utf8proc.git
+            GIT_TAG        v2.9.0)
+        set(UTF8PROC_INSTALL OFF CACHE BOOL "" FORCE)
+        set(UTF8PROC_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(utf8proc)
+    endif()
+
     # libLiteRt from Google's ai-edge-litert package — imported shared library.
     # Windows needs both .dll (runtime) and .lib (link-time import library);
     # other platforms only need the shared object itself.
@@ -216,6 +230,9 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/voxcpm2_c.cpp
         src/models/litert/hf_download.cpp
         src/models/litert/voxcpm2_tokenizer.cpp
+        src/models/litert/litert_supertonic_tts.cpp
+        src/models/litert/supertonic_tokenizer.cpp
+        src/models/litert/supertonic_c.cpp
         src/models/litert/litert_wespeaker_embedding.cpp
         src/models/litert/litert_pyannote_segmentation.cpp
         src/models/litert/litert_omnilingual_stt.cpp
@@ -242,6 +259,12 @@ if(SPEECH_CORE_WITH_LITERT)
     set_target_properties(speech_core_models_litert PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
     target_link_libraries(speech_core_models_litert PUBLIC speech_core litert)
+    # utf8proc for SupertonicTokenizer NFKD (PRIVATE: hidden behind the C ABI).
+    if(TARGET utf8proc)
+        target_link_libraries(speech_core_models_litert PRIVATE utf8proc)
+    else()
+        target_link_libraries(speech_core_models_litert PRIVATE utf8proc::utf8proc)
+    endif()
 
     # Optional first-run model download (sc_voxcpm2_create_from_pretrained).
     # libcurl provides resumable HTTPS with an OS-native TLS backend (Schannel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,9 +193,10 @@ if(SPEECH_CORE_WITH_LITERT)
     find_package(utf8proc QUIET)
     if(NOT utf8proc_FOUND)
         include(FetchContent)
+        # v2.11.0+ — earlier tags' cmake_minimum_required(VERSION 3.0.0) is rejected by CMake >= 4.
         FetchContent_Declare(utf8proc
             GIT_REPOSITORY https://github.com/JuliaStrings/utf8proc.git
-            GIT_TAG        v2.9.0)
+            GIT_TAG        v2.11.0)
         set(UTF8PROC_INSTALL OFF CACHE BOOL "" FORCE)
         set(UTF8PROC_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
         FetchContent_MakeAvailable(utf8proc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,10 @@ if(SPEECH_CORE_WITH_LITERT)
     find_package(utf8proc QUIET)
     if(NOT utf8proc_FOUND)
         include(FetchContent)
-        # v2.11.0+ — earlier tags' cmake_minimum_required(VERSION 3.0.0) is rejected by CMake >= 4.
+        # CMake >= 4 errors on utf8proc's cmake_minimum_required if the fetched/cached source is an
+        # older tag (e.g. v2.9.0's VERSION 3.0.0). Pin v2.11.0 (VERSION 3.10) AND set the policy floor
+        # so configure still succeeds even when a stale checkout surfaces on a CI runner.
+        set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
         FetchContent_Declare(utf8proc
             GIT_REPOSITORY https://github.com/JuliaStrings/utf8proc.git
             GIT_TAG        v2.11.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,13 @@ if(SPEECH_CORE_WITH_LITERT)
         if(MSVC)
             target_compile_definitions(speech_voxcpm2_clone PRIVATE _USE_MATH_DEFINES NOMINMAX)
         endif()
+
+        # SupertonicTTS-3 smoke test / example CLI.
+        add_executable(speech_supertonic_tts examples/litert/supertonic_tts.cpp)
+        target_link_libraries(speech_supertonic_tts PRIVATE speech_core_models_litert)
+        if(MSVC)
+            target_compile_definitions(speech_supertonic_tts PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
     endif()
 
     # Debug CLI for the HF downloader (resume/retry testing). Links the internal

--- a/examples/litert/supertonic_tts.cpp
+++ b/examples/litert/supertonic_tts.cpp
@@ -1,0 +1,84 @@
+// SupertonicTTS-3 LiteRT smoke test / example.
+//
+//   supertonic_tts <bundle_dir> [text] [lang] [voice] [out.wav]
+//
+// bundle_dir = the soniqo/Supertonic-3-LiteRT layout: the four .tflite graphs +
+// unicode_indexer.json + tts.json + voice_styles/<id>.json.
+
+#include "speech_core/supertonic_c.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<float> g_pcm;
+
+void on_chunk(const float* samples, size_t length, bool is_final, void* /*user*/) {
+    g_pcm.insert(g_pcm.end(), samples, samples + length);
+    std::printf("  chunk: %zu samples%s\n", length, is_final ? " (final)" : "");
+}
+
+void write_wav(const std::string& path, const std::vector<float>& pcm, int sr) {
+    std::vector<int16_t> i16(pcm.size());
+    for (size_t i = 0; i < pcm.size(); ++i) {
+        float v = pcm[i];
+        if (v > 1.f) v = 1.f;
+        if (v < -1.f) v = -1.f;
+        i16[i] = static_cast<int16_t>(v * 32767.f);
+    }
+    const uint32_t data_bytes = static_cast<uint32_t>(i16.size() * sizeof(int16_t));
+    const uint32_t byte_rate  = static_cast<uint32_t>(sr) * 2;
+    FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) { std::fprintf(stderr, "cannot write %s\n", path.c_str()); return; }
+    auto u32 = [&](uint32_t v) { std::fwrite(&v, 4, 1, f); };
+    auto u16 = [&](uint16_t v) { std::fwrite(&v, 2, 1, f); };
+    std::fwrite("RIFF", 1, 4, f); u32(36 + data_bytes); std::fwrite("WAVE", 1, 4, f);
+    std::fwrite("fmt ", 1, 4, f); u32(16); u16(1); u16(1);
+    u32(static_cast<uint32_t>(sr)); u32(byte_rate); u16(2); u16(16);
+    std::fwrite("data", 1, 4, f); u32(data_bytes);
+    std::fwrite(i16.data(), 1, data_bytes, f);
+    std::fclose(f);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <bundle_dir> [text] [lang] [voice] [out.wav]\n", argv[0]);
+        return 2;
+    }
+    const char* bundle = argv[1];
+    const char* text   = argc > 2 ? argv[2] : "Hello from soniqo dot audio.";
+    const char* lang   = argc > 3 ? argv[3] : "en";
+    const char* voice  = argc > 4 ? argv[4] : "F1";
+    const std::string out = argc > 5 ? argv[5] : "supertonic_out.wav";
+
+    sc_supertonic_t s = sc_supertonic_create(bundle);
+    if (!s) {
+        std::fprintf(stderr, "create failed: %s\n", sc_supertonic_last_error(nullptr));
+        return 1;
+    }
+    sc_supertonic_set_voice(s, voice);
+    sc_supertonic_set_total_step(s, 8);
+    sc_supertonic_set_seed(s, 1234);  // reproducible
+
+    std::printf("synthesizing [%s] \"%s\" voice=%s\n", lang, text, voice);
+    const int rc = sc_supertonic_synthesize(s, text, lang, on_chunk, nullptr);
+    if (rc != 0) {
+        std::fprintf(stderr, "synthesize failed (%d): %s\n", rc, sc_supertonic_last_error(s));
+        sc_supertonic_destroy(s);
+        return 1;
+    }
+
+    const int sr = sc_supertonic_output_sample_rate(s);
+    std::printf("OK: %zu samples @ %d Hz = %.2fs\n", g_pcm.size(), sr,
+                static_cast<double>(g_pcm.size()) / sr);
+    write_wav(out, g_pcm, sr);
+    std::printf("wrote %s\n", out.c_str());
+    sc_supertonic_destroy(s);
+    return 0;
+}

--- a/include/speech_core/models/litert_supertonic_tts.h
+++ b/include/speech_core/models/litert_supertonic_tts.h
@@ -18,7 +18,7 @@ namespace speech_core {
 /// Models: https://huggingface.co/soniqo/Supertonic-3-LiteRT
 ///
 /// Four LiteRT graphs orchestrated here (text padded to a fixed T = 128):
-///   duration_predictor : (text_ids[1,T] i32, style_dp[1,8,16], text_mask[1,1,T]) → duration[1] (sec)
+///   duration_predictor : (text_ids[1,T] i64, style_dp[1,8,16], text_mask[1,1,T]) → duration[1] (sec)
 ///   text_encoder       : (text_ids, style_ttl[1,50,256], text_mask)              → text_emb[1,256,T]
 ///   vector_estimator ×N: (noisy[1,144,L], text_emb, style_ttl, latent_mask[1,1,L],
 ///                         text_mask, current_step[1], total_step[1])              → denoised[1,144,L]
@@ -79,9 +79,10 @@ private:
         std::vector<float> style_dp;   // [1,8,16]   → 128
     };
 
-    // Synthesize one ≤T-token chunk into trimmed 44.1 kHz PCM.
-    std::vector<float> synth_chunk(const std::string& chunk, const std::string& language);
+    // Synthesize one ≤T-token chunk into trimmed 44.1 kHz PCM. chunk_index decorrelates the noise.
+    std::vector<float> synth_chunk(const std::string& chunk, const std::string& language, size_t chunk_index);
     const VoiceStyle& current_voice() const;
+    void destroy_graphs() noexcept;  // idempotent; used by the dtor and ctor-failure cleanup
 
     LiteRtModel         duration_model_  = nullptr;  LiteRtCompiledModel duration_compiled_  = nullptr;
     LiteRtModel         encoder_model_   = nullptr;  LiteRtCompiledModel encoder_compiled_   = nullptr;

--- a/include/speech_core/models/litert_supertonic_tts.h
+++ b/include/speech_core/models/litert_supertonic_tts.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/litert_engine.h"
+#include "speech_core/models/supertonic_tokenizer.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace speech_core {
+
+/// SupertonicTTS-3 — 99M non-autoregressive flow-matching multilingual TTS via LiteRT.
+/// 44.1 kHz output, 31 languages, **G2P-free** (NFKD + unicode-index tokenizer — no phonemizer).
+/// Models: https://huggingface.co/soniqo/Supertonic-3-LiteRT
+///
+/// Four LiteRT graphs orchestrated here (text padded to a fixed T = 128):
+///   duration_predictor : (text_ids[1,T] i32, style_dp[1,8,16], text_mask[1,1,T]) → duration[1] (sec)
+///   text_encoder       : (text_ids, style_ttl[1,50,256], text_mask)              → text_emb[1,256,T]
+///   vector_estimator ×N: (noisy[1,144,L], text_emb, style_ttl, latent_mask[1,1,L],
+///                         text_mask, current_step[1], total_step[1])              → denoised[1,144,L]
+///   vocoder            : (latent[1,144,L])                                        → wav[1, 512*6*L]
+///   L = ceil(duration*44100/(512*6)); noisy = randn([1,144,L])*latent_mask; speed divides duration.
+///
+/// Unlike VoxCPM2, this is **non-autoregressive**: a fixed `total_step` ODE loop (default 8), no stop
+/// logits, no KV cache. Each synthesize() splits text into ≤T-token chunks, runs the four graphs per
+/// chunk, and streams the trimmed PCM through the TTSChunkCallback (0.3 s silence between chunks).
+///
+/// Validated end-to-end against the ONNX reference at 66–82 dB mag-STFT SNR (en/de/ko); see the
+/// Runner repo's `speech-models/stmodels/controlled_ab.py`. Voice is a precomputed style pair
+/// (`voice_styles/<id>.json`); on-device voice cloning is out of scope (the style-extractor isn't
+/// released).
+class LiteRTSupertonicTts : public TTSInterface {
+public:
+    /// @param tokenizer_dir   holds `unicode_indexer.json` + `tts.json`
+    /// @param voice_styles_dir holds `<id>.json` style files (F1..F5, M1..M5)
+    LiteRTSupertonicTts(const std::string& duration_path,
+                        const std::string& text_encoder_path,
+                        const std::string& vector_estimator_path,
+                        const std::string& vocoder_path,
+                        const std::string& tokenizer_dir,
+                        const std::string& voice_styles_dir,
+                        bool hw_accel = false);
+    ~LiteRTSupertonicTts() override;
+
+    // --- TTSInterface ---
+    void synthesize(const std::string& text,
+                    const std::string& language,
+                    TTSChunkCallback on_chunk) override;
+    int output_sample_rate() const override { return 44100; }
+    void cancel() override;
+
+    /// Select the voice (e.g. "F1", "M3"). Default "F1". Throws if unknown.
+    void set_voice(const std::string& voice_id);
+
+    /// Flow-matching ODE steps: 5 (fast) · 8 (default) · 12 (quality).
+    void set_total_step(int total_step) { total_step_ = total_step; }
+
+    /// Speech rate; divides predicted duration. Default 1.05.
+    void set_speed(float speed) { speed_ = speed; }
+
+    /// Seed the latent-noise RNG. 0 ⇒ a fresh non-deterministic seed per call (default); a fixed seed
+    /// makes synthesis reproducible. The value used is reported by seed_used().
+    void set_seed(uint32_t seed) { seed_ = seed; }
+    uint32_t seed_used() const { return seed_used_; }
+
+    /// Silence inserted between chunks, in seconds. Default 0.3.
+    void set_chunk_silence(float seconds) { chunk_silence_s_ = seconds; }
+
+    /// Available voice ids loaded from `voice_styles_dir`.
+    std::vector<std::string> voices() const;
+
+private:
+    struct VoiceStyle {
+        std::vector<float> style_ttl;  // [1,50,256] → 12800
+        std::vector<float> style_dp;   // [1,8,16]   → 128
+    };
+
+    // Synthesize one ≤T-token chunk into trimmed 44.1 kHz PCM.
+    std::vector<float> synth_chunk(const std::string& chunk, const std::string& language);
+    const VoiceStyle& current_voice() const;
+
+    LiteRtModel         duration_model_  = nullptr;  LiteRtCompiledModel duration_compiled_  = nullptr;
+    LiteRtModel         encoder_model_   = nullptr;  LiteRtCompiledModel encoder_compiled_   = nullptr;
+    LiteRtModel         vector_model_    = nullptr;  LiteRtCompiledModel vector_compiled_    = nullptr;
+    LiteRtModel         vocoder_model_   = nullptr;  LiteRtCompiledModel vocoder_compiled_   = nullptr;
+
+    std::unique_ptr<SupertonicTokenizer>        tokenizer_;
+    std::unordered_map<std::string, VoiceStyle> voices_;
+    std::string                                 voice_id_ = "F1";
+
+    static constexpr int kTextT          = 128;       // fixed text length (relpos attention)
+    static constexpr int kLatentChannels = 144;       // latent_dim(24) * chunk_compress(6)
+    static constexpr int kChunkSamples   = 512 * 6;   // 3072 samples per latent frame
+    static constexpr int kVecEstLMin     = 17;        // exported vector_estimator floor
+    static constexpr int kStyleTtlFloats = 50 * 256;  // 12800
+    static constexpr int kStyleDpFloats  = 8 * 16;    // 128
+    static constexpr int kSampleRate     = 44100;
+
+    int               total_step_      = 8;
+    float             speed_           = 1.05f;
+    uint32_t          seed_            = 0;     // 0 ⇒ fresh seed per call
+    uint32_t          seed_used_       = 0;
+    float             chunk_silence_s_ = 0.3f;
+    std::atomic<bool> cancelled_{false};
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/supertonic_tokenizer.h
+++ b/include/speech_core/models/supertonic_tokenizer.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// SupertonicTTS G2P-free text front-end — the part that, for Kokoro/espeak-class TTS, is the
+/// hardest and most GPL-entangled piece, and which Supertonic collapses to:
+/// **NFKD + regex cleanup + `<lang>…</lang>` wrap + codepoint→token-id table lookup.**
+/// No phonemizer, no IPA, no lexicon, no espeak.
+///
+/// Faithful C++ port of `Supertone/supertonic` `py/helper.py::UnicodeProcessor` (MIT); validated
+/// against it in the Runner repo's `speech-models/stmodels/infer.py`. Two traps it handles:
+///   - **codepoint (not byte) work** — everything operates on decoded UTF-32, never `std::string`
+///     byte length.
+///   - **unknown token = -1** — out-of-range / unmapped codepoints resolve to -1 (never an OOB
+///     table index). The model masks padded positions; -1 ids only appear at real positions for
+///     genuinely out-of-vocab characters.
+///
+/// NFKD is the keystone: it decomposes precomposed Latin accents (ä → a +◌̈) and Hangul syllables
+/// (한 → ㅎ+ㅏ+ㄴ) into in-vocab components — which is exactly why German and Korean need no
+/// special-casing. NFKD here is provided by utf8proc (`UTF8PROC_DECOMPOSE | UTF8PROC_COMPAT`).
+class SupertonicTokenizer {
+public:
+    /// Token id for codepoints absent from the indexer table.
+    static constexpr int32_t kUnknownId = -1;
+
+    /// @param unicode_indexer_path flat JSON array of 65536 ints (`codepoint → id`, -1 if unsupported)
+    /// @param tts_json_path        `tts.json` (read for forward-compat; AVAILABLE_LANGS is baked in)
+    explicit SupertonicTokenizer(const std::string& unicode_indexer_path,
+                                 const std::string& tts_json_path = {});
+
+    /// Whether `lang` (ISO code, e.g. "de", "ko") is in Supertonic's AVAILABLE_LANGS.
+    bool supports(const std::string& lang) const;
+
+    /// Split free-form text into per-synthesis chunks. Caps each chunk so the wrapped, tokenized
+    /// form fits the exported fixed text length (`max_text_tokens`, default 128). Sentence-aware,
+    /// codepoint-counted; CJK uses a tighter cap. Mirrors `helper.py::_chunk_text`.
+    std::vector<std::string> chunk(const std::string& text, const std::string& lang) const;
+
+    /// Result of tokenizing one chunk for the fixed-T graphs.
+    struct Tokens {
+        std::vector<int32_t> ids;   ///< length == text_t (zero-padded)
+        std::vector<float>   mask;  ///< length == text_t (1.0 real, 0.0 pad), feeds text_mask[1,1,T]
+    };
+
+    /// Full front-end for one chunk: NFKD + cleanup + `<lang>` wrap + tokenize, then right-pad ids
+    /// to `text_t` (with 0) and build the float mask. Throws std::invalid_argument on bad language.
+    Tokens process(const std::string& text, const std::string& lang, int text_t = 128) const;
+
+    /// Largest wrapped+tokenized length the front-end will emit before padding (== text_t).
+    int max_text_tokens() const { return max_text_tokens_; }
+
+private:
+    std::string preprocess(const std::string& text, const std::string& lang) const;  // NFKD + clean + wrap
+    int32_t     lookup(uint32_t codepoint) const;
+
+    std::vector<int32_t> indexer_;          // [65536]
+    int                  max_text_tokens_ = 128;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/supertonic_tokenizer.h
+++ b/include/speech_core/models/supertonic_tokenizer.h
@@ -38,7 +38,10 @@ public:
     /// Split free-form text into per-synthesis chunks. Caps each chunk so the wrapped, tokenized
     /// form fits the exported fixed text length (`max_text_tokens`, default 128). Sentence-aware,
     /// codepoint-counted; CJK uses a tighter cap. Mirrors `helper.py::_chunk_text`.
-    std::vector<std::string> chunk(const std::string& text, const std::string& lang) const;
+    /// @param max_codepoints if > 0, an additional (tighter) per-chunk codepoint cap — used to keep a
+    ///        chunk's predicted audio within a fixed-shape graph's latent window.
+    std::vector<std::string> chunk(const std::string& text, const std::string& lang,
+                                   int max_codepoints = 0) const;
 
     /// Result of tokenizing one chunk for the fixed-T graphs.
     struct Tokens {

--- a/include/speech_core/supertonic_c.h
+++ b/include/speech_core/supertonic_c.h
@@ -1,0 +1,80 @@
+// C ABI for SupertonicTTS-3 — the non-autoregressive flow-matching multilingual TTS
+// (44.1 kHz, 31 languages, G2P-free) running on LiteRT through speech-core's TTSInterface.
+//
+// Mirrors voxcpm2_c.h. Example:
+//
+//   sc_supertonic_t s = sc_supertonic_create("/path/to/Supertonic-3-LiteRT");
+//   sc_supertonic_set_voice(s, "F1");
+//   sc_supertonic_synthesize(s, "Hello there", "en", on_chunk, user_ctx);
+//   sc_supertonic_destroy(s);
+//
+// The bundle dir holds the four graphs (`duration_predictor.tflite`, `text_encoder.tflite`,
+// `vector_estimator.tflite`, `vocoder.tflite`), the tokenizer assets (`unicode_indexer.json`,
+// `tts.json`), and a `voice_styles/` directory of `<id>.json` files — i.e. the layout of
+// https://huggingface.co/soniqo/Supertonic-3-LiteRT .
+
+#ifndef SPEECH_CORE_SUPERTONIC_C_H
+#define SPEECH_CORE_SUPERTONIC_C_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct sc_supertonic_s* sc_supertonic_t;
+
+/// Streamed PCM callback: `samples` is `length` mono float32 at the output sample rate;
+/// `is_final` is true on the last chunk of the utterance. `user` is passed through verbatim.
+typedef void (*sc_supertonic_chunk_fn)(const float* samples, size_t length,
+                                       bool is_final, void* user);
+
+/// Create from a bundle directory (see the file header for the expected layout). Returns NULL on
+/// failure; call sc_supertonic_last_error(NULL) for a message.
+sc_supertonic_t sc_supertonic_create(const char* bundle_dir);
+
+/// Create from explicit asset paths (graphs + tokenizer dir + voice-styles dir). `hw_accel`
+/// requests a hardware delegate where available. Returns NULL on failure.
+sc_supertonic_t sc_supertonic_create_from_paths(const char* duration_path,
+                                                const char* text_encoder_path,
+                                                const char* vector_estimator_path,
+                                                const char* vocoder_path,
+                                                const char* tokenizer_dir,
+                                                const char* voice_styles_dir,
+                                                bool hw_accel);
+
+void sc_supertonic_destroy(sc_supertonic_t synth);
+
+/// Select the voice (e.g. "F1", "M3"). No-op + error string on unknown id.
+void sc_supertonic_set_voice(sc_supertonic_t synth, const char* voice_id);
+
+/// Flow-matching ODE steps: 5 (fast) · 8 (default) · 12 (quality).
+void sc_supertonic_set_total_step(sc_supertonic_t synth, int total_step);
+
+/// Speech rate; divides predicted duration. Default 1.05.
+void sc_supertonic_set_speed(sc_supertonic_t synth, float speed);
+
+/// Latent-noise RNG seed; 0 ⇒ a fresh seed per synthesize() (default).
+void sc_supertonic_set_seed(sc_supertonic_t synth, uint32_t seed);
+
+/// Output sample rate (44100).
+int sc_supertonic_output_sample_rate(sc_supertonic_t synth);
+
+/// Synthesize `text` in ISO `language`, streaming PCM to `on_chunk`. Returns 0 on success,
+/// non-zero on failure (see sc_supertonic_last_error).
+int sc_supertonic_synthesize(sc_supertonic_t synth, const char* text, const char* language,
+                             sc_supertonic_chunk_fn on_chunk, void* user);
+
+/// Request cancellation of an in-flight synthesize() (callable from another thread).
+void sc_supertonic_cancel(sc_supertonic_t synth);
+
+/// Last error for `synth`, or the last creation error if `synth` is NULL. Never NULL.
+const char* sc_supertonic_last_error(sc_supertonic_t synth);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SPEECH_CORE_SUPERTONIC_C_H

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -25,17 +25,19 @@ int graph_latent_frames() {
     return 64;
 }
 
-// Parse a flat JSON number array at s[i] (i must point at '[').
+// Parse a JSON number array at s[i] (i must point at '['), FLATTENING any nesting — voice-style
+// `data` is stored as a nested array matching `dims` (e.g. [1][50][256]), not a flat list.
 std::vector<float> parse_float_array(const std::string& s, size_t& i) {
     std::vector<float> out;
     json::skip_ws(s, i);
     if (i >= s.size() || s[i] != '[') return out;
-    ++i;
+    int depth = 0;
     while (i < s.size()) {
-        json::skip_ws(s, i);
-        if (s[i] == ']') { ++i; break; }
-        if (s[i] == ',') { ++i; continue; }
-        const std::string v = json::parse_value_raw(s, i);
+        const char c = s[i];
+        if (c == '[') { ++depth; ++i; continue; }
+        if (c == ']') { --depth; ++i; if (depth == 0) break; continue; }
+        if (c == ',' || c == ' ' || c == '\t' || c == '\n' || c == '\r') { ++i; continue; }
+        const std::string v = json::parse_value_raw(s, i);  // one number; i advances to the delimiter
         if (!v.empty()) out.push_back(std::strtof(v.c_str(), nullptr));
     }
     return out;
@@ -220,11 +222,14 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
     LiteRtHostBuffer in_ttl (env, t_ttl,  voice.style_ttl.size() * sizeof(float), voice.style_ttl.data());
     LiteRtHostBuffer in_dp  (env, t_dp,   voice.style_dp.size()  * sizeof(float), voice.style_dp.data());
 
-    // --- 1) duration_predictor (text_ids, style_dp, text_mask) → duration[1] ---
+    // --- 1) duration_predictor → duration[1] ---
+    // LiteRtRunCompiledModel binds ins[] by the graph's tensor-INDEX order, which the ai_edge_torch
+    // export permutes away from the (args_0=ids, args_1=style_dp, args_2=text_mask) declaration.
+    // Introspected order of the published duration_predictor.tflite: [text_mask, text_ids, style_dp].
     float duration = 0.0f;
     {
         LiteRtHostBuffer out(env, t_dur, sizeof(float));
-        LiteRtTensorBuffer ins[3]  = { in_ids.raw(), in_dp.raw(), in_mask.raw() };
+        LiteRtTensorBuffer ins[3]  = { in_mask.raw(), in_ids.raw(), in_dp.raw() };
         LiteRtTensorBuffer outs[1] = { out.raw() };
         litert_check(LiteRtRunCompiledModel(duration_compiled_, 0, 3, ins, 1, outs),
                      "duration_predictor Run");
@@ -233,11 +238,12 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
     duration /= speed_;
     if (!(duration > 0.0f) || std::isnan(duration)) return {};
 
-    // --- 2) text_encoder (text_ids, style_ttl, text_mask) → text_emb[1,256,T] ---
+    // --- 2) text_encoder → text_emb[1,256,T] ---
+    // Introspected tensor-index order of text_encoder.tflite: [text_mask, text_ids, style_ttl].
     std::vector<float> text_emb(static_cast<size_t>(256) * kTextT);
     {
         LiteRtHostBuffer out(env, t_emb, text_emb.size() * sizeof(float));
-        LiteRtTensorBuffer ins[3]  = { in_ids.raw(), in_ttl.raw(), in_mask.raw() };
+        LiteRtTensorBuffer ins[3]  = { in_mask.raw(), in_ids.raw(), in_ttl.raw() };
         LiteRtTensorBuffer outs[1] = { out.raw() };
         litert_check(LiteRtRunCompiledModel(encoder_compiled_, 0, 3, ins, 1, outs),
                      "text_encoder Run");
@@ -288,9 +294,10 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
         LiteRtHostBuffer in_tot  (env, t_step, sizeof(float), &total_step_f);
         LiteRtHostBuffer out     (env, t_lat,  xt.size() * sizeof(float));
 
-        // export order: noisy, text_emb, style_ttl, latent_mask, text_mask, current_step, total_step
-        LiteRtTensorBuffer ins[7]  = { in_noisy.raw(), in_emb.raw(), in_ttl.raw(),
-                                       in_lmask.raw(), in_mask.raw(), in_cur.raw(), in_tot.raw() };
+        // Introspected tensor-index order of vector_estimator.tflite:
+        // [current_step, style_ttl, latent_mask, noisy, total_step, text_mask, text_emb].
+        LiteRtTensorBuffer ins[7]  = { in_cur.raw(), in_ttl.raw(), in_lmask.raw(),
+                                       in_noisy.raw(), in_tot.raw(), in_mask.raw(), in_emb.raw() };
         LiteRtTensorBuffer outs[1] = { out.raw() };
         litert_check(LiteRtRunCompiledModel(vector_compiled_, 0, 7, ins, 1, outs),
                      "vector_estimator Run");

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -95,39 +95,50 @@ LiteRTSupertonicTts::LiteRTSupertonicTts(const std::string& duration_path,
                                          const std::string& tokenizer_dir,
                                          const std::string& voice_styles_dir,
                                          bool hw_accel) {
-    auto& engine = LiteRTEngine::get();
-    engine.load(duration_path,         hw_accel, &duration_model_, &duration_compiled_);
-    engine.load(text_encoder_path,     hw_accel, &encoder_model_,  &encoder_compiled_);
-    engine.load(vector_estimator_path, hw_accel, &vector_model_,   &vector_compiled_);
-    engine.load(vocoder_path,          hw_accel, &vocoder_model_,  &vocoder_compiled_);
+    // The four LiteRt handles are raw (no per-member RAII), so a throw partway through loading would
+    // leak the already-acquired graphs (a partially-constructed object never runs the dtor). Guard
+    // the whole construction and release on failure.
+    try {
+        auto& engine = LiteRTEngine::get();
+        engine.load(duration_path,         hw_accel, &duration_model_, &duration_compiled_);
+        engine.load(text_encoder_path,     hw_accel, &encoder_model_,  &encoder_compiled_);
+        engine.load(vector_estimator_path, hw_accel, &vector_model_,   &vector_compiled_);
+        engine.load(vocoder_path,          hw_accel, &vocoder_model_,  &vocoder_compiled_);
 
-    namespace fs = std::filesystem;
-    tokenizer_ = std::make_unique<SupertonicTokenizer>(
-        (fs::path(tokenizer_dir) / "unicode_indexer.json").string(),
-        (fs::path(tokenizer_dir) / "tts.json").string());
+        namespace fs = std::filesystem;
+        tokenizer_ = std::make_unique<SupertonicTokenizer>(
+            (fs::path(tokenizer_dir) / "unicode_indexer.json").string(),
+            (fs::path(tokenizer_dir) / "tts.json").string());
 
-    for (const auto& entry : fs::directory_iterator(voice_styles_dir)) {
-        if (entry.path().extension() != ".json") continue;
-        VoiceStyle v;
-        load_style(entry.path().string(), v.style_ttl, v.style_dp);
-        if (v.style_ttl.size() != kStyleTtlFloats || v.style_dp.size() != kStyleDpFloats) continue;
-        voices_.emplace(entry.path().stem().string(), std::move(v));
+        for (const auto& entry : fs::directory_iterator(voice_styles_dir)) {
+            if (entry.path().extension() != ".json") continue;
+            VoiceStyle v;
+            load_style(entry.path().string(), v.style_ttl, v.style_dp);
+            if (v.style_ttl.size() != kStyleTtlFloats || v.style_dp.size() != kStyleDpFloats) continue;
+            voices_.emplace(entry.path().stem().string(), std::move(v));
+        }
+        if (voices_.empty())
+            throw std::runtime_error("Supertonic: no voice styles in " + voice_styles_dir);
+        if (!voices_.count(voice_id_)) voice_id_ = voices_.begin()->first;
+    } catch (...) {
+        destroy_graphs();  // release any LiteRt handles acquired before the failure, then rethrow
+        throw;
     }
-    if (voices_.empty())
-        throw std::runtime_error("Supertonic: no voice styles in " + voice_styles_dir);
-    if (!voices_.count(voice_id_)) voice_id_ = voices_.begin()->first;
 }
 
-LiteRTSupertonicTts::~LiteRTSupertonicTts() {
-    // Free compiled before model (litert_engine.h contract).
-    if (vocoder_compiled_)  LiteRtDestroyCompiledModel(vocoder_compiled_);
-    if (vocoder_model_)     LiteRtDestroyModel(vocoder_model_);
-    if (vector_compiled_)   LiteRtDestroyCompiledModel(vector_compiled_);
-    if (vector_model_)      LiteRtDestroyModel(vector_model_);
-    if (encoder_compiled_)  LiteRtDestroyCompiledModel(encoder_compiled_);
-    if (encoder_model_)     LiteRtDestroyModel(encoder_model_);
-    if (duration_compiled_) LiteRtDestroyCompiledModel(duration_compiled_);
-    if (duration_model_)    LiteRtDestroyModel(duration_model_);
+LiteRTSupertonicTts::~LiteRTSupertonicTts() { destroy_graphs(); }
+
+// Free compiled-before-model (litert_engine.h contract); idempotent + nulls each handle so the ctor
+// can call it on failure without risking a double-free.
+void LiteRTSupertonicTts::destroy_graphs() noexcept {
+    if (vocoder_compiled_)  { LiteRtDestroyCompiledModel(vocoder_compiled_);  vocoder_compiled_  = nullptr; }
+    if (vocoder_model_)     { LiteRtDestroyModel(vocoder_model_);             vocoder_model_     = nullptr; }
+    if (vector_compiled_)   { LiteRtDestroyCompiledModel(vector_compiled_);   vector_compiled_   = nullptr; }
+    if (vector_model_)      { LiteRtDestroyModel(vector_model_);              vector_model_      = nullptr; }
+    if (encoder_compiled_)  { LiteRtDestroyCompiledModel(encoder_compiled_);  encoder_compiled_  = nullptr; }
+    if (encoder_model_)     { LiteRtDestroyModel(encoder_model_);             encoder_model_     = nullptr; }
+    if (duration_compiled_) { LiteRtDestroyCompiledModel(duration_compiled_); duration_compiled_ = nullptr; }
+    if (duration_model_)    { LiteRtDestroyModel(duration_model_);            duration_model_    = nullptr; }
 }
 
 void LiteRTSupertonicTts::cancel() { cancelled_.store(true); }
@@ -162,12 +173,18 @@ void LiteRTSupertonicTts::synthesize(const std::string& text,
         seed_used_ = rd();
     }
 
-    const std::vector<std::string> chunks = tokenizer_->chunk(text, language);
+    // Keep each chunk's predicted audio within the fixed latent window (L frames). The chars/sec is a
+    // conservative heuristic — only needed for the fixed-shape bundle; the dynamic-L re-export removes
+    // it. Any residual overflow is logged + trimmed in synth_chunk().
+    const double window_s = static_cast<double>(graph_latent_frames()) * kChunkSamples / kSampleRate;
+    const bool cjk = (language == "ko" || language == "ja");
+    const int dur_cap = std::max(8, static_cast<int>(window_s * (cjk ? 6 : 14) * 0.9));
+    const std::vector<std::string> chunks = tokenizer_->chunk(text, language, dur_cap);
     const int silence = static_cast<int>(chunk_silence_s_ * kSampleRate);
 
     for (size_t ci = 0; ci < chunks.size(); ++ci) {
         if (cancelled_.load()) return;
-        std::vector<float> pcm = synth_chunk(chunks[ci], language);
+        std::vector<float> pcm = synth_chunk(chunks[ci], language, ci);
         const bool is_final = (ci + 1 == chunks.size());
 
         if (ci > 0 && silence > 0) {
@@ -179,21 +196,26 @@ void LiteRTSupertonicTts::synthesize(const std::string& text,
 }
 
 std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
-                                                    const std::string& language) {
+                                                    const std::string& language,
+                                                    size_t chunk_index) {
     LiteRtEnvironment env = LiteRTEngine::get().env();
     const VoiceStyle& voice = current_voice();
 
     // --- tokenize → fixed-T ids + mask ---
     const SupertonicTokenizer::Tokens tok = tokenizer_->process(chunk, language, kTextT);
 
-    const LiteRtRankedTensorType t_ids   = make_type(kLiteRtElementTypeInt32,   {1, kTextT});
+    // The exported LiteRT graphs take text_ids as INT64 (ai_edge_torch traces ids with torch.long;
+    // the CoreML export is int32 via a wrapper, but LiteRT stays int64 — confirmed against the
+    // published .tflite signatures). Widen the i32 tokenizer ids into an i64 input buffer.
+    const std::vector<int64_t> ids64(tok.ids.begin(), tok.ids.end());
+    const LiteRtRankedTensorType t_ids   = make_type(kLiteRtElementTypeInt64,   {1, kTextT});
     const LiteRtRankedTensorType t_mask  = make_type(kLiteRtElementTypeFloat32, {1, 1, kTextT});
     const LiteRtRankedTensorType t_ttl   = make_type(kLiteRtElementTypeFloat32, {1, 50, 256});
     const LiteRtRankedTensorType t_dp    = make_type(kLiteRtElementTypeFloat32, {1, 8, 16});
     const LiteRtRankedTensorType t_emb   = make_type(kLiteRtElementTypeFloat32, {1, 256, kTextT});
     const LiteRtRankedTensorType t_dur   = make_type(kLiteRtElementTypeFloat32, {1});
 
-    LiteRtHostBuffer in_ids (env, t_ids,  tok.ids.size()  * sizeof(int32_t), tok.ids.data());
+    LiteRtHostBuffer in_ids (env, t_ids,  ids64.size() * sizeof(int64_t), ids64.data());
     LiteRtHostBuffer in_mask(env, t_mask, tok.mask.size() * sizeof(float),   tok.mask.data());
     LiteRtHostBuffer in_ttl (env, t_ttl,  voice.style_ttl.size() * sizeof(float), voice.style_ttl.data());
     LiteRtHostBuffer in_dp  (env, t_dp,   voice.style_dp.size()  * sizeof(float), voice.style_dp.data());
@@ -222,18 +244,26 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
         out.read(text_emb.data(), text_emb.size() * sizeof(float));
     }
 
-    // --- latent geometry: L_true = ceil(dur*SR / 3072); graph runs at fixed L ---
+    // --- latent geometry: L_true = ceil(int(dur*SR) / 3072); graph runs at fixed L ---
     const int chunk_size = kChunkSamples;  // 512 * 6 = 3072
-    const int L_true = static_cast<int>(std::ceil(duration * kSampleRate / chunk_size));
+    // Match the reference (infer.py): truncate dur*SR to integer samples BEFORE the ceil.
+    const long long wav_len = static_cast<long long>(duration * kSampleRate);
+    const int L_true = static_cast<int>((wav_len + chunk_size - 1) / chunk_size);
     const int L      = graph_latent_frames();
     const int L_fill = std::min(std::max(L_true, 1), L);  // valid frames inside the fixed window
+    if (L_true > L) {
+        LOGE("Supertonic: chunk needs L=%d frames > fixed graph L=%d; audio truncated to %.2fs "
+             "(re-export with dynamic L, or shorten the chunk).",
+             L_true, L, static_cast<double>(chunk_size) * L / kSampleRate);
+    }
 
     // latent_mask[1,1,L]: 1.0 for the first L_fill frames, else 0.
     std::vector<float> latent_mask(static_cast<size_t>(L), 0.0f);
     for (int t = 0; t < L_fill; ++t) latent_mask[t] = 1.0f;
 
-    // noisy[1,144,L] = randn * latent_mask (row-major c*L + t).
-    std::mt19937 rng(seed_used_ + 0x9E3779B9u);  // decorrelate chunks via the golden ratio
+    // noisy[1,144,L] = randn * latent_mask (row-major c*L + t). Mix the chunk index into the seed so
+    // multi-chunk utterances draw distinct noise per chunk (the reference advances one shared RNG).
+    std::mt19937 rng(seed_used_ + 0x9E3779B9u * static_cast<uint32_t>(chunk_index + 1));
     std::normal_distribution<float> nd(0.0f, 1.0f);
     std::vector<float> xt(static_cast<size_t>(kLatentChannels) * L);
     for (int c = 0; c < kLatentChannels; ++c)

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -1,0 +1,291 @@
+#include "speech_core/models/litert_supertonic_tts.h"
+
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <stdexcept>
+
+namespace speech_core {
+namespace {
+
+// Exported fixed latent length (frames) of the vector_estimator / vocoder graphs. The published
+// LiteRT bundle is fixed-shape (T=128, L=64); a dynamic-L export is the stated follow-up. Override
+// at bring-up via SUPERTONIC_LATENT_FRAMES while validating against a re-exported graph.
+int graph_latent_frames() {
+    if (const char* e = std::getenv("SUPERTONIC_LATENT_FRAMES")) {
+        int v = std::atoi(e);
+        if (v > 0) return v;
+    }
+    return 64;
+}
+
+// Parse a flat JSON number array at s[i] (i must point at '[').
+std::vector<float> parse_float_array(const std::string& s, size_t& i) {
+    std::vector<float> out;
+    json::skip_ws(s, i);
+    if (i >= s.size() || s[i] != '[') return out;
+    ++i;
+    while (i < s.size()) {
+        json::skip_ws(s, i);
+        if (s[i] == ']') { ++i; break; }
+        if (s[i] == ',') { ++i; continue; }
+        const std::string v = json::parse_value_raw(s, i);
+        if (!v.empty()) out.push_back(std::strtof(v.c_str(), nullptr));
+    }
+    return out;
+}
+
+// Extract the "data" array from the top-level object value `key` (e.g. "style_ttl" → {dims,data}).
+// util/json.h has no nested navigation, so walk by hand with its primitives.
+std::vector<float> extract_style(const std::string& text, const std::string& key) {
+    size_t i = 0;
+    json::skip_ws(text, i);
+    if (i >= text.size() || text[i] != '{') return {};
+    ++i;
+    while (i < text.size()) {
+        json::skip_ws(text, i);
+        if (text[i] == '}') break;
+        if (text[i] == ',') { ++i; continue; }
+        const std::string k = json::parse_string(text, i);
+        json::skip_ws(text, i);
+        if (i < text.size() && text[i] == ':') ++i;
+        json::skip_ws(text, i);
+        if (k == key && i < text.size() && text[i] == '{') {
+            ++i;  // enter the {dims,data} object
+            while (i < text.size()) {
+                json::skip_ws(text, i);
+                if (text[i] == '}') { ++i; break; }
+                if (text[i] == ',') { ++i; continue; }
+                const std::string kk = json::parse_string(text, i);
+                json::skip_ws(text, i);
+                if (i < text.size() && text[i] == ':') ++i;
+                json::skip_ws(text, i);
+                if (kk == "data" && i < text.size() && text[i] == '[')
+                    return parse_float_array(text, i);
+                json::skip_value(text, i);
+            }
+            return {};
+        }
+        json::skip_value(text, i);
+    }
+    return {};
+}
+
+// Load one voice style file (helper.py::load_voice_style format): {"style_ttl":{"dims","data"},
+// "style_dp":{"dims","data"}} → flat row-major float vectors.
+void load_style(const std::string& path, std::vector<float>& ttl, std::vector<float>& dp) {
+    const std::string text = json::read_file(path);
+    if (text.empty()) throw std::runtime_error("Supertonic: cannot read voice style " + path);
+    ttl = extract_style(text, "style_ttl");
+    dp  = extract_style(text, "style_dp");
+}
+
+}  // namespace
+
+LiteRTSupertonicTts::LiteRTSupertonicTts(const std::string& duration_path,
+                                         const std::string& text_encoder_path,
+                                         const std::string& vector_estimator_path,
+                                         const std::string& vocoder_path,
+                                         const std::string& tokenizer_dir,
+                                         const std::string& voice_styles_dir,
+                                         bool hw_accel) {
+    auto& engine = LiteRTEngine::get();
+    engine.load(duration_path,         hw_accel, &duration_model_, &duration_compiled_);
+    engine.load(text_encoder_path,     hw_accel, &encoder_model_,  &encoder_compiled_);
+    engine.load(vector_estimator_path, hw_accel, &vector_model_,   &vector_compiled_);
+    engine.load(vocoder_path,          hw_accel, &vocoder_model_,  &vocoder_compiled_);
+
+    namespace fs = std::filesystem;
+    tokenizer_ = std::make_unique<SupertonicTokenizer>(
+        (fs::path(tokenizer_dir) / "unicode_indexer.json").string(),
+        (fs::path(tokenizer_dir) / "tts.json").string());
+
+    for (const auto& entry : fs::directory_iterator(voice_styles_dir)) {
+        if (entry.path().extension() != ".json") continue;
+        VoiceStyle v;
+        load_style(entry.path().string(), v.style_ttl, v.style_dp);
+        if (v.style_ttl.size() != kStyleTtlFloats || v.style_dp.size() != kStyleDpFloats) continue;
+        voices_.emplace(entry.path().stem().string(), std::move(v));
+    }
+    if (voices_.empty())
+        throw std::runtime_error("Supertonic: no voice styles in " + voice_styles_dir);
+    if (!voices_.count(voice_id_)) voice_id_ = voices_.begin()->first;
+}
+
+LiteRTSupertonicTts::~LiteRTSupertonicTts() {
+    // Free compiled before model (litert_engine.h contract).
+    if (vocoder_compiled_)  LiteRtDestroyCompiledModel(vocoder_compiled_);
+    if (vocoder_model_)     LiteRtDestroyModel(vocoder_model_);
+    if (vector_compiled_)   LiteRtDestroyCompiledModel(vector_compiled_);
+    if (vector_model_)      LiteRtDestroyModel(vector_model_);
+    if (encoder_compiled_)  LiteRtDestroyCompiledModel(encoder_compiled_);
+    if (encoder_model_)     LiteRtDestroyModel(encoder_model_);
+    if (duration_compiled_) LiteRtDestroyCompiledModel(duration_compiled_);
+    if (duration_model_)    LiteRtDestroyModel(duration_model_);
+}
+
+void LiteRTSupertonicTts::cancel() { cancelled_.store(true); }
+
+void LiteRTSupertonicTts::set_voice(const std::string& voice_id) {
+    if (!voices_.count(voice_id))
+        throw std::invalid_argument("Supertonic: unknown voice '" + voice_id + "'");
+    voice_id_ = voice_id;
+}
+
+std::vector<std::string> LiteRTSupertonicTts::voices() const {
+    std::vector<std::string> ids;
+    ids.reserve(voices_.size());
+    for (const auto& kv : voices_) ids.push_back(kv.first);
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+const LiteRTSupertonicTts::VoiceStyle& LiteRTSupertonicTts::current_voice() const {
+    auto it = voices_.find(voice_id_);
+    if (it == voices_.end()) throw std::runtime_error("Supertonic: voice not loaded");
+    return it->second;
+}
+
+void LiteRTSupertonicTts::synthesize(const std::string& text,
+                                     const std::string& language,
+                                     TTSChunkCallback on_chunk) {
+    cancelled_.store(false);
+    seed_used_ = seed_;
+    if (seed_used_ == 0) {
+        std::random_device rd;
+        seed_used_ = rd();
+    }
+
+    const std::vector<std::string> chunks = tokenizer_->chunk(text, language);
+    const int silence = static_cast<int>(chunk_silence_s_ * kSampleRate);
+
+    for (size_t ci = 0; ci < chunks.size(); ++ci) {
+        if (cancelled_.load()) return;
+        std::vector<float> pcm = synth_chunk(chunks[ci], language);
+        const bool is_final = (ci + 1 == chunks.size());
+
+        if (ci > 0 && silence > 0) {
+            std::vector<float> sil(static_cast<size_t>(silence), 0.0f);
+            on_chunk(sil.data(), sil.size(), false);
+        }
+        on_chunk(pcm.data(), pcm.size(), is_final);
+    }
+}
+
+std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
+                                                    const std::string& language) {
+    LiteRtEnvironment env = LiteRTEngine::get().env();
+    const VoiceStyle& voice = current_voice();
+
+    // --- tokenize → fixed-T ids + mask ---
+    const SupertonicTokenizer::Tokens tok = tokenizer_->process(chunk, language, kTextT);
+
+    const LiteRtRankedTensorType t_ids   = make_type(kLiteRtElementTypeInt32,   {1, kTextT});
+    const LiteRtRankedTensorType t_mask  = make_type(kLiteRtElementTypeFloat32, {1, 1, kTextT});
+    const LiteRtRankedTensorType t_ttl   = make_type(kLiteRtElementTypeFloat32, {1, 50, 256});
+    const LiteRtRankedTensorType t_dp    = make_type(kLiteRtElementTypeFloat32, {1, 8, 16});
+    const LiteRtRankedTensorType t_emb   = make_type(kLiteRtElementTypeFloat32, {1, 256, kTextT});
+    const LiteRtRankedTensorType t_dur   = make_type(kLiteRtElementTypeFloat32, {1});
+
+    LiteRtHostBuffer in_ids (env, t_ids,  tok.ids.size()  * sizeof(int32_t), tok.ids.data());
+    LiteRtHostBuffer in_mask(env, t_mask, tok.mask.size() * sizeof(float),   tok.mask.data());
+    LiteRtHostBuffer in_ttl (env, t_ttl,  voice.style_ttl.size() * sizeof(float), voice.style_ttl.data());
+    LiteRtHostBuffer in_dp  (env, t_dp,   voice.style_dp.size()  * sizeof(float), voice.style_dp.data());
+
+    // --- 1) duration_predictor (text_ids, style_dp, text_mask) → duration[1] ---
+    float duration = 0.0f;
+    {
+        LiteRtHostBuffer out(env, t_dur, sizeof(float));
+        LiteRtTensorBuffer ins[3]  = { in_ids.raw(), in_dp.raw(), in_mask.raw() };
+        LiteRtTensorBuffer outs[1] = { out.raw() };
+        litert_check(LiteRtRunCompiledModel(duration_compiled_, 0, 3, ins, 1, outs),
+                     "duration_predictor Run");
+        out.read(&duration, sizeof(float));
+    }
+    duration /= speed_;
+    if (!(duration > 0.0f) || std::isnan(duration)) return {};
+
+    // --- 2) text_encoder (text_ids, style_ttl, text_mask) → text_emb[1,256,T] ---
+    std::vector<float> text_emb(static_cast<size_t>(256) * kTextT);
+    {
+        LiteRtHostBuffer out(env, t_emb, text_emb.size() * sizeof(float));
+        LiteRtTensorBuffer ins[3]  = { in_ids.raw(), in_ttl.raw(), in_mask.raw() };
+        LiteRtTensorBuffer outs[1] = { out.raw() };
+        litert_check(LiteRtRunCompiledModel(encoder_compiled_, 0, 3, ins, 1, outs),
+                     "text_encoder Run");
+        out.read(text_emb.data(), text_emb.size() * sizeof(float));
+    }
+
+    // --- latent geometry: L_true = ceil(dur*SR / 3072); graph runs at fixed L ---
+    const int chunk_size = kChunkSamples;  // 512 * 6 = 3072
+    const int L_true = static_cast<int>(std::ceil(duration * kSampleRate / chunk_size));
+    const int L      = graph_latent_frames();
+    const int L_fill = std::min(std::max(L_true, 1), L);  // valid frames inside the fixed window
+
+    // latent_mask[1,1,L]: 1.0 for the first L_fill frames, else 0.
+    std::vector<float> latent_mask(static_cast<size_t>(L), 0.0f);
+    for (int t = 0; t < L_fill; ++t) latent_mask[t] = 1.0f;
+
+    // noisy[1,144,L] = randn * latent_mask (row-major c*L + t).
+    std::mt19937 rng(seed_used_ + 0x9E3779B9u);  // decorrelate chunks via the golden ratio
+    std::normal_distribution<float> nd(0.0f, 1.0f);
+    std::vector<float> xt(static_cast<size_t>(kLatentChannels) * L);
+    for (int c = 0; c < kLatentChannels; ++c)
+        for (int t = 0; t < L; ++t)
+            xt[static_cast<size_t>(c) * L + t] = nd(rng) * latent_mask[t];
+
+    const LiteRtRankedTensorType t_lat  = make_type(kLiteRtElementTypeFloat32, {1, kLatentChannels, L});
+    const LiteRtRankedTensorType t_lmsk = make_type(kLiteRtElementTypeFloat32, {1, 1, L});
+    const LiteRtRankedTensorType t_step = make_type(kLiteRtElementTypeFloat32, {1});
+
+    LiteRtHostBuffer in_lmask(env, t_lmsk, latent_mask.size() * sizeof(float), latent_mask.data());
+
+    // --- 3) vector_estimator × total_step (flow-matching ODE; xt fed forward) ---
+    const float total_step_f = static_cast<float>(total_step_);
+    for (int step = 0; step < total_step_; ++step) {
+        if (cancelled_.load()) return {};
+        const float cur_step_f = static_cast<float>(step);
+
+        LiteRtHostBuffer in_noisy(env, t_lat,  xt.size() * sizeof(float), xt.data());
+        LiteRtHostBuffer in_emb  (env, t_emb,  text_emb.size() * sizeof(float), text_emb.data());
+        LiteRtHostBuffer in_cur  (env, t_step, sizeof(float), &cur_step_f);
+        LiteRtHostBuffer in_tot  (env, t_step, sizeof(float), &total_step_f);
+        LiteRtHostBuffer out     (env, t_lat,  xt.size() * sizeof(float));
+
+        // export order: noisy, text_emb, style_ttl, latent_mask, text_mask, current_step, total_step
+        LiteRtTensorBuffer ins[7]  = { in_noisy.raw(), in_emb.raw(), in_ttl.raw(),
+                                       in_lmask.raw(), in_mask.raw(), in_cur.raw(), in_tot.raw() };
+        LiteRtTensorBuffer outs[1] = { out.raw() };
+        litert_check(LiteRtRunCompiledModel(vector_compiled_, 0, 7, ins, 1, outs),
+                     "vector_estimator Run");
+        out.read(xt.data(), xt.size() * sizeof(float));
+    }
+
+    // --- 4) vocoder (latent[1,144,L]) → wav[1, 3072*L] ---
+    std::vector<float> wav(static_cast<size_t>(chunk_size) * L);
+    {
+        LiteRtHostBuffer in_latent(env, t_lat, xt.size() * sizeof(float), xt.data());
+        const LiteRtRankedTensorType t_wav =
+            make_type(kLiteRtElementTypeFloat32, {1, chunk_size * L});
+        LiteRtHostBuffer out(env, t_wav, wav.size() * sizeof(float));
+        LiteRtTensorBuffer ins[1]  = { in_latent.raw() };
+        LiteRtTensorBuffer outs[1] = { out.raw() };
+        litert_check(LiteRtRunCompiledModel(vocoder_compiled_, 0, 1, ins, 1, outs), "vocoder Run");
+        out.read(wav.data(), wav.size() * sizeof(float));
+    }
+
+    // --- trim to floor(SR*dur), bounded by the valid latent window and the buffer ---
+    size_t n = static_cast<size_t>(std::floor(kSampleRate * duration));
+    n = std::min(n, static_cast<size_t>(chunk_size) * L_fill);
+    n = std::min(n, wav.size());
+    wav.resize(n);
+    return wav;
+}
+
+}  // namespace speech_core

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -15,8 +15,11 @@ namespace speech_core {
 namespace {
 
 // Exported fixed latent length (frames) of the vector_estimator / vocoder graphs. The published
-// LiteRT bundle is fixed-shape (T=128, L=64); a dynamic-L export is the stated follow-up. Override
-// at bring-up via SUPERTONIC_LATENT_FRAMES while validating against a re-exported graph.
+// LiteRT bundle is fixed-shape (T=128, L=64). A dynamic-L export is currently BLOCKED upstream:
+// litert_torch/odml_torch can't lower SupertonicTTS's relpos attention + ConvNeXt with a symbolic L
+// (see speech-models/stmodels/export_litert.py). The host instead caps chunk length to this window
+// (synthesize() below); longer chunks would need L-buckets or an upstream fix. SUPERTONIC_LATENT_FRAMES
+// overrides this only for experiments against a re-exported graph.
 int graph_latent_frames() {
     if (const char* e = std::getenv("SUPERTONIC_LATENT_FRAMES")) {
         int v = std::atoi(e);
@@ -176,8 +179,8 @@ void LiteRTSupertonicTts::synthesize(const std::string& text,
     }
 
     // Keep each chunk's predicted audio within the fixed latent window (L frames). The chars/sec is a
-    // conservative heuristic — only needed for the fixed-shape bundle; the dynamic-L re-export removes
-    // it. Any residual overflow is logged + trimmed in synth_chunk().
+    // conservative heuristic; because dynamic-L is blocked upstream (see graph_latent_frames()), this
+    // cap is the truncation guard. Any residual overflow is logged + trimmed in synth_chunk().
     const double window_s = static_cast<double>(graph_latent_frames()) * kChunkSamples / kSampleRate;
     const bool cjk = (language == "ko" || language == "ja");
     const int dur_cap = std::max(8, static_cast<int>(window_s * (cjk ? 6 : 14) * 0.9));
@@ -259,7 +262,7 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
     const int L_fill = std::min(std::max(L_true, 1), L);  // valid frames inside the fixed window
     if (L_true > L) {
         LOGE("Supertonic: chunk needs L=%d frames > fixed graph L=%d; audio truncated to %.2fs "
-             "(re-export with dynamic L, or shorten the chunk).",
+             "(shorten the chunk; dynamic L is blocked upstream).",
              L_true, L, static_cast<double>(chunk_size) * L / kSampleRate);
     }
 

--- a/src/models/litert/supertonic_c.cpp
+++ b/src/models/litert/supertonic_c.cpp
@@ -1,0 +1,114 @@
+#include "speech_core/supertonic_c.h"
+
+#include "speech_core/models/litert_supertonic_tts.h"
+
+#include <filesystem>
+#include <new>
+#include <string>
+
+using speech_core::LiteRTSupertonicTts;
+
+struct sc_supertonic_s {
+    LiteRTSupertonicTts engine;
+    std::string         last_error;
+
+    sc_supertonic_s(const std::string& dur, const std::string& enc, const std::string& vec,
+                    const std::string& voc, const std::string& tok, const std::string& vs,
+                    bool hw_accel)
+        : engine(dur, enc, vec, voc, tok, vs, hw_accel) {}
+};
+
+namespace {
+// Process-wide last-creation-error, returned when the caller passes a NULL handle.
+std::string& creation_error() {
+    static std::string err;
+    return err;
+}
+}  // namespace
+
+extern "C" {
+
+sc_supertonic_t sc_supertonic_create_from_paths(const char* duration_path,
+                                                const char* text_encoder_path,
+                                                const char* vector_estimator_path,
+                                                const char* vocoder_path,
+                                                const char* tokenizer_dir,
+                                                const char* voice_styles_dir,
+                                                bool hw_accel) {
+    try {
+        return new sc_supertonic_s(duration_path, text_encoder_path, vector_estimator_path,
+                                   vocoder_path, tokenizer_dir, voice_styles_dir, hw_accel);
+    } catch (const std::exception& e) {
+        creation_error() = e.what();
+        return nullptr;
+    } catch (...) {
+        creation_error() = "unknown error";
+        return nullptr;
+    }
+}
+
+sc_supertonic_t sc_supertonic_create(const char* bundle_dir) {
+    namespace fs = std::filesystem;
+    const fs::path b(bundle_dir ? bundle_dir : "");
+    const std::string vs = (b / "voice_styles").string();
+    return sc_supertonic_create_from_paths(
+        (b / "duration_predictor.tflite").string().c_str(),
+        (b / "text_encoder.tflite").string().c_str(),
+        (b / "vector_estimator.tflite").string().c_str(),
+        (b / "vocoder.tflite").string().c_str(),
+        b.string().c_str(),
+        vs.c_str(),
+        false);
+}
+
+void sc_supertonic_destroy(sc_supertonic_t synth) { delete synth; }
+
+void sc_supertonic_set_voice(sc_supertonic_t synth, const char* voice_id) {
+    if (!synth || !voice_id) return;
+    try { synth->engine.set_voice(voice_id); }
+    catch (const std::exception& e) { synth->last_error = e.what(); }
+}
+
+void sc_supertonic_set_total_step(sc_supertonic_t synth, int total_step) {
+    if (synth) synth->engine.set_total_step(total_step);
+}
+
+void sc_supertonic_set_speed(sc_supertonic_t synth, float speed) {
+    if (synth) synth->engine.set_speed(speed);
+}
+
+void sc_supertonic_set_seed(sc_supertonic_t synth, uint32_t seed) {
+    if (synth) synth->engine.set_seed(seed);
+}
+
+int sc_supertonic_output_sample_rate(sc_supertonic_t synth) {
+    return synth ? synth->engine.output_sample_rate() : 0;
+}
+
+int sc_supertonic_synthesize(sc_supertonic_t synth, const char* text, const char* language,
+                             sc_supertonic_chunk_fn on_chunk, void* user) {
+    if (!synth || !text || !language || !on_chunk) return 1;
+    try {
+        synth->engine.synthesize(text, language,
+            [on_chunk, user](const float* samples, size_t length, bool is_final) {
+                on_chunk(samples, length, is_final, user);
+            });
+        return 0;
+    } catch (const std::exception& e) {
+        synth->last_error = e.what();
+        return 2;
+    } catch (...) {
+        synth->last_error = "unknown error";
+        return 2;
+    }
+}
+
+void sc_supertonic_cancel(sc_supertonic_t synth) {
+    if (synth) synth->engine.cancel();
+}
+
+const char* sc_supertonic_last_error(sc_supertonic_t synth) {
+    return synth ? synth->last_error.c_str() : creation_error().c_str();
+}
+
+}  // extern "C"

--- a/src/models/litert/supertonic_tokenizer.cpp
+++ b/src/models/litert/supertonic_tokenizer.cpp
@@ -255,10 +255,11 @@ SupertonicTokenizer::process(const std::string& text, const std::string& lang, i
 }
 
 std::vector<std::string>
-SupertonicTokenizer::chunk(const std::string& text, const std::string& lang) const {
+SupertonicTokenizer::chunk(const std::string& text, const std::string& lang, int max_codepoints) const {
     // Cap so the wrapped, tokenized form fits the exported fixed text length (max_text_tokens_).
     // tag overhead = len("<lang>") + len("</lang>") = 2*lang + 5.
     int cap = max_text_tokens_ - (2 * static_cast<int>(lang.size()) + 5) - 1;
+    if (max_codepoints > 0 && max_codepoints < cap) cap = max_codepoints;  // fixed-window duration cap
     if (cap < 8) cap = 8;
 
     const std::vector<char32_t> cps = utf8_to_u32(text);

--- a/src/models/litert/supertonic_tokenizer.cpp
+++ b/src/models/litert/supertonic_tokenizer.cpp
@@ -1,0 +1,325 @@
+#include "speech_core/models/supertonic_tokenizer.h"
+
+#include "speech_core/util/json.h"
+
+#include <utf8proc.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace speech_core {
+namespace {
+
+// Authoritative AVAILABLE_LANGS from `supertonic/py/helper.py` / `stmodels/infer.py` — 32 entries.
+// Note: includes "na", **excludes "zh"** (Chinese rides "ja"/codepoints). The <lang> tag is fed
+// through the same codepoint tokenizer; there is no separate language tensor (tts.json: n_langs = 0).
+const std::unordered_set<std::string>& available_langs() {
+    static const std::unordered_set<std::string> kLangs = {
+        "en","ko","ja","ar","bg","cs","da","de","el","es",
+        "et","fi","fr","hi","hr","hu","id","it","lt","lv",
+        "nl","pl","pt","ro","ru","sk","sl","sv","tr","uk",
+        "vi","na",
+    };
+    return kLangs;
+}
+
+// ---- UTF-8 <-> UTF-32 (codepoint-level work; never byte length) ----
+std::vector<char32_t> utf8_to_u32(const std::string& s) {
+    std::vector<char32_t> out;
+    out.reserve(s.size());
+    size_t i = 0, n = s.size();
+    while (i < n) {
+        unsigned char c = static_cast<unsigned char>(s[i]);
+        char32_t cp; int len;
+        if      ((c & 0x80) == 0x00) { cp = c;        len = 1; }
+        else if ((c & 0xE0) == 0xC0) { cp = c & 0x1F; len = 2; }
+        else if ((c & 0xF0) == 0xE0) { cp = c & 0x0F; len = 3; }
+        else if ((c & 0xF8) == 0xF0) { cp = c & 0x07; len = 4; }
+        else { out.push_back(0xFFFD); ++i; continue; }
+        if (i + static_cast<size_t>(len) > n) { out.push_back(0xFFFD); break; }
+        bool ok = true;
+        for (int k = 1; k < len; ++k) {
+            unsigned char cc = static_cast<unsigned char>(s[i + k]);
+            if ((cc & 0xC0) != 0x80) { ok = false; break; }
+            cp = (cp << 6) | (cc & 0x3F);
+        }
+        if (!ok) { out.push_back(0xFFFD); ++i; continue; }
+        out.push_back(cp);
+        i += len;
+    }
+    return out;
+}
+
+void append_u32(std::string& s, char32_t cp) {
+    if (cp < 0x80) {
+        s.push_back(static_cast<char>(cp));
+    } else if (cp < 0x800) {
+        s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp < 0x10000) {
+        s.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+        s.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else {
+        s.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+        s.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        s.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+}
+
+std::string u32_to_utf8(const std::vector<char32_t>& v) {
+    std::string s;
+    s.reserve(v.size() * 2);
+    for (char32_t cp : v) append_u32(s, cp);
+    return s;
+}
+
+// NFKD via utf8proc (decompose + compatibility). The keystone of the G2P-free front-end.
+std::string nfkd(const std::string& s) {
+    utf8proc_uint8_t* out = nullptr;
+    utf8proc_ssize_t n = utf8proc_map(
+        reinterpret_cast<const utf8proc_uint8_t*>(s.data()),
+        static_cast<utf8proc_ssize_t>(s.size()), &out,
+        static_cast<utf8proc_option_t>(UTF8PROC_DECOMPOSE | UTF8PROC_COMPAT | UTF8PROC_STABLE));
+    if (n < 0 || !out) {
+        if (out) std::free(out);
+        return s;  // conservative fallback
+    }
+    std::string r(reinterpret_cast<char*>(out), static_cast<size_t>(n));
+    std::free(out);
+    return r;
+}
+
+bool is_emoji(char32_t c) {
+    return (c >= 0x1F600 && c <= 0x1F64F) || (c >= 0x1F300 && c <= 0x1F5FF) ||
+           (c >= 0x1F680 && c <= 0x1F6FF) || (c >= 0x1F700 && c <= 0x1F77F) ||
+           (c >= 0x1F780 && c <= 0x1F7FF) || (c >= 0x1F800 && c <= 0x1F8FF) ||
+           (c >= 0x1F900 && c <= 0x1F9FF) || (c >= 0x1FA00 && c <= 0x1FA6F) ||
+           (c >= 0x1FA70 && c <= 0x1FAFF) || (c >= 0x2600  && c <= 0x26FF)  ||
+           (c >= 0x2700  && c <= 0x27BF)  || (c >= 0x1F1E6 && c <= 0x1F1FF);
+}
+
+// helper.py::_char_repl + the `[♥☆♡©\\]` strip, on codepoints. `drop`==true → delete the char.
+char32_t char_repl(char32_t c, bool& drop) {
+    drop = false;
+    switch (c) {
+        case 0x2013: case 0x2011: case 0x2014: return '-';   // – ‑ —
+        case '_':                              return ' ';
+        case 0x201C: case 0x201D:              return '"';   // “ ”
+        case 0x2018: case 0x2019:              return '\'';  // ‘ ’
+        case 0x00B4: case '`':                 return '\'';  // ´ `
+        case '[': case ']': case '|': case '/': case '#': return ' ';
+        case 0x2192: case 0x2190:              return ' ';   // → ←
+        case 0x2665: case 0x2606: case 0x2661: case 0x00A9: case '\\':
+            drop = true; return 0;                            // ♥ ☆ ♡ © backslash
+        default: return c;
+    }
+}
+
+void replace_all(std::string& s, const std::string& from, const std::string& to) {
+    if (from.empty()) return;
+    size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos) {
+        s.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+}
+
+bool is_ws(char32_t c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+bool ends_with_terminal(const std::vector<char32_t>& v) {
+    if (v.empty()) return false;
+    // helper.py: [.!?;:,'"')\]}…。」』】〉》›»]$
+    static const std::u32string kTerm =
+        U".!?;:,'\")]}…。」』】〉》›»";
+    return kTerm.find(v.back()) != std::u32string::npos;
+}
+
+}  // namespace
+
+SupertonicTokenizer::SupertonicTokenizer(const std::string& unicode_indexer_path,
+                                         const std::string& /*tts_json_path*/) {
+    // unicode_indexer.json is a flat array of 65536 ints (codepoint → id, -1 if unsupported).
+    // speech-core's util/json.h has no array parser, so walk it with the primitives.
+    const std::string text = json::read_file(unicode_indexer_path);
+    if (text.empty())
+        throw std::runtime_error("Supertonic: cannot read " + unicode_indexer_path);
+    size_t i = 0;
+    json::skip_ws(text, i);
+    if (i >= text.size() || text[i] != '[')
+        throw std::runtime_error("Supertonic: unicode_indexer.json must be a flat JSON array");
+    ++i;
+    indexer_.reserve(65536);
+    while (i < text.size()) {
+        json::skip_ws(text, i);
+        if (text[i] == ']') { ++i; break; }
+        if (text[i] == ',') { ++i; continue; }
+        const std::string v = json::parse_value_raw(text, i);
+        if (!v.empty())
+            indexer_.push_back(static_cast<int32_t>(std::strtol(v.c_str(), nullptr, 10)));
+    }
+    if (indexer_.empty())
+        throw std::runtime_error("Supertonic: unicode_indexer.json parsed empty");
+}
+
+bool SupertonicTokenizer::supports(const std::string& lang) const {
+    return available_langs().count(lang) != 0;
+}
+
+int32_t SupertonicTokenizer::lookup(uint32_t cp) const {
+    if (cp < indexer_.size()) return indexer_[cp];
+    return kUnknownId;
+}
+
+std::string SupertonicTokenizer::preprocess(const std::string& text, const std::string& lang) const {
+    // 1) NFKD.
+    std::string s = nfkd(text);
+
+    // 2) emoji removal + char-level replacement/strip (codepoint pass).
+    {
+        std::vector<char32_t> in = utf8_to_u32(s);
+        std::vector<char32_t> out;
+        out.reserve(in.size());
+        for (char32_t c : in) {
+            if (is_emoji(c)) continue;
+            bool drop = false;
+            char32_t r = char_repl(c, drop);
+            if (drop) continue;
+            out.push_back(r);
+        }
+        s = u32_to_utf8(out);
+    }
+
+    // 3) expression replacements (helper.py::_expr_repl).
+    replace_all(s, "@", " at ");
+    replace_all(s, "e.g.,", "for example, ");
+    replace_all(s, "i.e.,", "that is, ");
+
+    // 4) drop a space before punctuation: " ," -> ",", " ." -> ".", ...
+    for (const char* p : {",", ".", "!", "?", ";", ":", "'"}) {
+        replace_all(s, std::string(" ") + p, p);
+    }
+
+    // 5) collapse repeated quotes.
+    while (s.find("\"\"") != std::string::npos) replace_all(s, "\"\"", "\"");
+    while (s.find("''")   != std::string::npos) replace_all(s, "''", "'");
+    while (s.find("``")   != std::string::npos) replace_all(s, "``", "`");
+
+    // 6) collapse whitespace + trim, then 7) ensure terminal punctuation.
+    {
+        std::vector<char32_t> in = utf8_to_u32(s);
+        std::vector<char32_t> out;
+        out.reserve(in.size());
+        bool prev_ws = false;
+        for (char32_t c : in) {
+            if (is_ws(c)) {
+                if (!prev_ws) out.push_back(' ');
+                prev_ws = true;
+            } else {
+                out.push_back(c);
+                prev_ws = false;
+            }
+        }
+        while (!out.empty() && out.front() == ' ') out.erase(out.begin());
+        while (!out.empty() && out.back() == ' ')  out.pop_back();
+        if (!ends_with_terminal(out)) out.push_back('.');
+        s = u32_to_utf8(out);
+    }
+
+    // 8) validate language + wrap.
+    if (!available_langs().count(lang))
+        throw std::invalid_argument("Supertonic: unsupported language '" + lang + "'");
+    return "<" + lang + ">" + s + "</" + lang + ">";
+}
+
+SupertonicTokenizer::Tokens
+SupertonicTokenizer::process(const std::string& text, const std::string& lang, int text_t) const {
+    const std::string wrapped = preprocess(text, lang);
+    const std::vector<char32_t> cps = utf8_to_u32(wrapped);
+
+    Tokens t;
+    t.ids.assign(static_cast<size_t>(text_t), 0);
+    t.mask.assign(static_cast<size_t>(text_t), 0.0f);
+    const int n = std::min<int>(static_cast<int>(cps.size()), text_t);
+    for (int i = 0; i < n; ++i) {
+        t.ids[i]  = lookup(static_cast<uint32_t>(cps[i]));
+        t.mask[i] = 1.0f;
+    }
+    return t;
+}
+
+std::vector<std::string>
+SupertonicTokenizer::chunk(const std::string& text, const std::string& lang) const {
+    // Cap so the wrapped, tokenized form fits the exported fixed text length (max_text_tokens_).
+    // tag overhead = len("<lang>") + len("</lang>") = 2*lang + 5.
+    int cap = max_text_tokens_ - (2 * static_cast<int>(lang.size()) + 5) - 1;
+    if (cap < 8) cap = 8;
+
+    const std::vector<char32_t> cps = utf8_to_u32(text);
+
+    // Sentence-ish split at terminal punctuation followed by whitespace (faithful subset of
+    // helper.py::_chunk_text; the abbreviation-guard regex there is a refinement — boundary
+    // differences only shift where the 0.3 s inter-chunk silence lands, not parity).
+    static const std::u32string kTerm = U".!?…。！？";
+    std::vector<std::vector<char32_t>> sentences;
+    std::vector<char32_t> cur;
+    for (size_t i = 0; i < cps.size(); ++i) {
+        cur.push_back(cps[i]);
+        const bool term    = kTerm.find(cps[i]) != std::u32string::npos;
+        const bool nextws  = (i + 1 < cps.size()) && is_ws(cps[i + 1]);
+        if (term && nextws) { sentences.push_back(cur); cur.clear(); }
+    }
+    if (!cur.empty()) sentences.push_back(cur);
+
+    std::vector<std::string> out;
+    std::vector<char32_t> chunk_cps;
+    auto flush = [&]() {
+        size_t a = 0, b = chunk_cps.size();
+        while (a < b && chunk_cps[a] == ' ') ++a;
+        while (b > a && chunk_cps[b - 1] == ' ') --b;
+        if (b > a) out.push_back(u32_to_utf8(std::vector<char32_t>(chunk_cps.begin() + a,
+                                                                   chunk_cps.begin() + b)));
+        chunk_cps.clear();
+    };
+    auto fits = [&](int extra) {
+        return static_cast<int>(chunk_cps.size()) + (chunk_cps.empty() ? 0 : 1) + extra <= cap;
+    };
+    auto append_unit = [&](const std::vector<char32_t>& u) {
+        if (!chunk_cps.empty()) chunk_cps.push_back(' ');
+        chunk_cps.insert(chunk_cps.end(), u.begin(), u.end());
+    };
+
+    for (auto& sent : sentences) {
+        if (static_cast<int>(sent.size()) <= cap) {
+            if (!fits(static_cast<int>(sent.size()))) flush();
+            append_unit(sent);
+            continue;
+        }
+        // Oversize sentence: hard-split on word boundaries (and pathologically long tokens).
+        flush();
+        std::vector<char32_t> word;
+        auto push_word = [&]() {
+            if (word.empty()) return;
+            if (!fits(static_cast<int>(word.size()))) flush();
+            append_unit(word);
+            word.clear();
+        };
+        for (char32_t c : sent) {
+            if (is_ws(c)) { push_word(); continue; }
+            word.push_back(c);
+            if (static_cast<int>(word.size()) >= cap) push_word();
+        }
+        push_word();
+    }
+    flush();
+    if (out.empty()) out.emplace_back();  // degenerate input → one empty chunk
+    return out;
+}
+
+}  // namespace speech_core


### PR DESCRIPTION
## Add SupertonicTTS-3 as a LiteRT `TTSInterface` model

SupertonicTTS-3 — 99M **non-autoregressive flow-matching** multilingual TTS (44.1 kHz, 31 languages, **G2P-free**). Plugs into `TTSInterface` like `LiteRTVoxCPM2Tts`, but non-AR: a fixed `total_step` ODE loop, no stop logits, no KV cache.

### What's here
- **`LiteRTSupertonicTts`** — orchestrates the four graphs (`duration_predictor` → `text_encoder` → `vector_estimator` ×N → `vocoder`) via `LiteRtRunCompiledModel`. Driver math ported verbatim from the validated `infer.py` reference.
- **`SupertonicTokenizer`** — NFKD (utf8proc) + cleanup + `<lang>` wrap + codepoint→id lookup. No espeak/phonemizer/GPL.
- **`sc_supertonic_*`** C ABI + a `speech_supertonic_tts` example/smoke-test CLI.
- **CMake** — registers the sources; adds `utf8proc` (MIT) via `find_package`-or-`FetchContent`, `PRIVATE`.

Models: https://huggingface.co/soniqo/Supertonic-3-LiteRT

### Validation (built, run, and cross-checked — not just compiled)
- Reviewed against the `infer.py`/`helper.py` reference across four dimensions (pipeline math, LiteRT API/memory safety, tokenizer parity, C-ABI/CMake). It caught a **critical** dtype bug: the LiteRT graphs take `text_ids` as **int64** (only the CoreML export is int32) — int32 would throw on every run. Tokenizer parity: **zero** findings.
- **Built against real libLiteRt and ran end-to-end on macOS.** Synthesized clean 44.1 kHz audio (RMS ~0.05, no clipping); the C++ duration matches the reference `duration_predictor` **exactly (0.0 ms)**. The runtime caught two more bugs static analysis couldn't:
  - LiteRT binds inputs by the graph's **tensor-index order**, which ai_edge_torch permutes away from the declared arg order — reordered all multi-input Runs to the introspected order.
  - Voice-style `data` is a **nested** array (`[1][50][256]`), not flat — the parser now flattens.

### Dynamic-L follow-up — investigated, **upstream-blocked**
The published bundle is fixed-shape (T=128, **L=64**). The dynamic-L re-export (`torch.export` `Dim` + `litert_torch` `dynamic_shapes`) doesn't lower: after patching an i64→i32 arange crash, `odml_torch` hits architecture walls with a symbolic L — VE `mul broadcasting (2,512,64)×(2,1,<dyn>)` (relpos attention materializes L_max) and vocoder `AssertionError float32[1,144,<dyn>]`. (CoreML gets dynamic L via coremltools RangeDim; litert_torch can't.) So the **fixed-L=64 graph + the host-side chunk cap is the correct shipping state** — the cap (in `SupertonicTokenizer::chunk`) keeps each chunk within the window, so truncation is guarded, not silent. Longer single chunks would need L-buckets or an upstream fix; the full finding is recorded in `export_litert.py`.
