### PR TITLE
[codex] Add VoxCPM2 split ONNX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On-device voice activity detection, speech-to-text (batch **and** real-time stre
 
 speech-core is a small orchestration core (state machine, turn detection, interruption handling, audio utilities — zero ML deps) plus a set of abstract interfaces. Model inference is **opt-in** through two interchangeable backends you can enable independently:
 
-- **ONNX Runtime** (`SPEECH_CORE_WITH_ONNX`) — Silero VAD, Parakeet STT, Nemotron-3.5 multilingual streaming STT, Kokoro TTS, DeepFilterNet3, Sidon speech restoration, **PersonaPlex 7B full-duplex speech-to-speech** (CUDA target).
+- **ONNX Runtime** (`SPEECH_CORE_WITH_ONNX`) — Silero VAD, Parakeet STT, Nemotron-3.5 multilingual streaming STT, Kokoro TTS, VoxCPM2 TTS, DeepFilterNet3, Sidon speech restoration, **PersonaPlex 7B full-duplex speech-to-speech** (CUDA target).
 - **LiteRT** (`SPEECH_CORE_WITH_LITERT`) — Silero VAD, Parakeet STT, **Nemotron streaming STT**, **Nemotron-3.5 multilingual streaming STT**, Omnilingual STT, Pyannote diarization, WeSpeaker embeddings, VoxCPM2 TTS. Backed by Google's `ai-edge-litert` (`libLiteRt`).
 
 Consumers can enable either, both, or neither — or bring their own implementations of the interfaces (CPU, GPU, CoreML/MLX, a remote API).
@@ -35,7 +35,7 @@ Consumers can enable either, both, or neither — or bring their own implementat
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) | Speech-to-text (multilingual) | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) | Diarization (segmentation) | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) | Speaker embedding | — | ✓ |
-| [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-LiteRT) | Text-to-speech (48 kHz, voice cloning) | — | ✓ |
+| [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) | Text-to-speech (48 kHz, voice cloning) | ✓ | ✓ |
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-ONNX) | Text-to-speech | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) | Speech enhancement | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) | Speech restoration — denoise + dereverb (16 kHz → 48 kHz) | ✓ | — |
@@ -176,6 +176,12 @@ tts.synthesize("Hello world", "en", [](const float* samples, size_t len, bool is
     // 48 kHz Float32 PCM, streamed in chunks
 });
 ```
+
+The ONNX wrapper exposes the same TTS interface via
+`speech_core::OnnxVoxCPM2Tts`. It accepts either a unified
+`voxcpm2-decoder.onnx` graph or split `voxcpm2-text-prefill.onnx` and
+`voxcpm2-token-step.onnx` graphs, plus the shared audio encoder/decoder and
+tokenizer files.
 
 For offline post-processing (for example spectral de-essing), use buffered
 delivery. `synthesize()` is the streaming call; buffered mode

--- a/docs/models.md
+++ b/docs/models.md
@@ -77,6 +77,16 @@ Kokoro 82M and DeepFilterNet3 do not yet have LiteRT exports — see `speech-mod
 
 `OnnxVoxCPMTts` is the smaller VoxCPM 0.5B serving wrapper used by the CPU cloud synth path. It loads split prefill/token-step decoder graphs when `voxcpm-text-prefill*.onnx` and `voxcpm-token-step*.onnx` sit beside the requested `voxcpm-decoder*.onnx`, with automatic fallback to the legacy unified decoder graph when split files are absent. It outputs 16 kHz PCM and supports prompt-audio cloning via `set_reference()`. For best clone fidelity, call `set_reference_transcript()` with the exact text spoken in the reference clip before `synthesize()`.
 
+`OnnxVoxCPM2Tts` runs the VoxCPM2 2B ONNX deployment bundle and outputs 48 kHz
+PCM. It supports two decoder layouts: a unified `voxcpm2-decoder.onnx` graph,
+or split `voxcpm2-text-prefill.onnx` and `voxcpm2-token-step.onnx` graphs. The
+unified export keeps shared transformer weights resident once, which is useful
+for GPU deployments; the split export is useful for CPU serving where unified
+peak RSS can exceed the pod memory budget. Both layouts use the same
+`voxcpm2-audio-encoder.onnx`, `voxcpm2-audio-decoder.onnx`, and
+`tokenizer.json` files, and both support reference-audio cloning through
+`set_reference()`.
+
 `OnnxCosyVoice3Tts` runs the CosyVoice3 0.5B ONNX deployment bundle (`llm_prefill`, `llm_step`, `flow_frontend`, flow estimator, `hift`) and outputs 24 kHz PCM. The current C++ contract expects zero-shot voice conditioning to be supplied explicitly through `set_conditioning()`: prompt text token IDs, prompt speech tokens, prompt mel features, and a 192-dim speaker embedding. This matches the cloud serving shape: compute conditioning once when a voice is created, persist the binary blob with the voice, then reuse it for synthesis without re-running the prompt frontend per request. The bundled `encode_conditioning_blob()` / `decode_conditioning_blob()` helpers define that persistence format. If the bundle also contains `hift_128.onnx` or `hift_256.onnx`, the wrapper uses the smallest fitting HiFT bucket for shorter clips and falls back to `hift.onnx`.
 
 `LiteRTVoxCPM2Tts` runs the full 4-graph orchestration end-to-end: `text_prefill → token_step ×N → audio_decode` with explicit K/V cache handoff every step. Voice cloning via the `audio_encoder` is supported by the graph but not yet surfaced through `TTSInterface` — `synthesize()` always feeds zero audio_feats today; adding a `set_reference_audio()` method is a follow-up. The bundle is large (~8.7 GB fp16 `selective` for ARM at the repo root; ~13 GB fp32-token-step for x86 in the `fp32-p16/` subdir) and inference is slow on CPU, so end-to-end validation runs in the **weekly** workflow (`.github/workflows/weekly-voxcpm2.yml`) rather than the daily nightly.

--- a/include/speech_core/models/onnx_voxcpm2_tts.h
+++ b/include/speech_core/models/onnx_voxcpm2_tts.h
@@ -18,12 +18,8 @@ namespace speech_core {
 /// 48 kHz output. Plain TTS by default; voice cloning when a reference clip is
 /// set via set_reference() — that runs the audio_encoder graph and conditions
 /// the prefill on the encoded reference latents.
-/// Model: https://huggingface.co/soniqo/VoxCPM2-ONNX (token_step / audio_encoder
-/// / audio_decoder graphs; text_prefill graph is required by the wrapper but as
-/// of speech-models facca69 only ships as a *tiny-random-init export* — the
-/// real-weights export is TBD. Running synthesize() against the random-init
-/// bundle will exercise the AR loop and produce noise; it's a link/load smoke
-/// path, not a quality path.)
+/// Model: https://huggingface.co/soniqo/VoxCPM2-ONNX (text_prefill,
+/// token_step, optional unified decoder, audio_encoder, audio_decoder).
 ///
 /// Mirrors LiteRTVoxCPM2Tts byte-for-byte at the AR-loop level. The four ORT
 /// sessions are loaded through OnnxEngine, which routes hw_accel=true to the
@@ -33,29 +29,38 @@ namespace speech_core {
 /// reads back from the returned OrtValues' GetTensorMutableData pointers —
 /// the same idiom ParakeetStt uses.
 ///
-/// Pipeline (three ONNX graphs orchestrated here):
+/// Pipeline (three or four ONNX graphs orchestrated here):
 ///   audio_encoder  : (audio [1, 102400] = 6.4 s @ 16 kHz)
 ///                    → (audio_feats [1, 40, 4, 64])    — cloning only
-///   decoder        : UNIFIED prefill + token-step graph (the merged export).
-///     prefill mode  : (text_tokens, text_mask, audio_feats, audio_mask, ctx_len)
+///   decoder        : either a UNIFIED prefill+token-step graph or split
+///                    text_prefill + token_step graphs.
+///     prefill       : (text_tokens, text_mask, audio_feats, audio_mask, ctx_len)
 ///                     → (lm_hidden, residual_hidden, prefix_feat_cond, base_cache, residual_cache)
-///     token mode ×N : (ts_lm_hidden, ts_residual_hidden, ts_prefix_feat_cond, ts_base_cache,
+///     token ×N      : (ts_lm_hidden, ts_residual_hidden, ts_prefix_feat_cond, ts_base_cache,
 ///                      ts_residual_cache, ts_position_id, ts_noise)
 ///                     → (ts_pred_feat, ts_stop_logits, ts_next_lm, ts_next_resid,
 ///                        ts_next_base_cache, ts_next_resid_cache)
 ///   audio_decoder  : (latent [1, 64, 256]) → PCM [1, 491520] (10.24 s @ 48 kHz)
 ///
-/// The prefill and token-step graphs share one 2B transformer; exporting them
-/// as one graph stores those weights ONCE, ~halving GPU weight residency vs two
-/// separate sessions (measured 19.0→10.8 GB on the prefill+token portion). Both
-/// modes live in `decoder_session_`; each Run requests only its mode's outputs
-/// (ORT executes just that subgraph) but must still supply every graph input,
-/// so the idle mode's inputs are fed cheap zero dummies (built per call).
+/// The unified decoder export stores the shared 2B transformer weights once,
+/// which is useful for GPU residency. In that mode each Run requests only one
+/// mode's outputs but still supplies every graph input, so idle inputs are fed
+/// cheap zero dummies. The split constructor is retained for CPU deployments
+/// where the unified graph's peak RSS can exceed the pod memory limit.
 class OnnxVoxCPM2Tts : public TTSInterface {
 public:
     /// `decoder_path` is the unified prefill+token-step graph
     /// (voxcpm2-decoder.onnx). audio_encoder/decoder + tokenizer as before.
     OnnxVoxCPM2Tts(const std::string& decoder_path,
+                   const std::string& audio_encoder_path,
+                   const std::string& audio_decoder_path,
+                   const std::string& tokenizer_path,
+                   bool hw_accel = true);
+
+    /// `prefill_path` and `token_step_path` are the split decoder graphs
+    /// (voxcpm2-text-prefill.onnx and voxcpm2-token-step.onnx).
+    OnnxVoxCPM2Tts(const std::string& prefill_path,
+                   const std::string& token_step_path,
                    const std::string& audio_encoder_path,
                    const std::string& audio_decoder_path,
                    const std::string& tokenizer_path,
@@ -137,14 +142,17 @@ private:
 
     const OrtApi* api_ = nullptr;
 
-    // One session for the unified prefill+token graph (weights resident once).
+    // One session for the unified prefill+token graph, or two sessions for the
+    // split CPU-serving export.
     OrtSession* decoder_session_       = nullptr;
+    OrtSession* prefill_session_       = nullptr;
+    OrtSession* step_session_          = nullptr;
     OrtSession* audio_encoder_session_ = nullptr;
     OrtSession* audio_decoder_session_ = nullptr;
+    bool        using_split_decoder_   = false;
 
-    // The unified graph's I/O split by the "ts_" prefix: prefill_io_ holds the
-    // prefill names (text_tokens…→lm_hidden…), step_io_ the token-step names
-    // (ts_lm_hidden…→ts_pred_feat…). Each is a subset of decoder_session_'s I/O.
+    // For unified graphs the I/O is split by the "ts_" prefix. For split
+    // graphs, each IoNames set comes directly from its session.
     IoNames prefill_io_;
     IoNames step_io_;
     IoNames encoder_io_;

--- a/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
+++ b/src/models/voxcpm2/onnx_voxcpm2_tts.cpp
@@ -177,9 +177,49 @@ OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& decoder_path,
     ref_audio_end_token_   = tokenizer_->token_id("<|ref_audio_end|>");
 }
 
+OnnxVoxCPM2Tts::OnnxVoxCPM2Tts(const std::string& prefill_path,
+                                const std::string& token_step_path,
+                                const std::string& audio_encoder_path,
+                                const std::string& audio_decoder_path,
+                                const std::string& tokenizer_path,
+                                bool hw_accel)
+{
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    using_split_decoder_ = true;
+
+    prefill_session_ = engine.load(prefill_path, hw_accel);
+    // Token-step shapes are fixed except the KV cache sequence axis, so this
+    // is the capture-hint target on hardware EPs that support graph capture.
+    step_session_ = engine.load(token_step_path, hw_accel,
+                                /*capture_hint=*/true);
+    audio_encoder_session_ = engine.load(audio_encoder_path, hw_accel);
+    audio_decoder_session_ = engine.load(audio_decoder_path, hw_accel);
+
+    query_io_names(prefill_session_, prefill_io_);
+    query_io_names(step_session_, step_io_);
+    query_io_names(audio_encoder_session_, encoder_io_);
+    query_io_names(audio_decoder_session_, decoder_io_);
+
+    // Context window comes from the prefill graph's rank-4 audio_feats input.
+    max_text_ = query_prefill_context(prefill_session_);
+    configure_cache_geometry();
+
+    tokenizer_         = std::make_unique<VoxCPM2Tokenizer>(tokenizer_path);
+    audio_start_token_ = tokenizer_->token_id("<|audio_start|>");
+    if (audio_start_token_ < 0) {
+        throw std::runtime_error(
+            "ONNX VoxCPM2: tokenizer is missing <|audio_start|> — bundle is malformed");
+    }
+    ref_audio_start_token_ = tokenizer_->token_id("<|ref_audio_start|>");
+    ref_audio_end_token_   = tokenizer_->token_id("<|ref_audio_end|>");
+}
+
 OnnxVoxCPM2Tts::~OnnxVoxCPM2Tts() {
     if (audio_decoder_session_)  api_->ReleaseSession(audio_decoder_session_);
     if (audio_encoder_session_)  api_->ReleaseSession(audio_encoder_session_);
+    if (step_session_)           api_->ReleaseSession(step_session_);
+    if (prefill_session_)        api_->ReleaseSession(prefill_session_);
     if (decoder_session_)        api_->ReleaseSession(decoder_session_);
 }
 
@@ -438,8 +478,9 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
             mem, const_cast<int64_t*>(&context_length_scalar), sizeof(int64_t),
             s_ctxlen, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_ctxlen));
 
-        // Idle (token-step) inputs: minimal-shape zero dummies, in step_io_
-        // input order (ts_lm, ts_resid, ts_pfc, ts_base, ts_rcache, ts_pos, ts_noise).
+        // Unified-only idle token-step inputs: minimal-shape zero dummies, in
+        // step_io_ input order (ts_lm, ts_resid, ts_pfc, ts_base, ts_rcache,
+        // ts_pos, ts_noise). Split prefill graphs do not expose these inputs.
         const int64_t d_lm[2]     = {1, kHidden};
         const int64_t d_pfc[3]    = {1, kPatchSize, kFeatDim};
         const int64_t d_bcache[6] = {2, kBaseLayers,     1, kKvHeads, 1, kHeadDim};
@@ -448,23 +489,30 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
         const int64_t d_noise[3]  = {1, kFeatDim, kPatchSize};
         std::vector<std::vector<uint8_t>> ts_dummy_bufs;
         std::vector<OrtValue*>            ts_dummy_vals;
-        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_pfc,    3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_scalar, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, ts_dummy_bufs, ts_dummy_vals);
-        make_dummy(d_noise,  3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        if (!using_split_decoder_) {
+            make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_lm,     2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_pfc,    3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_bcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_rcache, 6, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_scalar, 0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, ts_dummy_bufs, ts_dummy_vals);
+            make_dummy(d_noise,  3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, ts_dummy_bufs, ts_dummy_vals);
+        }
 
-        // Full input set = real prefill (prefill_io_ order) + ts_ dummies.
+        // Full input set = real prefill (prefill_io_ order) plus ts_ dummies
+        // only for the legacy unified graph.
         std::vector<const char*> in_names = prefill_io_.in_names;
-        in_names.insert(in_names.end(), step_io_.in_names.begin(), step_io_.in_names.end());
         std::vector<OrtValue*> in_vals = {t_tokens, t_tmask, t_afeats, t_amask, t_ctxlen};
-        in_vals.insert(in_vals.end(), ts_dummy_vals.begin(), ts_dummy_vals.end());
+        if (!using_split_decoder_) {
+            in_names.insert(in_names.end(), step_io_.in_names.begin(), step_io_.in_names.end());
+            in_vals.insert(in_vals.end(), ts_dummy_vals.begin(), ts_dummy_vals.end());
+        }
 
         OrtValue* prefill_out[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+        OrtSession* prefill_run_session =
+            using_split_decoder_ ? prefill_session_ : decoder_session_;
         ort_check(api_, api_->Run(
-            decoder_session_, nullptr,
+            prefill_run_session, nullptr,
             in_names.data(),  in_vals.data(), in_names.size(),
             prefill_io_.out_names.data(), prefill_io_.out_names.size(), prefill_out));
 
@@ -563,10 +611,13 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
     const int64_t s_noise  [3] = {1, kFeatDim, kPatchSize};
     const int64_t s_dec_in [3] = {1, kFramesPerChunk, kPredFeatFloats};
     (void)s_dec_in;  // referenced by the decoder Run below
+    OrtSession* step_run_session =
+        using_split_decoder_ ? step_session_ : decoder_session_;
 
-    // Idle (prefill) inputs for every token-step Run: zero dummies in
-    // prefill_io_ input order, created once and reused each step. Prefill input
-    // shapes are fixed (not dynamic), so the dummies use the real dimensions.
+    // Unified-only idle prefill inputs for every token-step Run: zero dummies
+    // in prefill_io_ input order, created once and reused each step. Prefill
+    // input shapes are fixed (not dynamic), so the dummies use the real
+    // dimensions. Split token-step graphs do not expose these inputs.
     const int64_t pd_tokens[2] = {1, max_text_};
     const int64_t pd_mask[2]   = {1, max_text_};
     const int64_t pd_afeats[4] = {1, max_text_, kPatchSize, kFeatDim};
@@ -574,11 +625,13 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
     const int64_t* pd_ctx      = nullptr;
     std::vector<std::vector<uint8_t>> prefill_dummy_bufs;
     std::vector<OrtValue*>            prefill_dummy_vals;
-    make_dummy(pd_tokens, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
-    make_dummy(pd_mask,   2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
-    make_dummy(pd_afeats, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
-    make_dummy(pd_amask,  2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
-    make_dummy(pd_ctx,    0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+    if (!using_split_decoder_) {
+        make_dummy(pd_tokens, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+        make_dummy(pd_mask,   2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+        make_dummy(pd_afeats, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+        make_dummy(pd_amask,  2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, prefill_dummy_bufs, prefill_dummy_vals);
+        make_dummy(pd_ctx,    0, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, prefill_dummy_bufs, prefill_dummy_vals);
+    }
 
     std::vector<float> synthesized_pcm;
 
@@ -675,7 +728,7 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
         OrtStatus* s = api_->CreateMemoryInfo(
             "Cuda", OrtDeviceAllocator, 0, OrtMemTypeDefault, &cuda_mem);
         if (s == nullptr) {
-            s = api_->CreateAllocator(decoder_session_, cuda_mem, &cuda_alloc);
+            s = api_->CreateAllocator(step_run_session, cuda_mem, &cuda_alloc);
         }
         if (s != nullptr) {
             // Session was created on CPU (e.g. hw_accel=false) — drop back
@@ -687,7 +740,7 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
     }
 
     if (use_gpu_bind) {
-        ort_check(api_, api_->CreateIoBinding(decoder_session_, &binding));
+        ort_check(api_, api_->CreateIoBinding(step_run_session, &binding));
 
         auto alloc_gpu = [&](const int64_t* shape, int rank, OrtValue** out) {
             ort_check(api_, api_->CreateTensorAsOrtValue(
@@ -741,17 +794,19 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
 
         // Input order mirrors the graph: ts_lm_hidden, ts_residual_hidden,
         // ts_prefix_feat_cond, ts_base_cache, ts_residual_cache, ts_position_id,
-        // ts_noise — plus the idle prefill dummies (ORT needs every input).
+        // ts_noise — plus idle prefill dummies only on the unified graph.
         std::vector<const char*> step_in_names = step_io_.in_names;
-        step_in_names.insert(step_in_names.end(),
-                             prefill_io_.in_names.begin(), prefill_io_.in_names.end());
         std::vector<OrtValue*> step_in_vals = {t_lm, t_resid, t_pfc, t_bcache, t_rcache, t_pos, t_noise};
-        step_in_vals.insert(step_in_vals.end(),
-                            prefill_dummy_vals.begin(), prefill_dummy_vals.end());
+        if (!using_split_decoder_) {
+            step_in_names.insert(step_in_names.end(),
+                                 prefill_io_.in_names.begin(), prefill_io_.in_names.end());
+            step_in_vals.insert(step_in_vals.end(),
+                                prefill_dummy_vals.begin(), prefill_dummy_vals.end());
+        }
 
         OrtValue* step_out[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
         ort_check(api_, api_->Run(
-            decoder_session_, nullptr,
+            step_run_session, nullptr,
             step_in_names.data(),  step_in_vals.data(), step_in_names.size(),
             step_io_.out_names.data(), step_io_.out_names.size(), step_out));
 
@@ -852,11 +907,13 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
             step == 0 ? in_rcache : gpu_rcache[slot_in]));
         ort_check(api_, api_->BindInput(binding, in_n[5], t_pos));
         ort_check(api_, api_->BindInput(binding, in_n[6], t_noise));
-        // Idle prefill inputs — bound to the persistent zero dummies so the
-        // unified graph has every input present (the prefill subgraph isn't run).
-        for (size_t i = 0; i < prefill_io_.in_names.size(); ++i)
-            ort_check(api_, api_->BindInput(
-                binding, prefill_io_.in_names[i], prefill_dummy_vals[i]));
+        // Idle prefill inputs — bound only for the legacy unified graph so it
+        // has every input present (the prefill subgraph isn't run).
+        if (!using_split_decoder_) {
+            for (size_t i = 0; i < prefill_io_.in_names.size(); ++i)
+                ort_check(api_, api_->BindInput(
+                    binding, prefill_io_.in_names[i], prefill_dummy_vals[i]));
+        }
 
         // Output layout: 0=pred_feat, 1=stop_logits, 2=next_lm_hidden,
         // 3=next_residual_hidden, 4=base_cache, 5=residual_cache.
@@ -868,7 +925,7 @@ void OnnxVoxCPM2Tts::synthesize_with_options(const std::string& text,
         ort_check(api_, api_->BindOutput(binding, out_n[4], gpu_base[slot_out]));
         ort_check(api_, api_->BindOutput(binding, out_n[5], gpu_rcache[slot_out]));
 
-        ort_check(api_, api_->RunWithBinding(decoder_session_, nullptr, binding));
+        ort_check(api_, api_->RunWithBinding(step_run_session, nullptr, binding));
         // CPU-bound outputs (pred_feat, stop_logits) need an explicit
         // device->host sync; GPU-bound outputs stay on device.
         ort_check(api_, api_->SynchronizeBoundOutputs(binding));

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -36,6 +36,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -58,6 +59,62 @@ int failures = 0;
 bool file_exists(const std::string& path) {
     std::ifstream f(path);
     return f.good();
+}
+
+struct OnnxVoxCPM2Bundle {
+    std::string dir;
+    std::string prefill;
+    std::string token_step;
+    std::string decoder;
+    std::string audio_encoder;
+    std::string audio_decoder;
+    std::string tokenizer;
+
+    bool has_split() const {
+        return file_exists(prefill) && file_exists(token_step);
+    }
+
+    bool has_unified() const {
+        return file_exists(decoder);
+    }
+
+    bool complete() const {
+        return (has_split() || has_unified())
+            && file_exists(audio_encoder)
+            && file_exists(audio_decoder)
+            && file_exists(tokenizer);
+    }
+};
+
+OnnxVoxCPM2Bundle onnx_voxcpm2_bundle() {
+    // The VoxCPM2 ONNX bundle is independent of $SPEECH_MODEL_DIR — it lives
+    // alongside the speech-models export workspace. Tries a sensible default
+    // and falls back to the env var $SPEECH_VOXCPM2_ONNX_DIR for CI flexibility.
+    const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
+    std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
+    return {
+        vox_dir,
+        vox_dir + "/voxcpm2-text-prefill.onnx",
+        vox_dir + "/voxcpm2-token-step.onnx",
+        vox_dir + "/voxcpm2-decoder.onnx",
+        vox_dir + "/voxcpm2-audio-encoder.onnx",
+        vox_dir + "/voxcpm2-audio-decoder.onnx",
+        vox_dir + "/tokenizer.json",
+    };
+}
+
+std::unique_ptr<speech_core::OnnxVoxCPM2Tts>
+make_onnx_voxcpm2_tts(const OnnxVoxCPM2Bundle& bundle, bool hw_accel) {
+    if (bundle.has_split()) {
+        return std::make_unique<speech_core::OnnxVoxCPM2Tts>(
+            bundle.prefill, bundle.token_step,
+            bundle.audio_encoder, bundle.audio_decoder,
+            bundle.tokenizer, hw_accel);
+    }
+    return std::make_unique<speech_core::OnnxVoxCPM2Tts>(
+        bundle.decoder,
+        bundle.audio_encoder, bundle.audio_decoder,
+        bundle.tokenizer, hw_accel);
 }
 
 std::string env_model_dir() {
@@ -532,40 +589,23 @@ void test_onnx_engine_provider_resolution(const std::string& /*dir*/) {
 // ---------------------------------------------------------------------------
 
 void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
-    // The VoxCPM2 ONNX bundle is independent of $SPEECH_MODEL_DIR — it lives
-    // alongside the speech-models export workspace. Tries a sensible default
-    // and falls back to the env var $SPEECH_VOXCPM2_ONNX_DIR for CI flexibility.
-    const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
-    std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
-
-    // File names mirror the speech-models/models/voxcpm2/export/convert_onnx.py
-    // output exactly: voxcpm2-{graph}.onnx (the speech-cloud LiteRT bundle uses
-    // the same prefix on the .tflite side too, so the wrapper file naming
-    // stays parallel between backends).
-    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
-    std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
-    std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
-    std::string tokenizer     = vox_dir + "/tokenizer.json";
-
-    if (!file_exists(decoder)
-        || !file_exists(audio_encoder) || !file_exists(audio_decoder)
-        || !file_exists(tokenizer))
-    {
+    OnnxVoxCPM2Bundle bundle = onnx_voxcpm2_bundle();
+    if (!bundle.complete()) {
         std::printf("  [skip] ONNX VoxCPM2 bundle not in %s "
-                    "(set SPEECH_VOXCPM2_ONNX_DIR to override)\n", vox_dir.c_str());
+                    "(set SPEECH_VOXCPM2_ONNX_DIR to override)\n",
+                    bundle.dir.c_str());
         return;
     }
-    std::printf("  test_onnx_voxcpm2_load ... ");
+    std::printf("  test_onnx_voxcpm2_load [%s] ... ",
+                bundle.has_split() ? "split" : "unified");
 
     // Phase 1 (always): construct + introspect. Confirms all four ORT
     // sessions load, the tokenizer parses, and the I/O introspection paths
     // don't throw.
-    speech_core::OnnxVoxCPM2Tts tts(decoder,
-                                     audio_encoder, audio_decoder,
-                                     tokenizer, /*hw_accel=*/false);
-    REQUIRE(tts.output_sample_rate() == 48000);
-    REQUIRE(tts.max_text_tokens() > 0);
-    REQUIRE(!tts.has_reference());
+    auto tts = make_onnx_voxcpm2_tts(bundle, /*hw_accel=*/false);
+    REQUIRE(tts->output_sample_rate() == 48000);
+    REQUIRE(tts->max_text_tokens() > 0);
+    REQUIRE(!tts->has_reference());
 
     // Phase 2 (production-config only): exercise the runtime audio paths
     // end-to-end with set_reference + a few AR steps + at least one
@@ -575,9 +615,9 @@ void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
     // mismatch the C++ wrapper's production constants (kFeatDim=64,
     // kPatchSize=4, kHidden=2048; see litert_voxcpm2_tts.h:139-160).
     // A real-weights export from openbmb/VoxCPM2 keeps max_text=512.
-    if (tts.max_text_tokens() < 256) {
+    if (tts->max_text_tokens() < 256) {
         std::printf("ok (max_text=%d, tiny config — skip runtime audio test)\n",
-                    tts.max_text_tokens());
+                    tts->max_text_tokens());
         return;
     }
     // Encoder Run: short 220 Hz ramp as reference clip.
@@ -585,17 +625,17 @@ void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
     for (size_t i = 0; i < ref.size(); ++i) {
         ref[i] = 0.05f * std::sin(2.0f * kPi * 220.0f * static_cast<float>(i) / 16000.0f);
     }
-    tts.set_reference(ref.data(), ref.size(), 16000);
-    REQUIRE(tts.has_reference());
+    tts->set_reference(ref.data(), ref.size(), 16000);
+    REQUIRE(tts->has_reference());
 
     // Decoder Run: cap the AR loop tight so the test stays bounded.
-    tts.set_seed(4242);
-    tts.set_max_steps(16);
-    tts.set_min_steps_before_stop(0);
+    tts->set_seed(4242);
+    tts->set_max_steps(16);
+    tts->set_min_steps_before_stop(0);
     size_t samples = 0;
     bool got_final = false;
     bool any_nonfinite = false;
-    tts.synthesize("hi", "en",
+    tts->synthesize("hi", "en",
         [&](const float* s, size_t n, bool is_final) {
             samples += n;
             if (is_final) got_final = true;
@@ -608,7 +648,7 @@ void test_onnx_voxcpm2_load(const std::string& /*dir*/) {
     REQUIRE(!any_nonfinite);
 
     std::printf("ok (max_text=%d production tokens=%d samples=%zu)\n",
-                tts.max_text_tokens(), tts.tokens_generated(), samples);
+                tts->max_text_tokens(), tts->tokens_generated(), samples);
 }
 
 void test_onnx_cosyvoice3_load(const std::string& /*dir*/) {
@@ -697,20 +737,12 @@ void test_onnx_cosyvoice3_load(const std::string& /*dir*/) {
 // ---------------------------------------------------------------------------
 
 void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
-    const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
-    std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
-
-    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
-    std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
-    std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
-    std::string tokenizer     = vox_dir + "/tokenizer.json";
+    OnnxVoxCPM2Bundle bundle = onnx_voxcpm2_bundle();
     std::string parakeet_enc  = dir + "/parakeet-encoder-int8.onnx";
     std::string parakeet_dec  = dir + "/parakeet-decoder-joint-int8.onnx";
     std::string parakeet_voc  = dir + "/vocab.json";
 
-    if (!file_exists(decoder)
-        || !file_exists(audio_encoder) || !file_exists(audio_decoder)
-        || !file_exists(tokenizer)
+    if (!bundle.complete()
         || !file_exists(parakeet_enc) || !file_exists(parakeet_dec)
         || !file_exists(parakeet_voc))
     {
@@ -718,24 +750,23 @@ void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
         return;
     }
 
-    speech_core::OnnxVoxCPM2Tts tts(decoder,
-                                     audio_encoder, audio_decoder,
-                                     tokenizer, /*hw_accel=*/true);
-    if (tts.max_text_tokens() < 256) {
+    auto tts = make_onnx_voxcpm2_tts(bundle, /*hw_accel=*/true);
+    if (tts->max_text_tokens() < 256) {
         std::printf("  [skip] roundtrip needs production-config VoxCPM2 bundle "
-                    "(max_text=%d)\n", tts.max_text_tokens());
+                    "(max_text=%d)\n", tts->max_text_tokens());
         return;
     }
-    std::printf("  test_onnx_voxcpm2_parakeet_roundtrip ... ");
+    std::printf("  test_onnx_voxcpm2_parakeet_roundtrip [%s] ... ",
+                bundle.has_split() ? "split" : "unified");
 
-    tts.set_seed(4242);
-    tts.set_max_steps(128);
-    tts.set_min_steps_before_stop(32);
+    tts->set_seed(4242);
+    tts->set_max_steps(128);
+    tts->set_min_steps_before_stop(32);
 
     const std::string phrase = "The quick brown fox jumps over the lazy dog";
     std::vector<float> audio_48k;
     bool got_final = false;
-    tts.synthesize(phrase, "en",
+    tts->synthesize(phrase, "en",
         [&](const float* s, size_t n, bool is_final) {
             if (s && n) audio_48k.insert(audio_48k.end(), s, s + n);
             if (is_final) got_final = true;
@@ -758,7 +789,7 @@ void test_onnx_voxcpm2_parakeet_roundtrip(const std::string& dir) {
         if (lower.find(w) != std::string::npos) ++matched;
     }
     std::printf("tokens=%d text=\"%s\" matched=%d/6 ",
-                tts.tokens_generated(), result.text.c_str(), matched);
+                tts->tokens_generated(), result.text.c_str(), matched);
     REQUIRE(matched >= 4);
     std::printf("ok\n");
 }
@@ -813,19 +844,12 @@ static std::vector<std::string> tokenize_lower(const std::string& s) {
 }
 
 void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
-    const char* override_dir = std::getenv("SPEECH_VOXCPM2_ONNX_DIR");
-    std::string vox_dir = override_dir ? override_dir : "/tmp/voxcpm2-onnx";
-    std::string decoder       = vox_dir + "/voxcpm2-decoder.onnx";
-    std::string audio_encoder = vox_dir + "/voxcpm2-audio-encoder.onnx";
-    std::string audio_decoder = vox_dir + "/voxcpm2-audio-decoder.onnx";
-    std::string tokenizer     = vox_dir + "/tokenizer.json";
+    OnnxVoxCPM2Bundle bundle = onnx_voxcpm2_bundle();
     std::string parakeet_enc  = dir + "/parakeet-encoder-int8.onnx";
     std::string parakeet_dec  = dir + "/parakeet-decoder-joint-int8.onnx";
     std::string parakeet_voc  = dir + "/vocab.json";
 
-    if (!file_exists(decoder)
-        || !file_exists(audio_encoder) || !file_exists(audio_decoder)
-        || !file_exists(tokenizer)
+    if (!bundle.complete()
         || !file_exists(parakeet_enc) || !file_exists(parakeet_dec)
         || !file_exists(parakeet_voc))
     {
@@ -833,12 +857,10 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
         return;
     }
 
-    speech_core::OnnxVoxCPM2Tts tts(decoder,
-                                     audio_encoder, audio_decoder,
-                                     tokenizer, /*hw_accel=*/true);
-    if (tts.max_text_tokens() < 256) {
+    auto tts = make_onnx_voxcpm2_tts(bundle, /*hw_accel=*/true);
+    if (tts->max_text_tokens() < 256) {
         std::printf("  [skip] wer_corpus needs production-config bundle "
-                    "(max_text=%d)\n", tts.max_text_tokens());
+                    "(max_text=%d)\n", tts->max_text_tokens());
         return;
     }
     // Surface which inference path will execute. The IoBinding refactor in this
@@ -851,8 +873,8 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
     const bool _gpu_on = OnnxEngine::get().has_gpu_provider();
     const char* _gpu_name = _gpu_on ? "GPU (via hook)" : "CPU (host path)";
     const char* _bind = _gpu_on ? "ON" : "OFF";
-    std::printf("  test_onnx_voxcpm2_wer_corpus [provider=%s iobinding=%s] ... ",
-                _gpu_name, _bind);
+    std::printf("  test_onnx_voxcpm2_wer_corpus [%s provider=%s iobinding=%s] ... ",
+                bundle.has_split() ? "split" : "unified", _gpu_name, _bind);
     std::fflush(stdout);
 
     // 15 short clean-English phrases (paraphrases of LibriSpeech-style
@@ -881,9 +903,9 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
     // emit filler tokens. set_reference would clone a target voice; for a
     // generic WER-vs-text test we skip the reference and rely on the
     // instruction alone to anchor the style.
-    tts.set_instruction("clear, natural delivery");
-    tts.set_max_steps(128);
-    tts.set_min_steps_before_stop(32);
+    tts->set_instruction("clear, natural delivery");
+    tts->set_max_steps(128);
+    tts->set_min_steps_before_stop(32);
 
     speech_core::ParakeetStt stt(parakeet_enc, parakeet_dec, parakeet_voc,
                                   /*hw_accel=*/true);
@@ -895,10 +917,10 @@ void test_onnx_voxcpm2_wer_corpus(const std::string& dir) {
     std::printf("\n");
     for (size_t i = 0; i < phrases.size(); ++i) {
         const std::string& ref = phrases[i];
-        tts.set_seed(static_cast<unsigned>(4242 + i));  // distinct per phrase
+        tts->set_seed(static_cast<unsigned>(4242 + i));  // distinct per phrase
 
         std::vector<float> audio_48k;
-        tts.synthesize(ref, "en",
+        tts->synthesize(ref, "en",
             [&](const float* s, size_t n, bool) {
                 if (s && n) audio_48k.insert(audio_48k.end(), s, s + n);
             });


### PR DESCRIPTION
## Summary
- Add a split prefill/token-step constructor to `OnnxVoxCPM2Tts` while preserving the unified decoder constructor.
- Route prefill and token-step runs through the correct ORT session depending on bundle layout.
- Update model tests to accept either split or unified VoxCPM2 ONNX bundles.
- Update README and model docs for VoxCPM2 ONNX support and bundle layout.

## Validation
- `cmake --build build-onnx -j8 --target test_voxcpm2_options test_models speech_voxcpm2_clone_onnx`
- `ctest --test-dir build-onnx --output-on-failure` — 18/18 passed.
- Production e2e smoke against current cloud VoxCPM2 split-ONNX worker: `scripts/loadtest/synth_multilingual_roundtrip.py --cases en_short --instruction " "` with a temporary cloned voice passed, coverage 1.00, WER 0.22, audio 2.88s.

## Notes
- The unified decoder path remains available for GPU-style bundles with shared weight residency.
- The split decoder path is intended for CPU serving where unified peak RSS can exceed the pod memory budget.