### PR TITLE
[codex] Add CosyVoice3 stage timing getters

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -250,7 +250,8 @@ tts.clear_conditioning();
 - Loads five inference graphs: `llm_prefill.onnx`, `llm_step.onnx`, `flow_frontend.onnx`, `flow.decoder.estimator.fp32.onnx`, and `hift.onnx`, plus `CosyVoice-BlankEN/{vocab.json,merges.txt}` for the Qwen text tokenizer.
 - Zero-shot voice cloning is intentionally a two-stage contract. This wrapper consumes cached conditioning tensors; it does not yet compute the frontend tensors from raw reference audio. Cloud and app callers should compute that conditioning at voice-create time and persist `encode_conditioning_blob()` output with the voice.
 - The conditioning blob contains prompt text token IDs, LLM prompt speech tokens, flow prompt speech tokens, prompt mel features `[frames,80]`, and a 192-dim speaker embedding. `prompt_text_from_transcript()` prepends the helper prompt prefix when the transcript does not already include `<|endofprompt|>`.
-- `tests/test_models.cpp` includes a load/blob smoke. Set `SPEECH_COSYVOICE3_ONNX_DIR=/path/to/CosyVoice3-0.5B-ONNX` to run it locally; otherwise it skips like the other heavyweight model tests.
+- After each `synthesize()` call, `prefill_ms()`, `ar_ms()`, and `audio_decode_ms()` expose coarse stage timing. `flow_frontend_ms()`, `flow_estimator_ms()`, and `hift_ms()` split `audio_decode_ms()` into the Flow/HiFT sub-stages used by cloud observability.
+- `tests/test_models.cpp` includes a load/blob smoke. Set `SPEECH_COSYVOICE3_ONNX_DIR=/path/to/CosyVoice3-0.5B-ONNX` to run it locally; add `SPEECH_COSYVOICE3_E2E=1` to synthesize a short clip and assert populated stage timings. Without the bundle, it skips like the other heavyweight model tests.
 
 ## LiteRTVoxCPM2Tts
 

--- a/include/speech_core/models/onnx_cosyvoice3_tts.h
+++ b/include/speech_core/models/onnx_cosyvoice3_tts.h
@@ -58,6 +58,9 @@ public:
     int64_t prefill_ms() const { return prefill_ms_; }
     int64_t ar_ms() const { return ar_ms_; }
     int64_t audio_decode_ms() const { return audio_decode_ms_; }
+    int64_t flow_frontend_ms() const { return flow_frontend_ms_; }
+    int64_t flow_estimator_ms() const { return flow_estimator_ms_; }
+    int64_t hift_ms() const { return hift_ms_; }
 
     static std::string helper_prompt_prefix();
     static std::string prompt_text_from_transcript(const std::string& transcript);
@@ -79,6 +82,9 @@ private:
     int64_t prefill_ms_ = -1;
     int64_t ar_ms_ = -1;
     int64_t audio_decode_ms_ = -1;
+    int64_t flow_frontend_ms_ = -1;
+    int64_t flow_estimator_ms_ = -1;
+    int64_t hift_ms_ = -1;
 };
 
 }  // namespace speech_core

--- a/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
+++ b/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
@@ -616,7 +616,10 @@ struct OnnxCosyVoice3Tts::Impl {
     }
 
     std::vector<float> run_flow_hift(const std::vector<int64_t>& speech_tokens,
-                                     int* decode_ms) {
+                                     int* decode_ms,
+                                     int* flow_frontend_ms,
+                                     int* flow_estimator_ms,
+                                     int* hift_ms) {
         if (!has_conditioning) {
             throw std::runtime_error("CosyVoice3 conditioning is required");
         }
@@ -663,8 +666,10 @@ struct OnnxCosyVoice3Tts::Impl {
         const char* out_names[4] = {"mu", "mask", "spks", "cond"};
         OrtValue* outs[4] = {nullptr, nullptr, nullptr, nullptr};
         auto t0 = Clock::now();
+        auto flow_frontend_t0 = Clock::now();
         ort_check(api, api->Run(flow_frontend, nullptr,
             in_names, in, 5, out_names, 4, outs));
+        *flow_frontend_ms = static_cast<int>(elapsed_ms(flow_frontend_t0));
         for (auto* v : in) api->ReleaseValue(v);
 
         const int generated_frames =
@@ -706,6 +711,7 @@ struct OnnxCosyVoice3Tts::Impl {
         const int64_t s_mask[3] = {2, 1, total_frames};
         const int64_t s_t[1] = {2};
         const int64_t s_spks[2] = {2, 80};
+        auto flow_estimator_t0 = Clock::now();
         for (int i = 0; i < 10; ++i) {
             std::vector<float> x2(static_cast<size_t>(2) * 80 * total_frames);
             std::vector<float> mu2(x2.size());
@@ -745,6 +751,7 @@ struct OnnxCosyVoice3Tts::Impl {
                 x[j] += dt * guided;
             }
         }
+        *flow_estimator_ms = static_cast<int>(elapsed_ms(flow_estimator_t0));
 
         std::vector<float> hift_in(static_cast<size_t>(80) * kHiftFrames, 0.0f);
         for (int c = 0; c < 80; ++c) {
@@ -757,11 +764,13 @@ struct OnnxCosyVoice3Tts::Impl {
         const char* hift_in_names[1] = {"speech_feat"};
         const char* hift_out_names[1] = {"wav"};
         OrtValue* hift_out[1] = {nullptr};
+        auto hift_t0 = Clock::now();
         ort_check(api, api->Run(hift, nullptr,
             hift_in_names, &hift_in_v, 1, hift_out_names, 1, hift_out));
         api->ReleaseValue(hift_in_v);
         std::vector<float> wav = copy_f32(hift_out[0], static_cast<size_t>(kHiftFrames) * 480);
         api->ReleaseValue(hift_out[0]);
+        *hift_ms = static_cast<int>(elapsed_ms(hift_t0));
         wav.resize(static_cast<size_t>(generated_frames) * 480);
         *decode_ms = static_cast<int>(elapsed_ms(t0));
         return wav;
@@ -807,6 +816,9 @@ void OnnxCosyVoice3Tts::synthesize(const std::string& text,
     prefill_ms_ = -1;
     ar_ms_ = -1;
     audio_decode_ms_ = -1;
+    flow_frontend_ms_ = -1;
+    flow_estimator_ms_ = -1;
+    hift_ms_ = -1;
 
     std::string prompt = instruction_.empty() ? text : instruction_ + " " + text;
     std::vector<int64_t> target = impl_->encode_text(prompt);
@@ -819,8 +831,17 @@ void OnnxCosyVoice3Tts::synthesize(const std::string& text,
     prefill_ms_ = prefill_ms;
     ar_ms_ = ar_ms;
     int decode_ms = 0;
-    auto wav = impl_->run_flow_hift(speech_tokens, &decode_ms);
+    int flow_frontend_ms = 0;
+    int flow_estimator_ms = 0;
+    int hift_ms = 0;
+    auto wav = impl_->run_flow_hift(speech_tokens, &decode_ms,
+                                    &flow_frontend_ms,
+                                    &flow_estimator_ms,
+                                    &hift_ms);
     audio_decode_ms_ = decode_ms;
+    flow_frontend_ms_ = flow_frontend_ms;
+    flow_estimator_ms_ = flow_estimator_ms;
+    hift_ms_ = hift_ms;
     on_chunk(wav.data(), wav.size(), true);
 }
 

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -668,6 +668,12 @@ void test_onnx_cosyvoice3_load(const std::string& /*dir*/) {
         REQUIRE(got_final);
         REQUIRE(samples > 0);
         REQUIRE(!any_nonfinite);
+        REQUIRE(tts.prefill_ms() >= 0);
+        REQUIRE(tts.ar_ms() >= 0);
+        REQUIRE(tts.audio_decode_ms() >= 0);
+        REQUIRE(tts.flow_frontend_ms() >= 0);
+        REQUIRE(tts.flow_estimator_ms() >= 0);
+        REQUIRE(tts.hift_ms() >= 0);
         std::printf("ok (e2e samples=%zu tokens=%d)\n",
                     samples, tts.tokens_generated());
     } else {


### PR DESCRIPTION
## What changed

- Adds `flow_frontend_ms()`, `flow_estimator_ms()`, and `hift_ms()` to `OnnxCosyVoice3Tts`.
- Measures those sub-stages inside `run_flow_hift()` while preserving the existing coarse `audio_decode_ms()` timing.
- Resets the new timing fields at the start of each synth call.
- Extends the CosyVoice3 model docs and the opt-in heavyweight E2E smoke to assert populated timing fields.

## Why

`speech-cloud` needs to distinguish CosyVoice3 decode cost between Flow frontend, Flow estimator, and HiFT. The existing `audio_decode_ms()` was too coarse for production profiling.

## Adversarial review notes

- The change is additive to the public C++ surface; existing callers are unaffected.
- Timer values are only committed to the object after a successful synth call. Failed calls keep the reset `-1` state.
- `audio_decode_ms()` remains the total decode region; the new fields are sub-stage timings and may not sum exactly to the total because of surrounding allocation/copy overhead and millisecond rounding.
- E2E coverage uses synthetic conditioning, so it proves timing propagation through real ONNX graphs but does not claim clone-quality coverage.

## Validation

- `cmake --build /tmp/speech-core-cosy-timing/build-cosy-timing -j 6`
- `ctest --test-dir /tmp/speech-core-cosy-timing/build-cosy-timing --output-on-failure -j 6` → 15/15 passed
- `SPEECH_MODEL_DIR=/tmp/speech-core-cosy-timing/tests/data SPEECH_COSYVOICE3_ONNX_DIR=/tmp/speech-cloud-synthesis-models/cosyvoice3 SPEECH_COSYVOICE3_E2E=1 SPEECH_CORE_ORT_THREADS=4 ctest --test-dir /tmp/speech-core-cosy-timing/build-cosy-timing --output-on-failure -V -R '^test_models$' -j 1` → passed, `test_onnx_cosyvoice3_load ... ok (e2e samples=7680 tokens=8)`
- `git diff --check`
