### PR TITLE
[codex] Fix VoxCPM2 Chinese tokenization

### DIFF
--- a/include/speech_core/models/voxcpm2_tokenizer.h
+++ b/include/speech_core/models/voxcpm2_tokenizer.h
@@ -16,7 +16,9 @@ namespace speech_core {
 ///     1. Normalize: prepend ▁, replace each ' ' with ▁ (SentencePiece-style)
 ///     2. BPE on Unicode codepoints with byte fallback (<0xXX> for codepoints
 ///        absent from the vocab)
-///     3. Post-process: prepend BOS (<s>, id=1)
+///     3. Split multi-character Chinese tokens into individual Han characters,
+///        matching VoxCPM2's upstream tokenizer wrapper
+///     4. Post-process: prepend BOS (<s>, id=1)
 ///
 ///   decode(ids):
 ///     1. Skip special tokens
@@ -59,6 +61,10 @@ private:
 
     // Special tokens are skipped during decode and never participate in BPE.
     std::unordered_set<int> special_ids_;
+
+    // Pure multi-character Han vocab entries. VoxCPM2's upstream Python wrapper
+    // splits these after tokenization because merged Chinese words degrade TTS.
+    std::unordered_set<std::string> multichar_chinese_tokens_;
 
     int  bos_id_         = 1;
     int  eos_id_         = 2;

--- a/src/models/litert/voxcpm2_tokenizer.cpp
+++ b/src/models/litert/voxcpm2_tokenizer.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
@@ -81,6 +82,65 @@ std::vector<std::string> utf8_chars(const std::string& s) {
         if (i + len > s.size()) len = s.size() - i;
         out.emplace_back(s.substr(i, len));
         i += len;
+    }
+    return out;
+}
+
+bool utf8_codepoint(const std::string& ch, uint32_t& cp) {
+    if (ch.empty()) return false;
+    const unsigned char c0 = static_cast<unsigned char>(ch[0]);
+    if ((c0 & 0x80) == 0x00) {
+        if (ch.size() != 1) return false;
+        cp = c0;
+        return true;
+    }
+    if ((c0 & 0xE0) == 0xC0) {
+        if (ch.size() != 2) return false;
+        const unsigned char c1 = static_cast<unsigned char>(ch[1]);
+        if ((c1 & 0xC0) != 0x80) return false;
+        cp = ((c0 & 0x1F) << 6) | (c1 & 0x3F);
+        return true;
+    }
+    if ((c0 & 0xF0) == 0xE0) {
+        if (ch.size() != 3) return false;
+        const unsigned char c1 = static_cast<unsigned char>(ch[1]);
+        const unsigned char c2 = static_cast<unsigned char>(ch[2]);
+        if ((c1 & 0xC0) != 0x80 || (c2 & 0xC0) != 0x80) return false;
+        cp = ((c0 & 0x0F) << 12) | ((c1 & 0x3F) << 6) | (c2 & 0x3F);
+        return true;
+    }
+    if ((c0 & 0xF8) == 0xF0) {
+        if (ch.size() != 4) return false;
+        const unsigned char c1 = static_cast<unsigned char>(ch[1]);
+        const unsigned char c2 = static_cast<unsigned char>(ch[2]);
+        const unsigned char c3 = static_cast<unsigned char>(ch[3]);
+        if ((c1 & 0xC0) != 0x80 || (c2 & 0xC0) != 0x80 || (c3 & 0xC0) != 0x80) return false;
+        cp = ((c0 & 0x07) << 18) | ((c1 & 0x3F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F);
+        return true;
+    }
+    return false;
+}
+
+bool is_multichar_basic_han(const std::string& token) {
+    int count = 0;
+    for (const auto& ch : utf8_chars(token)) {
+        uint32_t cp = 0;
+        if (!utf8_codepoint(ch, cp)) return false;
+        if (cp < 0x4E00 || cp > 0x9FFF) return false;
+        ++count;
+    }
+    return count >= 2;
+}
+
+std::string remove_space_markers(const std::string& token) {
+    std::string out;
+    out.reserve(token.size());
+    for (size_t i = 0; i < token.size(); ) {
+        if (i + 3 <= token.size() && std::memcmp(&token[i], kSpaceMarker, 3) == 0) {
+            i += 3;
+        } else {
+            out += token[i++];
+        }
     }
     return out;
 }
@@ -190,6 +250,12 @@ VoxCPM2Tokenizer::VoxCPM2Tokenizer(const std::string& path) {
         }
     }
 
+    for (const auto& kv : vocab_) {
+        if (is_multichar_basic_han(kv.first)) {
+            multichar_chinese_tokens_.insert(kv.first);
+        }
+    }
+
     // merges: ["left right", ...]  (lower index = higher merge priority)
     size_t merges_pos = find_member(text, model_inner, model_end, "merges");
     if (merges_pos == std::string::npos || text[merges_pos] != '[') {
@@ -284,12 +350,23 @@ std::vector<int> VoxCPM2Tokenizer::bpe(const std::string& word) const {
         tokens.erase(tokens.begin() + best_idx + 1);
     }
 
-    // Resolve each token to its ID; missing → <unk>.
+    // VoxCPM2 wraps its tokenizer with mask_multichar_chinese_tokens(): after
+    // BPE, pure multi-character Chinese vocab tokens are split back into
+    // single characters before ID conversion. Without this, Chinese synthesis
+    // degrades badly even though raw tokenizer parity tests pass.
     std::vector<int> ids;
     ids.reserve(tokens.size());
     for (const auto& t : tokens) {
-        auto it = vocab_.find(t);
-        ids.push_back(it != vocab_.end() ? it->second : unk_id_);
+        const std::string clean = remove_space_markers(t);
+        if (multichar_chinese_tokens_.count(clean)) {
+            for (const auto& ch : utf8_chars(clean)) {
+                auto it = vocab_.find(ch);
+                ids.push_back(it != vocab_.end() ? it->second : unk_id_);
+            }
+        } else {
+            auto it = vocab_.find(t);
+            ids.push_back(it != vocab_.end() ? it->second : unk_id_);
+        }
     }
     return ids;
 }

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -26,6 +26,8 @@
 #include "speech_core/vad/streaming_vad.h"
 #include "speech_core/voxcpm2_c.h"
 
+#include "voxcpm2_tokenizer_test_util.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -570,10 +572,9 @@ void test_litert_voxcpm2_synthesize(const std::string& dir) {
 }
 
 // ---------------------------------------------------------------------------
-// VoxCPM2 tokenizer — pins encode/decode to the reference output from the
-// Python HuggingFace `tokenizers` library against the published
-// tokenizer.json. Only requires the tokenizer file, not the .tflite graphs,
-// so it runs whenever tokenizer.json is present.
+// VoxCPM2 tokenizer — pins encode/decode to upstream VoxCPM2's tokenizer
+// wrapper. Only requires tokenizer.json, not the .tflite graphs, so it runs
+// whenever tokenizer.json is present.
 // ---------------------------------------------------------------------------
 
 void test_voxcpm2_tokenizer(const std::string& dir) {
@@ -582,45 +583,7 @@ void test_voxcpm2_tokenizer(const std::string& dir) {
         std::printf("  [skip] tokenizer.json not in %s\n", dir.c_str());
         return;
     }
-    std::printf("  test_voxcpm2_tokenizer ... ");
-
-    speech_core::VoxCPM2Tokenizer t(tok_path);
-    REQUIRE(t.bos_id() == 1);
-    REQUIRE(t.eos_id() == 2);
-    REQUIRE(t.unk_id() == 0);
-    REQUIRE(t.vocab_size() > 73000);
-
-    // Reference outputs from python `tokenizers.Tokenizer.from_file(...).encode(s).ids`.
-    // The trailing roundtrip check exercises the decoder (skip-specials,
-    // ▁→space, byte fallback collapse, strip leading space).
-    struct Case { std::string text; std::vector<int> ids; };
-    const std::vector<Case> cases = {
-        {"Hello world",                    {1, 21045, 2809}},
-        {"The quick brown fox jumps over the lazy dog.",
-                                           {1, 1507, 4766, 13329, 49712, 43384, 1865, 1358, 29117, 6595, 72}},
-        {"Hello, world!",                  {1, 21045, 59342, 2809, 73}},
-        {"\xE4\xBD\xA0\xE5\xA5\xBD",       {1, 59320, 23523}},   // "你好"
-        {"caf\xC3\xA9",                    {1, 33903, 60025}},   // "café"
-        {"",                               {1}},
-        {" ",                              {1, 1345}},
-        {"a b  c",                         {1, 1348, 1376, 1345, 59333}},
-        // Byte-fallback path — rare CJK U+20BB7 encodes to F0 A0 AE B7
-        {"\xF0\xA0\xAE\xB7",               {1, 59320, 1329, 1249, 1263, 1272}},
-    };
-    for (const auto& c : cases) {
-        auto got = t.encode(c.text);
-        if (got != c.ids) {
-            std::printf("\n    encode(\"%s\"): got [", c.text.c_str());
-            for (size_t i = 0; i < got.size(); ++i) std::printf("%s%d", i ? "," : "", got[i]);
-            std::printf("], want [");
-            for (size_t i = 0; i < c.ids.size(); ++i) std::printf("%s%d", i ? "," : "", c.ids[i]);
-            std::printf("] ");
-        }
-        REQUIRE(got == c.ids);
-        // Roundtrip: encode then decode should return the original text.
-        REQUIRE(t.decode(got) == c.text);
-    }
-    std::printf("ok\n");
+    REQUIRE(speech_core_test::run_voxcpm2_tokenizer_reference_cases(tok_path));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -28,6 +28,8 @@
 #include "speech_core/models/silero_vad.h"
 #include "speech_core/vad/streaming_vad.h"
 
+#include "voxcpm2_tokenizer_test_util.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -582,6 +584,23 @@ void test_onnx_engine_provider_resolution(const std::string& /*dir*/) {
 }
 
 // ---------------------------------------------------------------------------
+// VoxCPM2 tokenizer parity — independent of the ONNX graphs, but lives in the
+// ONNX test binary because speech_core_models owns the shared tokenizer in
+// ONNX-only builds.
+// ---------------------------------------------------------------------------
+
+void test_voxcpm2_tokenizer(const std::string& /*dir*/) {
+    OnnxVoxCPM2Bundle bundle = onnx_voxcpm2_bundle();
+    if (!file_exists(bundle.tokenizer)) {
+        std::printf("  [skip] tokenizer.json not in %s "
+                    "(set SPEECH_VOXCPM2_ONNX_DIR to override)\n",
+                    bundle.dir.c_str());
+        return;
+    }
+    REQUIRE(speech_core_test::run_voxcpm2_tokenizer_reference_cases(bundle.tokenizer));
+}
+
+// ---------------------------------------------------------------------------
 // ONNX VoxCPM2 load smoke — constructs the wrapper from the random-init
 // exported graphs at /tmp/voxcpm2-onnx/ (the tiny-init bundle from
 // speech-models, used until the real-weights text_prefill export lands).
@@ -1083,6 +1102,7 @@ int main() {
     RUN(test_deepfilter);
     RUN(test_sidon_restorer);
     RUN(test_kokoro_parakeet_roundtrip);
+    RUN(test_voxcpm2_tokenizer);
     RUN(test_onnx_voxcpm2_load);
     RUN(test_onnx_cosyvoice3_load);
     RUN(test_onnx_voxcpm2_parakeet_roundtrip);

--- a/tests/voxcpm2_tokenizer_test_util.h
+++ b/tests/voxcpm2_tokenizer_test_util.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "speech_core/models/voxcpm2_tokenizer.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace speech_core_test {
+
+inline void print_ids(const std::vector<int>& ids) {
+    std::printf("[");
+    for (size_t i = 0; i < ids.size(); ++i) {
+        std::printf("%s%d", i ? "," : "", ids[i]);
+    }
+    std::printf("]");
+}
+
+inline bool run_voxcpm2_tokenizer_reference_cases(const std::string& tok_path) {
+    std::printf("  test_voxcpm2_tokenizer ... ");
+
+    speech_core::VoxCPM2Tokenizer t(tok_path);
+    if (t.bos_id() != 1 || t.eos_id() != 2 || t.unk_id() != 0 || t.vocab_size() <= 73000) {
+        std::printf("bad tokenizer metadata ");
+        return false;
+    }
+
+    // Reference outputs from upstream VoxCPM2's text tokenizer wrapper:
+    // `mask_multichar_chinese_tokens(LlamaTokenizerFast.from_pretrained(...))`.
+    // Chinese and Japanese Han cases intentionally differ from raw HuggingFace
+    // tokenizer IDs: VoxCPM2 splits merged multi-character Han tokens back to
+    // single characters before ID conversion.
+    struct Case { std::string text; std::vector<int> ids; };
+    const std::vector<Case> cases = {
+        {"Hello world",                    {1, 21045, 2809}},
+        {"The quick brown fox jumps over the lazy dog.",
+                                           {1, 1507, 4766, 13329, 49712, 43384, 1865, 1358, 29117, 6595, 72}},
+        {"Hello, world!",                  {1, 21045, 59342, 2809, 73}},
+        {"\xE4\xBD\xA0\xE5\xA5\xBD",       {1, 59320, 59496, 59495}},
+        {"\xE8\xAF\xB7\xE7\xA1\xAE\xE8\xAE\xA4\xE4\xBA\x91\xE7\xAB\xAF\xE8\xAF\xAD\xE9\x9F\xB3\xE5\x90\x88\xE6\x88\x90\xE4\xBB\x8A\xE5\xA4\xA9\xE6\xB8\x85\xE6\x99\xB0\xE7\xA8\xB3\xE5\xAE\x9A\xE3\x80\x82",
+                                           {1, 32435, 59699, 59638, 59968, 60197, 59836, 59941, 59474, 59452, 59856, 59534, 59726, 61533, 60334, 59421, 66}},
+        {"\xED\x95\x9C\xEA\xB5\xAD\xEC\x96\xB4\x20\xEC\x9D\x8C\xEC\x84\xB1\x20\xED\x95\xA9\xEC\x84\xB1\xEC\x9D\x84\x20\xED\x99\x95\xEC\x9D\xB8\xED\x95\xA9\xEB\x8B\x88\xEB\x8B\xA4\x2E",
+                                           {1, 59320, 62385, 1323, 1270, 1262, 62793, 59320, 1325, 1246, 1229, 63409, 59320, 63966, 63409, 62274, 59320, 1326, 1242, 1238, 62946, 63966, 35773, 72}},
+        {"\xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF\xE4\xB8\x96\xE7\x95\x8C\xE3\x80\x82",
+                                           {1, 59320, 62190, 62524, 61377, 63251, 61579, 59792, 59868, 66}},
+        {"\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E\xE3\x81\xAE\xE9\x9F\xB3\xE5\xA3\xB0\xE5\x90\x88\xE6\x88\x90\xE3\x82\x92\xE7\xA2\xBA\xE8\xAA\x8D\xE3\x81\x97\xE3\x81\xBE\xE3\x81\x99\xE3\x80\x82",
+                                           {1, 59420, 59416, 65419, 60931, 59941, 60068, 59474, 59452, 61417, 65013, 72626, 61432, 32902, 66}},
+        {"caf\xC3\xA9",                    {1, 33903, 60025}},
+        {"",                               {1}},
+        {" ",                              {1, 1345}},
+        {"a b  c",                         {1, 1348, 1376, 1345, 59333}},
+        {"\xF0\xA0\xAE\xB7",               {1, 59320, 1329, 1249, 1263, 1272}},
+    };
+
+    for (const auto& c : cases) {
+        auto got = t.encode(c.text);
+        if (got != c.ids) {
+            std::printf("\n    encode(\"%s\"): got ", c.text.c_str());
+            print_ids(got);
+            std::printf(", want ");
+            print_ids(c.ids);
+            std::printf(" ");
+            return false;
+        }
+        const std::string decoded = t.decode(got);
+        if (decoded != c.text) {
+            std::printf("\n    decode(encode(\"%s\")) -> \"%s\" ", c.text.c_str(), decoded.c_str());
+            return false;
+        }
+    }
+
+    std::printf("ok\n");
+    return true;
+}
+
+}  // namespace speech_core_test


### PR DESCRIPTION
## What changed

- Match upstream VoxCPM2 text tokenization by splitting pure multi-character Han vocab tokens after BPE and before ID lookup.
- Share tokenizer parity cases between ONNX and LiteRT model tests.
- Add Chinese, Korean, and Japanese tokenizer fixtures against the production tokenizer IDs.

## Root cause

Our C++ tokenizer matched raw HuggingFace tokenizer output, but VoxCPM2 wraps that tokenizer with `mask_multichar_chinese_tokens`. Without the wrapper behavior, Chinese text keeps merged word tokens such as `确认`, `云端`, and `语音`, which upstream explicitly splits into single Han characters for synthesis.

## Validation

- `cmake --build build-onnx --target test_models -j 8`
- `SPEECH_MODEL_DIR=/tmp/empty-speech-models SPEECH_VOXCPM2_ONNX_DIR=/tmp/voxcpm2-prod-tokenizer ./build-onnx/test_models`
- `ctest --test-dir build-onnx --output-on-failure`
- `cmake -B build-litert -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=/Users/ivan/repos/speech-studio/core-sidecar/build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-litert --target test_litert_models -j 8`
- `DYLD_LIBRARY_PATH=/Users/ivan/repos/speech-studio/core-sidecar/build SPEECH_LITERT_MODEL_DIR=/tmp/voxcpm2-prod-tokenizer ctest --test-dir build-litert --output-on-failure -R ^test_litert_models`

Note: a full `ctest` in the fresh `build-litert` directory was not meaningful because only `test_litert_models` had been built there; the targeted CTest passed.
