### PR TITLE
[codex] Add VoxCPM 0.5B ONNX TTS wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/kokoro/kokoro_multilingual.cpp
         src/models/deepfilter/deepfilter.cpp
         src/models/sidon/onnx_sidon_restorer.cpp
+        src/models/voxcpm/onnx_voxcpm_tts.cpp
         src/models/voxcpm2/onnx_voxcpm2_tts.cpp
         src/models/nemotron/onnx_nemotron_streaming_stt.cpp
         src/models/personaplex/onnx_personaplex.cpp

--- a/docs/models.md
+++ b/docs/models.md
@@ -11,6 +11,7 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 | `KokoroTts` | `TTSInterface` | `speech_core/models/kokoro_tts.h` | full |
 | `DeepFilterEnhancer` | `EnhancerInterface` | `speech_core/models/deepfilter.h` | full |
 | `OnnxSidonRestorer` | (own API; `EnhancerInterface` adapter) | `speech_core/models/onnx_sidon_restorer.h` | full — see [OnnxSidonRestorer](#onnxsidonrestorer) |
+| `OnnxVoxCPMTts` | `TTSInterface` | `speech_core/models/onnx_voxcpm_tts.h` | full |
 | `OnnxVoxCPM2Tts` | `TTSInterface` | `speech_core/models/onnx_voxcpm2_tts.h` | full |
 | `OnnxNemotronStreamingStt` | `STTInterface` | `speech_core/models/onnx_nemotron_streaming_stt.h` | full (streaming) |
 | `OnnxPersonaPlex` | `FullDuplexSpeechInterface` | `speech_core/models/onnx_personaplex.h` | structural — see [OnnxPersonaPlex](#onnxpersonaplex) |
@@ -72,6 +73,8 @@ format) and `chat()` (run prefill+decode, parse tool-call markers, populate
 `DiarizationPipeline` (`speech_core/diarization/diarization_pipeline.h`, implements `DiarizerInterface`) composes a segmenter + embedder + constrained clustering. It is pure C++ and ships in the **core** library (built always, no LiteRT dependency); pair it with the LiteRT segmenter + embedder above.
 
 Kokoro 82M and DeepFilterNet3 do not yet have LiteRT exports — see `speech-models` for conversion status. When they land, wrappers will be added alongside the existing two.
+
+`OnnxVoxCPMTts` is the smaller VoxCPM 0.5B serving wrapper used by the CPU cloud synth path. It loads one unified decoder graph plus audio encoder/decoder sidecars, outputs 16 kHz PCM, and supports prompt-audio cloning via `set_reference()`. For best clone fidelity, call `set_reference_transcript()` with the exact text spoken in the reference clip before `synthesize()`.
 
 `LiteRTVoxCPM2Tts` runs the full 4-graph orchestration end-to-end: `text_prefill → token_step ×N → audio_decode` with explicit K/V cache handoff every step. Voice cloning via the `audio_encoder` is supported by the graph but not yet surfaced through `TTSInterface` — `synthesize()` always feeds zero audio_feats today; adding a `set_reference_audio()` method is a follow-up. The bundle is large (~8.7 GB fp16 `selective` for ARM at the repo root; ~13 GB fp32-token-step for x86 in the `fp32-p16/` subdir) and inference is slow on CPU, so end-to-end validation runs in the **weekly** workflow (`.github/workflows/weekly-voxcpm2.yml`) rather than the daily nightly.
 
@@ -186,6 +189,32 @@ auto result = stt.transcribe(audio, length, 16000);
 - Encoder INT8 weight-quantized (~595 MB on disk vs ~840 MB ONNX FP32), decoder-joint stays FP32 to avoid LSTM drift
 - Decoder-joint exposes `(encoder_out, target, h, c)` as four discrete tensors (ORT bundles `target_length` and uses suffix-`_1`/`_2` for h/c)
 - Model files: [soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) — `parakeet-encoder.tflite`, `parakeet-decoder-joint.tflite`, `vocab.json`
+
+## OnnxVoxCPMTts
+
+```cpp
+#include <speech_core/models/onnx_voxcpm_tts.h>
+
+speech_core::OnnxVoxCPMTts tts(
+    "/models/voxcpm-decoder.fp16w.onnx",
+    "/models/voxcpm-audio-encoder.onnx",
+    "/models/voxcpm-audio-decoder.onnx",
+    "/models/tokenizer.json");
+
+tts.set_reference(reference_pcm_16khz.data(), reference_pcm_16khz.size(), 16000);
+tts.set_reference_transcript("This is the exact sentence in the reference clip.");
+tts.synthesize("Hello world", "en", [](const float* samples, size_t length, bool is_final) {
+    // 16 kHz Float32 PCM, streamed in decoder chunks.
+});
+tts.clear_reference();
+```
+
+- VoxCPM 0.5B bilingual TTS, ONNX Runtime backend.
+- Serving bundle: [soniqo/VoxCPM-0.5B-ONNX](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX).
+- Loads three graphs: a unified `voxcpm-decoder*.onnx` prefill+token-step graph plus `voxcpm-audio-encoder.onnx` and `voxcpm-audio-decoder.onnx`.
+- Default cloud CPU deployment uses `voxcpm-decoder.fp16w.onnx`: FP16 external weights with FP32 compute tensors, keeping CPU RSS lower while preserving graph I/O shape.
+- Voice cloning is prompt-audio based. `set_reference()` encodes the 16 kHz prompt clip into latent frames; `set_reference_transcript()` is optional but recommended, and should be the exact transcript of that clip. Existing callers that only set audio still work.
+- End-to-end audio-quality validation is intentionally heavy because it downloads a multi-GB bundle and runs autoregressive synthesis. Keep ordinary CI to compile/smoke checks; run synth → ASR round-trips manually or from a weekly workflow when promoting a new bundle.
 
 ## LiteRTVoxCPM2Tts
 

--- a/include/speech_core/models/onnx_voxcpm_tts.h
+++ b/include/speech_core/models/onnx_voxcpm_tts.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/voxcpm2_tokenizer.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// VoxCPM 0.5B bilingual TTS via ONNX Runtime.
+/// 16 kHz output. Plain TTS by default; prompt-audio conditioning when a
+/// reference clip is set via set_reference(). Supplying the exact transcript
+/// for that clip via set_reference_transcript() improves clone fidelity.
+/// Model: https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX.
+///
+/// Mirrors the upstream VoxCPM 0.5B inference loop at the AR-loop level. The
+/// three ORT sessions are loaded through OnnxEngine, which routes hw_accel=true to the
+/// hardware EP via the optional SessionOptionsHook (with automatic CPU fallback) and
+/// to NNAPI/QNN on Android. Each per-Run call mints a fresh set of OrtValues
+/// over caller-owned host memory via CreateTensorWithDataAsOrtValue, then
+/// reads back from the returned OrtValues' GetTensorMutableData pointers —
+/// the same idiom ParakeetStt uses.
+///
+/// Pipeline (three ONNX graphs orchestrated here):
+///   audio_encoder  : (audio [1, 102400] = 6.4 s @ 16 kHz)
+///                    → (audio_feats [1, 80, 2, 64])    — prompt conditioning only
+///   decoder        : UNIFIED prefill + token-step graph (the merged export).
+///     prefill mode  : (text_tokens, text_mask, audio_feats, audio_mask, ctx_len)
+///                     → (lm_hidden, residual_hidden, prefix_feat_cond, base_cache, residual_cache)
+///     token mode ×N : (ts_lm_hidden, ts_residual_hidden, ts_prefix_feat_cond, ts_base_cache,
+///                      ts_residual_cache, ts_position_id, ts_noise)
+///                     → (ts_pred_feat, ts_stop_logits, ts_next_lm, ts_next_resid,
+///                        ts_next_base_cache, ts_next_resid_cache)
+///   audio_decoder  : (latent [1, 64, 128]) → PCM [1, 81920] (5.12 s @ 16 kHz)
+///
+/// The prefill and token-step graphs share one transformer; exporting them as
+/// one graph stores those weights once. Both modes live in `decoder_session_`;
+/// each Run requests only its mode's outputs but must still supply every graph
+/// input, so the idle mode's inputs are fed cheap zero dummies.
+class OnnxVoxCPMTts : public TTSInterface {
+public:
+    /// `decoder_path` is the unified prefill+token-step graph
+    /// (voxcpm-decoder.onnx). audio_encoder/decoder + tokenizer as before.
+    OnnxVoxCPMTts(const std::string& decoder_path,
+                   const std::string& audio_encoder_path,
+                   const std::string& audio_decoder_path,
+                   const std::string& tokenizer_path,
+                   bool hw_accel = true);
+    ~OnnxVoxCPMTts() override;
+
+    // --- TTSInterface ---
+    void synthesize(const std::string& text,
+                    const std::string& language,
+                    TTSChunkCallback on_chunk) override;
+    int output_sample_rate() const override { return 16000; }
+    void cancel() override;
+
+    /// Override the per-utterance instruction prefix (defaults to empty).
+    void set_instruction(std::string instruction) { instruction_ = std::move(instruction); }
+
+    /// Cap the number of AR steps per synthesize() call. Defaults to 2048
+    /// (model max). Reducing it bounds latency and is useful in tests.
+    void set_max_steps(int max_steps) { max_steps_ = max_steps; }
+
+    /// Treat the model's stop signal as authoritative after this many steps.
+    void set_min_steps_before_stop(int min_steps) { min_stop_steps_ = min_steps; }
+
+    /// Honour the model's stop signal at all. When false, synthesize() always
+    /// runs the full max_steps() budget.
+    void set_stop_on_stop_token(bool stop_on_stop_token) { stop_on_stop_token_ = stop_on_stop_token; }
+
+    /// Seed the noise RNG that drives the diffusion-style AR step. 0 ⇒ draw a
+    /// fresh non-deterministic seed at the next synthesize() (its value is
+    /// then reported by seed_used()). Default is 0.
+    void set_seed(uint32_t seed) { seed_ = seed; }
+
+    /// The seed actually used by the most recent synthesize() call.
+    uint32_t seed_used() const { return seed_used_; }
+
+    /// Number of AR steps (acoustic tokens) emitted by the most recent
+    /// synthesize() call. 0 before the first call.
+    int tokens_generated() const { return tokens_generated_; }
+
+    /// Whether the most recent synthesize() stopped because the model raised
+    /// its stop signal (true) vs hitting max-steps / being cancelled (false).
+    bool stopped_on_stop_token() const { return stopped_on_stop_token_; }
+
+    /// Maximum number of text tokens the prefill graph accepts. 512 on the
+    /// deployed bundle.
+    int max_text_tokens() const { return max_text_; }
+
+    /// Condition subsequent synthesize() calls on a reference speaker clip.
+    /// `pcm` is mono float samples in [-1, 1] at `sample_rate`; resampled to
+    /// 16 kHz and padded/truncated to the encoder's fixed 6.4 s window.
+    void set_reference(const float* pcm, size_t length, int sample_rate);
+
+    /// Optional exact transcript of the current reference clip. Call after
+    /// set_reference(); clear_reference() clears it with the audio prompt.
+    void set_reference_transcript(std::string transcript) {
+        ref_transcript_ = std::move(transcript);
+    }
+
+    /// Drop any reference clip; synthesize() falls back to plain TTS.
+    void clear_reference();
+
+    /// Whether a reference clip is currently set.
+    bool has_reference() const { return ref_frames_ > 0; }
+
+private:
+    // Helpers populated at construction: each graph's input/output names as
+    // queried via Session{Get,Get}{Input,Output}Name. Stored as owned
+    // std::string and a parallel const char*[] for Run().
+    struct IoNames {
+        std::vector<std::string>  in_names_str;
+        std::vector<std::string>  out_names_str;
+        std::vector<const char*>  in_names;
+        std::vector<const char*>  out_names;
+    };
+    void query_io_names(OrtSession* session, IoNames& names);
+
+    // Query the prefill graph's max_text_tokens context window. The
+    // audio_feats input is the rank-4 tensor [1, max_text, patch, feat].
+    int query_prefill_context(OrtSession* session);
+
+    const OrtApi* api_ = nullptr;
+
+    // One session for the unified prefill+token graph (weights resident once).
+    OrtSession* decoder_session_       = nullptr;
+    OrtSession* audio_encoder_session_ = nullptr;
+    OrtSession* audio_decoder_session_ = nullptr;
+
+    // The unified graph's I/O split by the "ts_" prefix: prefill_io_ holds the
+    // prefill names (text_tokens…→lm_hidden…), step_io_ the token-step names
+    // (ts_lm_hidden…→ts_pred_feat…). Each is a subset of decoder_session_'s I/O.
+    IoNames prefill_io_;
+    IoNames step_io_;
+    IoNames encoder_io_;
+    IoNames decoder_io_;
+
+    std::unique_ptr<VoxCPM2Tokenizer> tokenizer_;
+    int audio_start_token_     = -1;
+
+    // Cached reference latents from the last set_reference() call. Laid out as
+    // ref_frames_ consecutive [patch, feat] frames (kPredFeatFloats each).
+    std::vector<float> ref_feats_;
+    std::string        ref_transcript_;
+    int                ref_frames_ = 0;
+
+    // Bundle-invariant shape constants (same across every VoxCPM export).
+    static constexpr int  kMaxGenerated        = 2048;
+    static constexpr int  kHidden              = 1024;
+    static constexpr int  kFeatDim             = 64;
+    static constexpr int  kPatchSize           = 2;
+    static constexpr int  kPredFeatFloats      = kPatchSize * kFeatDim;            // 128
+    static constexpr int  kFramesPerChunk      = 64;
+    static constexpr int  kDecoderInputFloats  = kFramesPerChunk * kPredFeatFloats; // 8192
+    static constexpr int  kDecoderOutputFloats = 81920;      // 5.12 s @ 16 kHz
+    static constexpr int  kSamplesPerStep      = 1280;       // 80 ms @ 16 kHz
+    static constexpr int  kBaseLayers          = 24;
+    static constexpr int  kResidualLayers      = 6;
+    static constexpr int  kKvHeads             = 2;
+    static constexpr int  kHeadDim             = 64;
+
+    // Reference-audio conditioning constants.
+    static constexpr int  kCondSampleRate      = 16000;
+    static constexpr int  kRefAudioSamples     = 102400;   // 6.4 s @ 16 kHz
+    static constexpr int  kRefFrameStride      = 1280;     // samples per latent frame
+    static constexpr int  kMaxRefFrames        = kRefAudioSamples / kRefFrameStride; // 80
+
+    // Context geometry queried from the loaded prefill graph.
+    int  max_text_               = 512;
+    int  full_seq_               = 512 + kMaxGenerated;
+    long base_cache_floats_      = 0;
+    long residual_cache_floats_  = 0;
+    long base_prefill_floats_    = 0;
+    long residual_prefill_floats_= 0;
+
+    std::string       instruction_;
+    int               max_steps_          = kMaxGenerated;
+    int               min_stop_steps_     = 8;
+    bool              stop_on_stop_token_ = true;
+    uint32_t          seed_               = 0;
+    std::atomic<bool> cancelled_{false};
+
+    // Per-call metadata, populated at the end of synthesize().
+    uint32_t          seed_used_             = 0;
+    int               tokens_generated_      = 0;
+    bool              stopped_on_stop_token_ = false;
+};
+
+}  // namespace speech_core

--- a/src/models/voxcpm/onnx_voxcpm_tts.cpp
+++ b/src/models/voxcpm/onnx_voxcpm_tts.cpp
@@ -1,0 +1,876 @@
+#include "speech_core/models/onnx_voxcpm_tts.h"
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+namespace speech_core {
+
+namespace {
+
+// RAII for an OrtAllocator-allocated string (input/output name).
+struct OrtStringHandle {
+    const OrtApi* api = nullptr;
+    OrtAllocator* alloc = nullptr;
+    char* p = nullptr;
+    OrtStringHandle(const OrtApi* a, OrtAllocator* al) : api(a), alloc(al) {}
+    ~OrtStringHandle() {
+        if (p && api && alloc) api->AllocatorFree(alloc, p);
+    }
+    OrtStringHandle(const OrtStringHandle&) = delete;
+    OrtStringHandle& operator=(const OrtStringHandle&) = delete;
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// IO name introspection
+// ---------------------------------------------------------------------------
+
+void OnnxVoxCPMTts::query_io_names(OrtSession* session, IoNames& names) {
+    OrtAllocator* alloc = nullptr;
+    ort_check(api_, api_->GetAllocatorWithDefaultOptions(&alloc));
+
+    size_t n_in = 0;
+    ort_check(api_, api_->SessionGetInputCount(session, &n_in));
+    names.in_names_str.reserve(n_in);
+    for (size_t i = 0; i < n_in; ++i) {
+        OrtStringHandle h(api_, alloc);
+        ort_check(api_, api_->SessionGetInputName(session, i, alloc, &h.p));
+        names.in_names_str.emplace_back(h.p);
+    }
+
+    size_t n_out = 0;
+    ort_check(api_, api_->SessionGetOutputCount(session, &n_out));
+    names.out_names_str.reserve(n_out);
+    for (size_t i = 0; i < n_out; ++i) {
+        OrtStringHandle h(api_, alloc);
+        ort_check(api_, api_->SessionGetOutputName(session, i, alloc, &h.p));
+        names.out_names_str.emplace_back(h.p);
+    }
+
+    // Build parallel const char*[] for api_->Run().
+    names.in_names.clear();
+    names.in_names.reserve(names.in_names_str.size());
+    for (auto& s : names.in_names_str) names.in_names.push_back(s.c_str());
+    names.out_names.clear();
+    names.out_names.reserve(names.out_names_str.size());
+    for (auto& s : names.out_names_str) names.out_names.push_back(s.c_str());
+}
+
+int OnnxVoxCPMTts::query_prefill_context(OrtSession* session) {
+    constexpr int kDefault = 512;
+    if (!session) return kDefault;
+
+    size_t n_in = 0;
+    if (api_->SessionGetInputCount(session, &n_in) != nullptr) return kDefault;
+
+    for (size_t i = 0; i < n_in; ++i) {
+        OrtTypeInfo* type_info = nullptr;
+        if (api_->SessionGetInputTypeInfo(session, i, &type_info) != nullptr) continue;
+        const OrtTensorTypeAndShapeInfo* shape_info = nullptr;
+        if (api_->CastTypeInfoToTensorInfo(type_info, &shape_info) != nullptr || !shape_info) {
+            api_->ReleaseTypeInfo(type_info);
+            continue;
+        }
+        size_t rank = 0;
+        api_->GetDimensionsCount(shape_info, &rank);
+        if (rank == 4) {  // audio_feats: [1, max_text, patch, feat]
+            std::vector<int64_t> dims(rank);
+            api_->GetDimensions(shape_info, dims.data(), rank);
+            api_->ReleaseTypeInfo(type_info);
+            const int v = static_cast<int>(dims[1]);
+            if (v > 0) return v;
+            return kDefault;
+        }
+        api_->ReleaseTypeInfo(type_info);
+    }
+    return kDefault;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor / destructor
+// ---------------------------------------------------------------------------
+
+OnnxVoxCPMTts::OnnxVoxCPMTts(const std::string& decoder_path,
+                                const std::string& audio_encoder_path,
+                                const std::string& audio_decoder_path,
+                                const std::string& tokenizer_path,
+                                bool hw_accel)
+{
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    // The unified graph runs both the one-shot prefill and the 25-60 per-step
+    // token decodes. Token-step shapes are fixed, so this is the capture
+    // hint target on hardware EPs that support graph capture.
+    decoder_session_       = engine.load(decoder_path, hw_accel,
+                                         /*capture_hint=*/true);
+    audio_encoder_session_ = engine.load(audio_encoder_path, hw_accel);
+    audio_decoder_session_ = engine.load(audio_decoder_path, hw_accel);
+
+    // Split the unified graph's I/O into prefill (no prefix) and token (ts_).
+    IoNames full;
+    query_io_names(decoder_session_, full);
+    auto is_ts = [](const std::string& s) { return s.rfind("ts_", 0) == 0; };
+    for (auto& s : full.in_names_str)
+        (is_ts(s) ? step_io_ : prefill_io_).in_names_str.push_back(s);
+    for (auto& s : full.out_names_str)
+        (is_ts(s) ? step_io_ : prefill_io_).out_names_str.push_back(s);
+    auto rebuild = [](IoNames& io) {
+        io.in_names.clear();
+        for (auto& s : io.in_names_str) io.in_names.push_back(s.c_str());
+        io.out_names.clear();
+        for (auto& s : io.out_names_str) io.out_names.push_back(s.c_str());
+    };
+    rebuild(prefill_io_);
+    rebuild(step_io_);
+
+    query_io_names(audio_encoder_session_, encoder_io_);
+    query_io_names(audio_decoder_session_, decoder_io_);
+
+    // Context window comes from the prefill graph's rank-4 audio_feats input.
+    max_text_                = query_prefill_context(decoder_session_);
+    full_seq_                = max_text_ + kMaxGenerated;
+    base_cache_floats_       = 2L * kBaseLayers     * kKvHeads * full_seq_ * kHeadDim;
+    residual_cache_floats_   = 2L * kResidualLayers * kKvHeads * full_seq_ * kHeadDim;
+    base_prefill_floats_     = 2L * kBaseLayers     * kKvHeads * max_text_ * kHeadDim;
+    residual_prefill_floats_ = 2L * kResidualLayers * kKvHeads * max_text_ * kHeadDim;
+
+    tokenizer_         = std::make_unique<VoxCPM2Tokenizer>(tokenizer_path);
+    audio_start_token_ = tokenizer_->token_id("<|audio_start|>");
+    if (audio_start_token_ < 0) {
+        throw std::runtime_error(
+            "ONNX VoxCPM: tokenizer is missing <|audio_start|> — bundle is malformed");
+    }
+}
+
+OnnxVoxCPMTts::~OnnxVoxCPMTts() {
+    if (audio_decoder_session_)  api_->ReleaseSession(audio_decoder_session_);
+    if (audio_encoder_session_)  api_->ReleaseSession(audio_encoder_session_);
+    if (decoder_session_)        api_->ReleaseSession(decoder_session_);
+}
+
+void OnnxVoxCPMTts::cancel() {
+    cancelled_.store(true, std::memory_order_relaxed);
+}
+
+// ---------------------------------------------------------------------------
+// Reference conditioning
+// ---------------------------------------------------------------------------
+
+void OnnxVoxCPMTts::clear_reference() {
+    ref_feats_.clear();
+    ref_feats_.shrink_to_fit();
+    ref_transcript_.clear();
+    ref_frames_ = 0;
+}
+
+void OnnxVoxCPMTts::set_reference(const float* pcm, size_t length, int sample_rate) {
+    clear_reference();
+    if (!pcm || length == 0) return;
+
+    // Resample to the encoder's conditioning rate (16 kHz).
+    std::vector<float> mono;
+    if (sample_rate != kCondSampleRate) {
+        mono = Resampler::resample(pcm, length, sample_rate, kCondSampleRate);
+    } else {
+        mono.assign(pcm, pcm + length);
+    }
+    if (mono.empty()) return;
+
+    // Trim leading silence (same gate as the LiteRT variant).
+    {
+        float peak = 0.0f;
+        for (float v : mono) peak = std::max(peak, std::abs(v));
+        const float gate = std::max(0.01f, 0.1f * peak);
+        constexpr int kWin = 320;  // 20 ms @ 16 kHz
+        size_t start = 0;
+        for (; start + kWin <= mono.size(); start += kWin) {
+            double ss = 0.0;
+            for (int i = 0; i < kWin; ++i) ss += double(mono[start + i]) * mono[start + i];
+            if (std::sqrt(ss / kWin) > gate) break;
+        }
+        if (start + kWin <= mono.size() && start > 0) {
+            const size_t preroll = std::min<size_t>(start, kCondSampleRate / 10);
+            mono.erase(mono.begin(), mono.begin() + (start - preroll));
+        }
+    }
+
+    // Rescue quiet reference clips (same recipe as the LiteRT variant). See
+    // litert_voxcpm2_tts.cpp set_reference() for the full rationale.
+    {
+        double ss = 0.0;
+        float peak = 0.0f;
+        for (float v : mono) {
+            ss += double(v) * v;
+            peak = std::max(peak, std::abs(v));
+        }
+        if (!mono.empty() && peak > 1e-6f) {
+            const double rms = std::sqrt(ss / mono.size());
+            const float kQuietThreshold = 0.04f;
+            const float kTargetRms      = 0.08f;
+            const float kPeakCap        = 0.95f;
+            if (rms < kQuietThreshold) {
+                float scale = static_cast<float>(kTargetRms / rms);
+                if (peak * scale > kPeakCap) scale = kPeakCap / peak;
+                for (float& v : mono) v *= scale;
+            }
+        }
+    }
+
+    const size_t real_samples = std::min<size_t>(mono.size(), kRefAudioSamples);
+    int real_frames = static_cast<int>((real_samples + kRefFrameStride - 1) / kRefFrameStride);
+    real_frames = std::clamp(real_frames, 1, kMaxRefFrames);
+
+    // Pad/truncate to the encoder's fixed-length input.
+    mono.resize(kRefAudioSamples, 0.0f);
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    const int64_t in_shape[2]  = {1, kRefAudioSamples};
+    OrtValue* t_in = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, mono.data(), mono.size() * sizeof(float),
+        in_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_in));
+
+    OrtValue* enc_inputs[1]  = {t_in};
+    OrtValue* enc_outputs[1] = {nullptr};
+    ort_check(api_, api_->Run(
+        audio_encoder_session_, nullptr,
+        encoder_io_.in_names.data(),  enc_inputs,  encoder_io_.in_names.size(),
+        encoder_io_.out_names.data(), encoder_io_.out_names.size(), enc_outputs));
+
+    float* out_ptr = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(enc_outputs[0], (void**)&out_ptr));
+
+    std::vector<float> enc_out(static_cast<size_t>(kMaxRefFrames) * kPredFeatFloats);
+    std::memcpy(enc_out.data(), out_ptr, enc_out.size() * sizeof(float));
+
+    api_->ReleaseValue(enc_outputs[0]);
+    api_->ReleaseValue(t_in);
+
+    ref_feats_.assign(enc_out.begin(),
+                      enc_out.begin() + static_cast<size_t>(real_frames) * kPredFeatFloats);
+    ref_frames_ = real_frames;
+
+    if (std::getenv("VOXCPM_DEBUG")) {
+        double ss = 0.0;
+        for (float v : ref_feats_) ss += static_cast<double>(v) * v;
+        const double rms = ref_feats_.empty() ? 0.0 : std::sqrt(ss / ref_feats_.size());
+        LOGI("VoxCPM (ORT) reference: %d frames (%zu real samples), feats rms=%.4f",
+             ref_frames_, real_samples, rms);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// synthesize()
+// ---------------------------------------------------------------------------
+
+void OnnxVoxCPMTts::synthesize(const std::string& text,
+                                 const std::string& /*language*/,
+                                 TTSChunkCallback on_chunk)
+{
+    if (!on_chunk) return;
+    cancelled_.store(false, std::memory_order_relaxed);
+
+    tokens_generated_      = 0;
+    stopped_on_stop_token_ = false;
+    seed_used_             = 0;
+
+    // --- 1. Build the prefill sequence. VoxCPM 0.5B conditions on a prompt
+    // prefix: optional reference transcript tokens, then encoded prompt-audio
+    // frames, then the target text and audio_start generation cue.
+    std::vector<int> ref_text_ids;
+    if (ref_frames_ > 0 && !ref_transcript_.empty()) {
+        ref_text_ids = tokenizer_->encode(ref_transcript_);
+    }
+    std::string prompt = instruction_.empty() ? text : "(" + instruction_ + ")" + text;
+    std::vector<int> target_ids = tokenizer_->encode(prompt);
+    target_ids.push_back(audio_start_token_);
+
+    std::vector<int64_t> text_tokens(max_text_, 0);
+    std::vector<float>   text_mask  (max_text_, 0.0f);
+    std::vector<float>   audio_feats(static_cast<size_t>(max_text_) * kPredFeatFloats, 0.0f);
+    std::vector<float>   audio_mask (max_text_, 0.0f);
+
+    int pos = 0;
+    const int prompt_audio_slots = ref_frames_;
+    const int avail = std::max(1, max_text_ - prompt_audio_slots);
+    const int ref_text_budget =
+        ref_text_ids.empty() ? 0 : std::max(0, avail - static_cast<int>(target_ids.size()));
+    if (static_cast<int>(ref_text_ids.size()) > ref_text_budget) {
+        ref_text_ids.resize(static_cast<size_t>(ref_text_budget));
+    }
+    const int target_budget = std::max(1, avail - static_cast<int>(ref_text_ids.size()));
+    if (static_cast<int>(target_ids.size()) > target_budget) {
+        std::vector<int> trimmed;
+        trimmed.reserve(static_cast<size_t>(target_budget));
+        for (int i = 0; i < target_budget - 1; ++i) trimmed.push_back(target_ids[i]);
+        trimmed.push_back(audio_start_token_);
+        target_ids.swap(trimmed);
+    }
+    for (int id : ref_text_ids) {
+        text_tokens[pos] = id;
+        text_mask[pos]   = 1.0f;
+        ++pos;
+    }
+    for (int f = 0; f < ref_frames_ && pos < max_text_; ++f) {
+        audio_mask[pos] = 1.0f;
+        std::memcpy(audio_feats.data() + static_cast<size_t>(pos) * kPredFeatFloats,
+                    ref_feats_.data()  + static_cast<size_t>(f)   * kPredFeatFloats,
+                    kPredFeatFloats * sizeof(float));
+        ++pos;
+    }
+    for (int id : target_ids) {
+        text_tokens[pos] = id;
+        text_mask[pos]   = 1.0f;
+        ++pos;
+    }
+    const int     context_length        = pos;
+    const int64_t context_length_scalar = context_length;
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    // The unified graph exposes both modes' inputs; ORT requires every graph
+    // input in each Run even though we request only one mode's outputs (it
+    // executes just that subgraph). make_dummy mints a zero tensor for an idle
+    // input — minimal shape, since the nodes that read it are never run.
+    auto make_dummy = [&](const int64_t* shape, int rank,
+                          ONNXTensorElementDataType dt,
+                          std::vector<std::vector<uint8_t>>& bufs,
+                          std::vector<OrtValue*>& vals) {
+        size_t elems = 1;
+        for (int i = 0; i < rank; ++i) elems *= static_cast<size_t>(shape[i] > 0 ? shape[i] : 1);
+        const size_t esz = (dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) ? 8u : 4u;
+        bufs.emplace_back(elems * esz, 0);
+        OrtValue* v = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, bufs.back().data(), bufs.back().size(), shape, rank, dt, &v));
+        vals.push_back(v);
+    };
+
+    // --- 2. prefill mode → initial hiddens + caches.
+    //
+    std::vector<float> lm_hidden       (kHidden);
+    std::vector<float> residual_hidden (kHidden);
+    std::vector<float> prefix_feat_cond(kPredFeatFloats);
+    std::vector<float> base_prefill    (static_cast<size_t>(base_prefill_floats_));
+    std::vector<float> residual_prefill(static_cast<size_t>(residual_prefill_floats_));
+    {
+        const int64_t s_text_tokens[2] = {1, max_text_};
+        const int64_t s_text_mask  [2] = {1, max_text_};
+        const int64_t s_audio_feats[4] = {1, max_text_, kPatchSize, kFeatDim};
+        const int64_t s_audio_mask [2] = {1, max_text_};
+        const int64_t* s_ctxlen        = nullptr;  // scalar (rank 0)
+
+        OrtValue* t_tokens = nullptr;
+        OrtValue* t_tmask  = nullptr;
+        OrtValue* t_afeats = nullptr;
+        OrtValue* t_amask  = nullptr;
+        OrtValue* t_ctxlen = nullptr;
+
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, text_tokens.data(), text_tokens.size() * sizeof(int64_t),
+            s_text_tokens, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_tokens));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, text_mask.data(), text_mask.size() * sizeof(float),
+            s_text_mask, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_tmask));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, audio_feats.data(), audio_feats.size() * sizeof(float),
+            s_audio_feats, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_afeats));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, audio_mask.data(), audio_mask.size() * sizeof(float),
+            s_audio_mask, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_amask));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, const_cast<int64_t*>(&context_length_scalar), sizeof(int64_t),
+            s_ctxlen, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_ctxlen));
+
+        // Idle (token-step) inputs: minimal-shape zero dummies, in step_io_
+        // input order (ts_lm, ts_resid, ts_pfc, ts_base, ts_rcache, ts_pos, ts_noise).
+        const int64_t d_lm[2]     = {1, kHidden};
+        const int64_t d_pfc[3]    = {1, kPatchSize, kFeatDim};
+        const int64_t d_bcache[6] = {2, kBaseLayers,     1, kKvHeads, 1, kHeadDim};
+        const int64_t d_rcache[6] = {2, kResidualLayers, 1, kKvHeads, 1, kHeadDim};
+        const int64_t* d_scalar   = nullptr;
+        const int64_t d_noise[3]  = {1, kFeatDim, kPatchSize};
+        std::vector<std::vector<uint8_t>> ts_dummy_bufs;
+        std::vector<OrtValue*>            ts_dummy_vals;
+        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_pfc,    3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_scalar, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, ts_dummy_bufs, ts_dummy_vals);
+        make_dummy(d_noise,  3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+
+        // Full input set = real prefill (prefill_io_ order) + ts_ dummies.
+        std::vector<const char*> in_names = prefill_io_.in_names;
+        in_names.insert(in_names.end(), step_io_.in_names.begin(), step_io_.in_names.end());
+        std::vector<OrtValue*> in_vals = {t_tokens, t_tmask, t_afeats, t_amask, t_ctxlen};
+        in_vals.insert(in_vals.end(), ts_dummy_vals.begin(), ts_dummy_vals.end());
+
+        OrtValue* prefill_out[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+        ort_check(api_, api_->Run(
+            decoder_session_, nullptr,
+            in_names.data(),  in_vals.data(), in_names.size(),
+            prefill_io_.out_names.data(), prefill_io_.out_names.size(), prefill_out));
+
+        for (OrtValue* v : ts_dummy_vals) api_->ReleaseValue(v);
+
+        auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
+            void* p = nullptr;
+            ort_check(api_, api_->GetTensorMutableData(v, &p));
+            std::memcpy(dst, p, bytes);
+        };
+        // Output order mirrors the LiteRT graph: lm_hidden, residual_hidden,
+        // prefix_feat_cond, base_cache, residual_cache.
+        copy_out(prefill_out[0], lm_hidden.data(),        lm_hidden.size()        * sizeof(float));
+        copy_out(prefill_out[1], residual_hidden.data(),  residual_hidden.size()  * sizeof(float));
+        copy_out(prefill_out[2], prefix_feat_cond.data(), prefix_feat_cond.size() * sizeof(float));
+        copy_out(prefill_out[3], base_prefill.data(),     base_prefill.size()     * sizeof(float));
+        copy_out(prefill_out[4], residual_prefill.data(), residual_prefill.size() * sizeof(float));
+
+        for (int i = 4; i >= 0; --i) api_->ReleaseValue(prefill_out[i]);
+        api_->ReleaseValue(t_ctxlen);
+        api_->ReleaseValue(t_amask);
+        api_->ReleaseValue(t_afeats);
+        api_->ReleaseValue(t_tmask);
+        api_->ReleaseValue(t_tokens);
+    }
+
+    if (std::getenv("VOXCPM_DEBUG")) {
+        auto rms = [](const std::vector<float>& v) {
+            double s = 0.0; for (float x : v) s += double(x) * x;
+            return v.empty() ? 0.0 : std::sqrt(s / v.size());
+        };
+        LOGI("VoxCPM (ORT) prefill: ctx_len=%d ref_frames=%d lm_rms=%.4f resid_rms=%.4f pfc_rms=%.4f",
+             context_length, ref_frames_, rms(lm_hidden), rms(residual_hidden),
+             rms(prefix_feat_cond));
+    }
+
+    // --- 3. Grow caches from prefill window to full_seq_ by zero-padding axis 4.
+    auto pad_cache = [pref_seq = max_text_, full_seq = full_seq_](
+                         const std::vector<float>& src, std::vector<float>& dst,
+                         int layers, int kv_heads, int head_dim) {
+        std::fill(dst.begin(), dst.end(), 0.0f);
+        const size_t per_kv  = static_cast<size_t>(layers) * kv_heads;
+        const size_t src_row = static_cast<size_t>(pref_seq) * head_dim;
+        const size_t dst_row = static_cast<size_t>(full_seq) * head_dim;
+        for (int kv = 0; kv < 2; ++kv) {
+            for (size_t i = 0; i < per_kv; ++i) {
+                const float* src_ptr = src.data() + (kv * per_kv + i) * src_row;
+                float*       dst_ptr = dst.data() + (kv * per_kv + i) * dst_row;
+                std::memcpy(dst_ptr, src_ptr, src_row * sizeof(float));
+            }
+        }
+    };
+    std::vector<float> base_cache    (static_cast<size_t>(base_cache_floats_));
+    std::vector<float> residual_cache(static_cast<size_t>(residual_cache_floats_));
+    pad_cache(base_prefill,     base_cache,     kBaseLayers,     kKvHeads, kHeadDim);
+    pad_cache(residual_prefill, residual_cache, kResidualLayers, kKvHeads, kHeadDim);
+    base_prefill    .clear(); base_prefill    .shrink_to_fit();
+    residual_prefill.clear(); residual_prefill.shrink_to_fit();
+
+    // --- 4. AR loop.
+    std::vector<float> pred_feat   (kPredFeatFloats);
+    std::vector<float> stop_logits (2);
+    std::vector<float> next_lm     (kHidden);
+    std::vector<float> next_resid  (kHidden);
+    std::vector<float> noise       (kPredFeatFloats);
+    std::vector<float> feature_buffer; feature_buffer.reserve(kDecoderInputFloats);
+    std::vector<float> decoder_input(kDecoderInputFloats, 0.0f);
+    std::vector<float> pcm         (kDecoderOutputFloats);
+
+    uint32_t rng_seed = seed_;
+    if (rng_seed == 0) {
+        std::random_device rd;
+        rng_seed = rd();
+    }
+    seed_used_ = rng_seed;
+    std::mt19937 rng(rng_seed);
+    std::normal_distribution<float> normal(0.0f, 1.0f);
+
+    // Static tensor shapes used inside the step loop.
+    const int64_t s_lm     [2] = {1, kHidden};
+    const int64_t s_resid  [2] = {1, kHidden};
+    const int64_t s_pfc    [3] = {1, kPatchSize, kFeatDim};
+    const int64_t s_bcache [6] = {2, kBaseLayers,     1, kKvHeads, full_seq_, kHeadDim};
+    const int64_t s_rcache [6] = {2, kResidualLayers, 1, kKvHeads, full_seq_, kHeadDim};
+    const int64_t* s_pos       = nullptr;  // scalar
+    const int64_t s_noise  [3] = {1, kFeatDim, kPatchSize};
+    // Idle (prefill) inputs for every token-step Run: zero dummies in
+    // prefill_io_ input order, created once and reused each step. Prefill input
+    // shapes are fixed (not dynamic), so the dummies use the real dimensions.
+    const int64_t pd_tokens[2] = {1, max_text_};
+    const int64_t pd_mask[2]   = {1, max_text_};
+    const int64_t pd_afeats[4] = {1, max_text_, kPatchSize, kFeatDim};
+    const int64_t pd_amask[2]  = {1, max_text_};
+    const int64_t* pd_ctx      = nullptr;
+    std::vector<std::vector<uint8_t>> prefill_dummy_bufs;
+    std::vector<OrtValue*>            prefill_dummy_vals;
+    make_dummy(pd_tokens, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_mask,   2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_afeats, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_amask,  2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+    make_dummy(pd_ctx,    0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+
+    auto flush_decoder = [&](size_t valid_steps, bool is_final) {
+        std::fill(decoder_input.begin(), decoder_input.end(), 0.0f);
+        const size_t cap_steps = std::min<size_t>(
+            valid_steps, static_cast<size_t>(kFramesPerChunk));
+        for (size_t step_idx = 0; step_idx < cap_steps; ++step_idx) {
+            const float* pred = feature_buffer.data() + step_idx * kPredFeatFloats;
+            for (int p = 0; p < kPatchSize; ++p) {
+                const int t = static_cast<int>(step_idx) * kPatchSize + p;
+                if (t >= kDecoderInputFloats / kFeatDim) break;
+                for (int c = 0; c < kFeatDim; ++c) {
+                    decoder_input[c * (kDecoderInputFloats / kFeatDim) + t]
+                        = pred[p * kFeatDim + c];
+                }
+            }
+        }
+
+        const int64_t s_in[3] = {1, kFeatDim, kFramesPerChunk * kPatchSize};
+        OrtValue* t_in = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, decoder_input.data(), decoder_input.size() * sizeof(float),
+            s_in, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_in));
+
+        OrtValue* dec_in[1]  = {t_in};
+        OrtValue* dec_out[1] = {nullptr};
+        ort_check(api_, api_->Run(
+            audio_decoder_session_, nullptr,
+            decoder_io_.in_names.data(),  dec_in,  decoder_io_.in_names.size(),
+            decoder_io_.out_names.data(), decoder_io_.out_names.size(), dec_out));
+
+        float* out_pcm_ptr = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(dec_out[0], (void**)&out_pcm_ptr));
+        std::memcpy(pcm.data(), out_pcm_ptr, pcm.size() * sizeof(float));
+
+        api_->ReleaseValue(dec_out[0]);
+        api_->ReleaseValue(t_in);
+
+        const size_t valid_samples = std::min<size_t>(
+            static_cast<size_t>(valid_steps) * kSamplesPerStep, pcm.size());
+        on_chunk(pcm.data(), valid_samples, is_final);
+
+        feature_buffer.clear();
+    };
+
+    int  steps_done       = 0;
+    int  steps_in_chunk   = 0;
+    bool stopped_by_model = false;
+    const bool debug_steps = std::getenv("VOXCPM_DEBUG") != nullptr;
+
+    // CUDA IoBinding path — keep heavy state (lm_hidden, residual_hidden,
+    // base_cache, residual_cache) GPU-resident between AR steps. Each step
+    // would otherwise re-upload ~200 MB of state to the device, dominating
+    // wall time at this scale. Off-by-default for CPU sessions so the
+    // existing well-tested codepath keeps running unchanged.
+    //
+    // Names use the graph's actual input/output names (introspected at load
+    // via query_io_names) so we don't hard-code "lm_hidden" / "next_lm_hidden"
+    // here — index into step_io_ to stay model-agnostic.
+    // Try to set up GPU IoBinding when the engine resolved a CUDA provider.
+    // Per-session might still be on CPU (when hw_accel=false at construction,
+    // e.g. the load smoke test) — in that case CreateAllocator returns a
+    // status with "No requested allocator available" and we fall through to
+    // the host path.
+    bool use_gpu_bind =
+        OnnxEngine::get().has_gpu_provider()
+        && std::getenv("SPEECH_CORE_VOXCPM2_NO_IOBINDING") == nullptr;
+
+    OrtMemoryInfo* cuda_mem = nullptr;
+    OrtAllocator*  cuda_alloc = nullptr;
+    OrtIoBinding*  binding = nullptr;
+    // Ping-pong sets of GPU state tensors (lm, resid, base, rcache).
+    OrtValue* gpu_lm[2]      = {nullptr, nullptr};
+    OrtValue* gpu_resid[2]   = {nullptr, nullptr};
+    OrtValue* gpu_base[2]    = {nullptr, nullptr};
+    OrtValue* gpu_rcache[2]  = {nullptr, nullptr};
+    int       slot_in   = 0;  // index of the "current" (input) slot
+    int       slot_out  = 1;  // index of the "next" (output) slot
+
+    if (use_gpu_bind) {
+        // CUDA EP registers its device allocator under name "Cuda" with type
+        // OrtDeviceAllocator (NOT OrtArenaAllocator).
+        OrtStatus* s = api_->CreateMemoryInfo(
+            "Cuda", OrtDeviceAllocator, 0, OrtMemTypeDefault, &cuda_mem);
+        if (s == nullptr) {
+            s = api_->CreateAllocator(decoder_session_, cuda_mem, &cuda_alloc);
+        }
+        if (s != nullptr) {
+            // Session was created on CPU (e.g. hw_accel=false) — drop back
+            // to the host path silently. Free the partial state.
+            api_->ReleaseStatus(s);
+            if (cuda_mem) { api_->ReleaseMemoryInfo(cuda_mem); cuda_mem = nullptr; }
+            use_gpu_bind = false;
+        }
+    }
+
+    if (use_gpu_bind) {
+        ort_check(api_, api_->CreateIoBinding(decoder_session_, &binding));
+
+        auto alloc_gpu = [&](const int64_t* shape, int rank, OrtValue** out) {
+            ort_check(api_, api_->CreateTensorAsOrtValue(
+                cuda_alloc, shape, rank,
+                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, out));
+        };
+        for (int i = 0; i < 2; ++i) {
+            alloc_gpu(s_lm,     2, &gpu_lm[i]);
+            alloc_gpu(s_resid,  2, &gpu_resid[i]);
+            alloc_gpu(s_bcache, 6, &gpu_base[i]);
+            alloc_gpu(s_rcache, 6, &gpu_rcache[i]);
+        }
+    }
+
+    for (int step = 0; step < max_steps_; ++step) {
+        if (cancelled_.load(std::memory_order_relaxed)) break;
+
+        for (float& v : noise) v = normal(rng);
+        const int64_t position_id = static_cast<int64_t>(context_length + step);
+
+      if (!use_gpu_bind) {
+        OrtValue* t_lm    = nullptr;
+        OrtValue* t_resid = nullptr;
+        OrtValue* t_pfc   = nullptr;
+        OrtValue* t_bcache= nullptr;
+        OrtValue* t_rcache= nullptr;
+        OrtValue* t_pos   = nullptr;
+        OrtValue* t_noise = nullptr;
+
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, lm_hidden.data(), lm_hidden.size() * sizeof(float),
+            s_lm, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_lm));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, residual_hidden.data(), residual_hidden.size() * sizeof(float),
+            s_resid, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_resid));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, prefix_feat_cond.data(), prefix_feat_cond.size() * sizeof(float),
+            s_pfc, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_pfc));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, base_cache.data(), base_cache.size() * sizeof(float),
+            s_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_bcache));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, residual_cache.data(), residual_cache.size() * sizeof(float),
+            s_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_rcache));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, const_cast<int64_t*>(&position_id), sizeof(int64_t),
+            s_pos, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_pos));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, noise.data(), noise.size() * sizeof(float),
+            s_noise, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_noise));
+
+        // Input order mirrors the graph: ts_lm_hidden, ts_residual_hidden,
+        // ts_prefix_feat_cond, ts_base_cache, ts_residual_cache, ts_position_id,
+        // ts_noise — plus the idle prefill dummies (ORT needs every input).
+        std::vector<const char*> step_in_names = step_io_.in_names;
+        step_in_names.insert(step_in_names.end(),
+                             prefill_io_.in_names.begin(), prefill_io_.in_names.end());
+        std::vector<OrtValue*> step_in_vals = {t_lm, t_resid, t_pfc, t_bcache, t_rcache, t_pos, t_noise};
+        step_in_vals.insert(step_in_vals.end(),
+                            prefill_dummy_vals.begin(), prefill_dummy_vals.end());
+
+        OrtValue* step_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+        ort_check(api_, api_->Run(
+            decoder_session_, nullptr,
+            step_in_names.data(),  step_in_vals.data(), step_in_names.size(),
+            step_io_.out_names.data(), step_io_.out_names.size(), step_out));
+
+        // Output order mirrors LiteRT: pred_feat, stop_logits, next_lm,
+        // next_residual, base_cache, residual_cache.
+        auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
+            void* p = nullptr;
+            ort_check(api_, api_->GetTensorMutableData(v, &p));
+            std::memcpy(dst, p, bytes);
+        };
+        copy_out(step_out[0], pred_feat.data(),      pred_feat.size()      * sizeof(float));
+        copy_out(step_out[1], stop_logits.data(),    stop_logits.size()    * sizeof(float));
+        copy_out(step_out[2], next_lm.data(),        next_lm.size()        * sizeof(float));
+        copy_out(step_out[3], next_resid.data(),     next_resid.size()     * sizeof(float));
+        copy_out(step_out[4], base_cache.data(),     base_cache.size()     * sizeof(float));
+        copy_out(step_out[5], residual_cache.data(), residual_cache.size() * sizeof(float));
+
+        for (int i = 5; i >= 0; --i) api_->ReleaseValue(step_out[i]);
+        api_->ReleaseValue(t_noise);
+        api_->ReleaseValue(t_pos);
+        api_->ReleaseValue(t_rcache);
+        api_->ReleaseValue(t_bcache);
+        api_->ReleaseValue(t_pfc);
+        api_->ReleaseValue(t_resid);
+        api_->ReleaseValue(t_lm);
+
+        lm_hidden        = next_lm;
+        residual_hidden  = next_resid;
+        prefix_feat_cond = pred_feat;
+      } else {
+        // ------ GPU IoBinding path ------
+        // pred_feat (256 floats), stop_logits (2 floats), pfc (256 floats),
+        // position_id (1 i64), noise (256 floats): all small enough to keep
+        // bound to host memory; ORT handles GPU<->CPU sync via
+        // SynchronizeBoundOutputs / SynchronizeBoundInputs.
+        OrtValue* t_pos = nullptr;
+        OrtValue* t_noise = nullptr;
+        OrtValue* t_pfc_in = nullptr;
+        OrtValue* t_pred_feat_out = nullptr;
+        OrtValue* t_stop_logits_out = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, const_cast<int64_t*>(&position_id), sizeof(int64_t),
+            s_pos, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_pos));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, noise.data(), noise.size() * sizeof(float),
+            s_noise, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_noise));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, prefix_feat_cond.data(), prefix_feat_cond.size() * sizeof(float),
+            s_pfc, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_pfc_in));
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, pred_feat.data(), pred_feat.size() * sizeof(float),
+            s_pfc, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_pred_feat_out));
+        // Graph outputs stop_logits as rank-2 [1, 2], not rank-1.
+        const int64_t s_stop[2] = {1, 2};
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, stop_logits.data(), stop_logits.size() * sizeof(float),
+            s_stop, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_stop_logits_out));
+
+        // On step 0, the state inputs (lm/resid/base/rcache) come from the
+        // host (post-prefill); ORT will upload them to the device implicitly
+        // when we BindInput a CPU OrtValue. On step 1+, the previous step's
+        // GPU output slot is the current input.
+        OrtValue* in_lm     = nullptr;
+        OrtValue* in_resid  = nullptr;
+        OrtValue* in_base   = nullptr;
+        OrtValue* in_rcache = nullptr;
+        if (step == 0) {
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, lm_hidden.data(), lm_hidden.size() * sizeof(float),
+                s_lm, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &in_lm));
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, residual_hidden.data(), residual_hidden.size() * sizeof(float),
+                s_resid, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &in_resid));
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, base_cache.data(), base_cache.size() * sizeof(float),
+                s_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &in_base));
+            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+                mem, residual_cache.data(), residual_cache.size() * sizeof(float),
+                s_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &in_rcache));
+        }
+
+        api_->ClearBoundInputs(binding);
+        api_->ClearBoundOutputs(binding);
+
+        // Bind inputs — names come from the loaded graph's introspected list.
+        // Index layout from query_io_names: 0=lm_hidden, 1=residual_hidden,
+        // 2=prefix_feat_cond, 3=base_cache, 4=residual_cache, 5=position_id,
+        // 6=noise. (Same ordering as the existing host path's step_in array.)
+        const char* const* in_n = step_io_.in_names.data();
+        ort_check(api_, api_->BindInput(binding, in_n[0],
+            step == 0 ? in_lm     : gpu_lm[slot_in]));
+        ort_check(api_, api_->BindInput(binding, in_n[1],
+            step == 0 ? in_resid  : gpu_resid[slot_in]));
+        ort_check(api_, api_->BindInput(binding, in_n[2], t_pfc_in));
+        ort_check(api_, api_->BindInput(binding, in_n[3],
+            step == 0 ? in_base   : gpu_base[slot_in]));
+        ort_check(api_, api_->BindInput(binding, in_n[4],
+            step == 0 ? in_rcache : gpu_rcache[slot_in]));
+        ort_check(api_, api_->BindInput(binding, in_n[5], t_pos));
+        ort_check(api_, api_->BindInput(binding, in_n[6], t_noise));
+        // Idle prefill inputs — bound to the persistent zero dummies so the
+        // unified graph has every input present (the prefill subgraph isn't run).
+        for (size_t i = 0; i < prefill_io_.in_names.size(); ++i)
+            ort_check(api_, api_->BindInput(
+                binding, prefill_io_.in_names[i], prefill_dummy_vals[i]));
+
+        // Output layout: 0=pred_feat, 1=stop_logits, 2=next_lm_hidden,
+        // 3=next_residual_hidden, 4=base_cache, 5=residual_cache.
+        const char* const* out_n = step_io_.out_names.data();
+        ort_check(api_, api_->BindOutput(binding, out_n[0], t_pred_feat_out));
+        ort_check(api_, api_->BindOutput(binding, out_n[1], t_stop_logits_out));
+        ort_check(api_, api_->BindOutput(binding, out_n[2], gpu_lm[slot_out]));
+        ort_check(api_, api_->BindOutput(binding, out_n[3], gpu_resid[slot_out]));
+        ort_check(api_, api_->BindOutput(binding, out_n[4], gpu_base[slot_out]));
+        ort_check(api_, api_->BindOutput(binding, out_n[5], gpu_rcache[slot_out]));
+
+        ort_check(api_, api_->RunWithBinding(decoder_session_, nullptr, binding));
+        // CPU-bound outputs (pred_feat, stop_logits) need an explicit
+        // device->host sync; GPU-bound outputs stay on device.
+        ort_check(api_, api_->SynchronizeBoundOutputs(binding));
+
+        if (step == 0) {
+            api_->ReleaseValue(in_rcache);
+            api_->ReleaseValue(in_base);
+            api_->ReleaseValue(in_resid);
+            api_->ReleaseValue(in_lm);
+        }
+        api_->ReleaseValue(t_stop_logits_out);
+        api_->ReleaseValue(t_pred_feat_out);
+        api_->ReleaseValue(t_pfc_in);
+        api_->ReleaseValue(t_noise);
+        api_->ReleaseValue(t_pos);
+
+        // pred_feat host buffer now holds the new value (ORT synced it).
+        // Feed it back as next iter's prefix_feat_cond input.
+        prefix_feat_cond = pred_feat;
+
+        // Swap which GPU slot is "current" for next iter's state inputs.
+        std::swap(slot_in, slot_out);
+      }
+
+        feature_buffer.insert(feature_buffer.end(), pred_feat.begin(), pred_feat.end());
+        ++steps_done;
+        ++steps_in_chunk;
+
+        const bool stop_signal = stop_on_stop_token_
+                              && stop_logits[1] > stop_logits[0]
+                              && steps_done > min_stop_steps_;
+        if (stop_signal) stopped_by_model = true;
+
+        if (debug_steps && (step < 6 || stop_signal)) {
+            float pmax = 0.0f; double sum = 0.0, sq = 0.0;
+            for (float v : pred_feat) { pmax = std::max(pmax, std::abs(v)); sum += v; sq += double(v) * v; }
+            const double mean = sum / pred_feat.size();
+            const double sd = std::sqrt(std::max(0.0, sq / pred_feat.size() - mean * mean));
+            LOGI("VoxCPM (ORT) step %d: pred|max|=%.4f mean=%.4f std=%.4f stop=[%.2f,%.2f]%s",
+                 step, pmax, mean, sd, stop_logits[0], stop_logits[1],
+                 stop_signal ? " STOP" : "");
+        }
+
+        if (steps_in_chunk == kFramesPerChunk) {
+            flush_decoder(kFramesPerChunk, /*is_final=*/false);
+            steps_in_chunk = 0;
+        }
+        if (stop_signal) break;
+    }
+
+    if (use_gpu_bind) {
+        for (int i = 0; i < 2; ++i) {
+            if (gpu_rcache[i])  api_->ReleaseValue(gpu_rcache[i]);
+            if (gpu_base[i])    api_->ReleaseValue(gpu_base[i]);
+            if (gpu_resid[i])   api_->ReleaseValue(gpu_resid[i]);
+            if (gpu_lm[i])      api_->ReleaseValue(gpu_lm[i]);
+        }
+        if (binding)    api_->ReleaseIoBinding(binding);
+        if (cuda_alloc) api_->ReleaseAllocator(cuda_alloc);
+        if (cuda_mem)   api_->ReleaseMemoryInfo(cuda_mem);
+    }
+
+    for (OrtValue* v : prefill_dummy_vals) api_->ReleaseValue(v);
+
+    if (steps_in_chunk > 0) {
+        flush_decoder(static_cast<size_t>(steps_in_chunk), /*is_final=*/true);
+    } else {
+        on_chunk(nullptr, 0, /*is_final=*/true);
+    }
+
+    tokens_generated_      = steps_done;
+    stopped_on_stop_token_ = stopped_by_model;
+}
+
+}  // namespace speech_core


### PR DESCRIPTION
## What changed

Adds `speech_core::OnnxVoxCPMTts`, a VoxCPM 0.5B ONNX Runtime TTS wrapper for the published `soniqo/VoxCPM-0.5B-ONNX` serving bundle.

The wrapper loads the unified prefill/token-step decoder graph plus audio encoder and decoder sidecars, exposes the existing `TTSInterface`, supports prompt-audio cloning through `set_reference()`, and adds `set_reference_transcript()` for the exact transcript of the prompt clip.

Docs are updated in `docs/models.md` with model matrix coverage, usage example, bundle path expectations, and guidance on heavy e2e validation.

## Why

The cloud CPU synth path is moving from the larger VoxCPM2 bundle to the smaller VoxCPM 0.5B ONNX serving bundle. This keeps the reusable model orchestration in `speech-core` instead of carrying cloud-local wrapper code.

## Validation

- Configured and built from a clean branch:
  `cmake -S /tmp/speech-core-voxcpm-pr -B /tmp/speech-core-voxcpm-pr-build -DCMAKE_BUILD_TYPE=Release -DSPEECH_CORE_WITH_ONNX=ON -DORT_DIR=/tmp/ort-sdk/onnxruntime-osx-arm64-1.27.0 -DSPEECH_CORE_BUILD_TESTS=ON`
- Built all targets with `cmake --build /tmp/speech-core-voxcpm-pr-build -j$(sysctl -n hw.ncpu)`
- Ran `DYLD_LIBRARY_PATH=/tmp/ort-sdk/onnxruntime-osx-arm64-1.27.0/lib ctest --test-dir /tmp/speech-core-voxcpm-pr-build --output-on-failure`
- Result: 15/15 tests passed

## Notes

Heavy audio-quality checks still belong in a weekly/manual synth-to-ASR round-trip because the bundle is multi-GB and autoregressive synthesis is slow on CPU.
