### PR TITLE
Add Whisper ONNX STT runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/voxcpm2/onnx_voxcpm2_tts.cpp
         src/models/nemotron/onnx_nemotron_streaming_stt.cpp
         src/models/personaplex/onnx_personaplex.cpp
+        src/models/whisper/onnx_whisper_stt.cpp
     )
     # VoxCPM2 tokenizer is pure C++17 and shared with the LiteRT target. To
     # avoid duplicate symbols when a downstream binary links both targets, we
@@ -858,6 +859,10 @@ if(SPEECH_CORE_PACKAGE)
     # invoked without a model_dir argument.
     install(PROGRAMS scripts/download_models.sh
         DESTINATION bin RENAME speech_download_models)
+    if(SPEECH_CORE_WITH_ONNX)
+        install(PROGRAMS scripts/download_whisper_onnx.sh
+            DESTINATION bin RENAME speech_download_whisper_onnx)
+    endif()
     if(SPEECH_CORE_WITH_LITERT)
         install(PROGRAMS scripts/download_models_litert.sh
             DESTINATION bin RENAME speech_download_models_litert)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On-device voice activity detection, speech-to-text (batch **and** real-time stre
 
 speech-core is a small orchestration core (state machine, turn detection, interruption handling, audio utilities — zero ML deps) plus a set of abstract interfaces. Model inference is **opt-in** through two interchangeable backends you can enable independently:
 
-- **ONNX Runtime** (`SPEECH_CORE_WITH_ONNX`) — Silero VAD, Parakeet STT, Nemotron-3.5 multilingual streaming STT, Kokoro TTS, VoxCPM2 TTS, DeepFilterNet3, Sidon speech restoration, **PersonaPlex 7B full-duplex speech-to-speech** (CUDA target).
+- **ONNX Runtime** (`SPEECH_CORE_WITH_ONNX`) — Silero VAD, Parakeet STT, Whisper v3/turbo STT, Nemotron-3.5 multilingual streaming STT, Kokoro TTS, VoxCPM2 TTS, DeepFilterNet3, Sidon speech restoration, **PersonaPlex 7B full-duplex speech-to-speech** (CUDA target).
 - **LiteRT** (`SPEECH_CORE_WITH_LITERT`) — Silero VAD, Parakeet STT, **Nemotron streaming STT**, **Nemotron-3.5 multilingual streaming STT**, Omnilingual STT, Pyannote diarization, WeSpeaker embeddings, VoxCPM2 TTS. Backed by Google's `ai-edge-litert` (`libLiteRt`).
 
 Consumers can enable either, both, or neither — or bring their own implementations of the interfaces (CPU, GPU, CoreML/MLX, a remote API).
@@ -30,6 +30,7 @@ Consumers can enable either, both, or neither — or bring their own implementat
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) | Voice activity detection | ✓ | ✓ |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) | Speech-to-text | ✓ | ✓ |
+| [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) | Speech-to-text (multilingual, greedy ONNX runtime) | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) | Streaming speech-to-text | ✓ | ✓ |
 | [Nemotron-3.5 ASR Streaming Multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) | Streaming speech-to-text (multilingual, prompt-conditioned) | ✓ | ✓ |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) | Speech-to-text (multilingual) | — | ✓ |
@@ -303,6 +304,7 @@ The orchestration + diarization unit tests need no model files. Integration test
 ```bash
 scripts/fetch_litert.sh build/litert
 scripts/download_models_litert.sh            # public soniqo/* models, no token
+scripts/download_whisper_onnx.sh turbo int8  # optional large Whisper bundle
 cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$PWD/build/litert && cmake --build build
 SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -8,6 +8,7 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 |---|---|---|---|
 | `SileroVad` | `VADInterface` | `speech_core/models/silero_vad.h` | full |
 | `ParakeetStt` | `STTInterface` | `speech_core/models/parakeet_stt.h` | full |
+| `OnnxWhisperStt` | `STTInterface` | `speech_core/models/onnx_whisper_stt.h` | full |
 | `KokoroTts` | `TTSInterface` | `speech_core/models/kokoro_tts.h` | full |
 | `DeepFilterEnhancer` | `EnhancerInterface` | `speech_core/models/deepfilter.h` | full |
 | `OnnxSidonRestorer` | (own API; `EnhancerInterface` adapter) | `speech_core/models/onnx_sidon_restorer.h` | full — see [OnnxSidonRestorer](#onnxsidonrestorer) |
@@ -173,6 +174,36 @@ auto result = stt.transcribe(audio, length, 16000);
 - Language detection via `<|xx|>` BPE tokens
 - Streaming supported via `begin_stream` / `push_chunk` / `end_stream` (accumulates audio and re-transcribes each chunk; not a true streaming decoder)
 - Model files: [soniqo/Parakeet-TDT-0.6B-ONNX](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-ONNX) — `parakeet-encoder.onnx` (FP32, plus external `.onnx.data`) or `parakeet-encoder-int8.onnx` (~840 MB / ~100 MB INT8), `parakeet-decoder-joint.onnx` / `parakeet-decoder-joint-int8.onnx`, `vocab.json`. Decoder-joint inputs `targets` + `target_length` are INT32; encoder length input stays INT64.
+
+## OnnxWhisperStt
+
+```cpp
+#include <speech_core/models/onnx_whisper_stt.h>
+
+speech_core::OnnxWhisperStt stt(
+    "/models/whisper-turbo/turbo-encoder.int8.onnx",
+    "/models/whisper-turbo/turbo-decoder.int8.onnx",
+    "/models/whisper-turbo/turbo-tokens.txt");
+
+auto result = stt.transcribe(audio, length, 16000);
+```
+
+- OpenAI Whisper small, medium, large-v3, and large-v3-turbo exported through the sherpa-onnx encoder/decoder graph contract.
+- Native ONNX Runtime implementation in `speech_core_models`: Whisper log-mel frontend, encoder cross-attention KV, greedy decoder self-KV cache, metadata-driven language detection, and base64 token-table decoding.
+- Fixed language prompts are available with `Config.language` or `set_language("de")`; empty language auto-detects on multilingual models.
+- The default chunk size leaves room for sherpa-style tail padding, so long audio is processed in approximately 29.5 second windows.
+- Download helper:
+
+```bash
+scripts/download_whisper_onnx.sh turbo int8
+scripts/download_whisper_onnx.sh medium fp16
+```
+
+- Model files:
+  [soniqo/Whisper-Small-ONNX](https://huggingface.co/soniqo/Whisper-Small-ONNX),
+  [soniqo/Whisper-Medium-ONNX](https://huggingface.co/soniqo/Whisper-Medium-ONNX),
+  [soniqo/Whisper-Large-v3-ONNX](https://huggingface.co/soniqo/Whisper-Large-v3-ONNX),
+  [soniqo/Whisper-Large-v3-Turbo-ONNX](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX).
 
 ## LiteRTSileroVad
 

--- a/include/speech_core/models/onnx_whisper_stt.h
+++ b/include/speech_core/models/onnx_whisper_stt.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace speech_core {
+
+/// Whisper speech recognition for sherpa-onnx style encoder/decoder exports.
+class OnnxWhisperStt : public STTInterface {
+public:
+    struct Config {
+        int sample_rate = 16000;
+        int n_fft = 400;
+        int hop_length = 160;
+        int win_length = 400;
+
+        // sherpa-onnx pads feature frames after the actual audio so Whisper can
+        // emit EOT reliably. The encoder is capped at 3000 frames.
+        int max_feature_frames = 3000;
+        int reserve_tail_frames = 50;
+        int tail_padding_frames = 1000;
+
+        // Chunk long inputs before feature extraction. 0 uses
+        // (max_feature_frames - reserve_tail_frames) * hop_length.
+        size_t max_audio_samples = 0;
+
+        // Empty means auto-detect for multilingual models. Values are language
+        // codes from model metadata, e.g. "en", "de", "es", "zh".
+        std::string language;
+        std::string task = "transcribe";
+
+        // 0 uses sherpa's heuristic: min(audio_seconds * 6, n_text_ctx / 2).
+        int max_decode_tokens = 0;
+    };
+
+    OnnxWhisperStt(const std::string& encoder_path,
+                   const std::string& decoder_path,
+                   const std::string& tokens_path,
+                   bool hw_accel = true);
+
+    OnnxWhisperStt(const std::string& encoder_path,
+                   const std::string& decoder_path,
+                   const std::string& tokens_path,
+                   const Config& config,
+                   bool hw_accel = true);
+
+    ~OnnxWhisperStt() override;
+
+    TranscriptionResult transcribe(
+        const float* audio, size_t length, int sample_rate) override;
+
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+
+    /// Set a fixed language prompt. Passing an empty string re-enables
+    /// auto-detection on multilingual models.
+    bool set_language(const std::string& language);
+
+private:
+    struct Metadata {
+        int n_mels = 80;
+        int n_text_layer = 0;
+        int n_text_ctx = 0;
+        int n_text_state = 0;
+        int n_vocab = 0;
+        int sot = 50258;
+        int eot = 50257;
+        int transcribe = 50360;
+        int translate = 50359;
+        int no_timestamps = 50364;
+        int is_multilingual = 0;
+        std::vector<int64_t> sot_sequence;
+        std::vector<int32_t> all_language_tokens;
+        std::vector<std::string> all_language_codes;
+        std::unordered_map<std::string, int32_t> lang2id;
+        std::unordered_map<int32_t, std::string> id2lang;
+    };
+
+    struct DecodeResult {
+        std::string text;
+        std::string language;
+        float confidence = 1.0f;
+    };
+
+    void load_metadata();
+    void load_tokens(const std::string& path);
+
+    std::vector<float> compute_features(
+        const float* audio, size_t length, int* out_frames) const;
+    DecodeResult decode_chunk(const float* audio, size_t length);
+    int32_t detect_language(OrtValue* cross_k, OrtValue* cross_v);
+    DecodeResult decode_greedy(OrtValue* cross_k, OrtValue* cross_v,
+                               int num_feature_frames);
+
+    std::vector<float> make_mel_filterbank() const;
+    std::string decode_tokens(const std::vector<int32_t>& ids) const;
+
+    const OrtApi* api_ = nullptr;
+    OrtSession* encoder_ = nullptr;
+    OrtSession* decoder_ = nullptr;
+    Config cfg_;
+    Metadata meta_;
+    std::vector<std::string> token_table_;
+};
+
+}  // namespace speech_core

--- a/scripts/download_whisper_onnx.sh
+++ b/scripts/download_whisper_onnx.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${1:-turbo}"
+PRECISION="${2:-int8}"
+DEST="${3:-scripts/models/whisper-${MODEL}}"
+
+case "$MODEL" in
+  small)    REPO="soniqo/Whisper-Small-ONNX"; PREFIX="small" ;;
+  medium)   REPO="soniqo/Whisper-Medium-ONNX"; PREFIX="medium" ;;
+  large-v3) REPO="soniqo/Whisper-Large-v3-ONNX"; PREFIX="large-v3" ;;
+  turbo)    REPO="soniqo/Whisper-Large-v3-Turbo-ONNX"; PREFIX="turbo" ;;
+  *)
+    echo "Usage: $0 [small|medium|large-v3|turbo] [int8|fp16|fp32|all] [dest]" >&2
+    exit 2
+    ;;
+esac
+
+case "$PRECISION" in
+  int8|fp16|fp32|all) ;;
+  *)
+    echo "precision must be int8, fp16, fp32, or all" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$DEST"
+
+AUTH_ARGS=()
+if [ -n "${HF_TOKEN:-}" ]; then
+  AUTH_ARGS=(-H "Authorization: Bearer ${HF_TOKEN}")
+fi
+
+download() {
+  local name="$1"
+  local required="${2:-1}"
+  local url="https://huggingface.co/${REPO}/resolve/main/${name}"
+  local out="${DEST}/${name}"
+  if [ -f "$out" ]; then
+    echo "exists ${out}"
+    return
+  fi
+  echo "download ${REPO}/${name}"
+  if ! curl -L --fail --retry 3 "${AUTH_ARGS[@]}" -o "${out}.part" "$url"; then
+    rm -f "${out}.part"
+    if [ "$required" = "1" ]; then
+      exit 1
+    fi
+    echo "optional missing ${name}"
+    return
+  fi
+  mv "${out}.part" "$out"
+}
+
+download README.md 0
+download manifest.json 1
+download "${PREFIX}-tokens.txt" 1
+
+download_precision() {
+  local p="$1"
+  case "$p" in
+    int8)
+      download "${PREFIX}-encoder.int8.onnx" 1
+      download "${PREFIX}-decoder.int8.onnx" 1
+      ;;
+    fp16)
+      download "${PREFIX}-encoder.fp16.onnx" 1
+      download "${PREFIX}-encoder.fp16.onnx.data" 1
+      download "${PREFIX}-decoder.fp16.onnx" 1
+      download "${PREFIX}-decoder.fp16.onnx.data" 1
+      ;;
+    fp32)
+      download "${PREFIX}-encoder.onnx" 1
+      download "${PREFIX}-decoder.onnx" 1
+      download "${PREFIX}-encoder.weights" 0
+      download "${PREFIX}-decoder.weights" 0
+      ;;
+  esac
+}
+
+if [ "$PRECISION" = "all" ]; then
+  download_precision int8
+  download_precision fp16
+  download_precision fp32
+else
+  download_precision "$PRECISION"
+fi
+
+echo
+echo "Whisper ONNX bundle ready: ${DEST}"
+echo "Example:"
+echo "  SPEECH_WHISPER_ONNX_DIR=${DEST} SPEECH_MODEL_DIR=${DEST} ctest --test-dir build --output-on-failure"

--- a/src/models/whisper/onnx_whisper_stt.cpp
+++ b/src/models/whisper/onnx_whisper_stt.cpp
@@ -1,0 +1,719 @@
+#include "speech_core/models/onnx_whisper_stt.h"
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_engine.h"
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace speech_core {
+
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+struct OrtValueHandle {
+    const OrtApi* api = nullptr;
+    OrtValue* value = nullptr;
+
+    OrtValueHandle() = default;
+    OrtValueHandle(const OrtApi* a, OrtValue* v) : api(a), value(v) {}
+    ~OrtValueHandle() { reset(); }
+
+    OrtValueHandle(const OrtValueHandle&) = delete;
+    OrtValueHandle& operator=(const OrtValueHandle&) = delete;
+
+    OrtValueHandle(OrtValueHandle&& other) noexcept
+        : api(other.api), value(other.value) {
+        other.value = nullptr;
+    }
+    OrtValueHandle& operator=(OrtValueHandle&& other) noexcept {
+        if (this != &other) {
+            reset();
+            api = other.api;
+            value = other.value;
+            other.value = nullptr;
+        }
+        return *this;
+    }
+
+    OrtValue* get() const { return value; }
+    OrtValue* release() {
+        OrtValue* v = value;
+        value = nullptr;
+        return v;
+    }
+    void reset(OrtValue* v = nullptr) {
+        if (value && api) api->ReleaseValue(value);
+        value = v;
+    }
+};
+
+struct MetadataHandle {
+    const OrtApi* api = nullptr;
+    OrtModelMetadata* value = nullptr;
+    ~MetadataHandle() { if (value && api) api->ReleaseModelMetadata(value); }
+};
+
+std::string trim(std::string s) {
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    auto b = std::find_if(s.begin(), s.end(), not_space);
+    auto e = std::find_if(s.rbegin(), s.rend(), not_space).base();
+    if (b >= e) return {};
+    return std::string(b, e);
+}
+
+std::string normalize_language(std::string s) {
+    s = trim(std::move(s));
+    auto dash = s.find('-');
+    if (dash != std::string::npos) s.resize(dash);
+    for (char& c : s) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return s;
+}
+
+int base64_ord(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+std::string base64_decode(const std::string& s) {
+    if (s.empty()) return {};
+    std::string out;
+    out.reserve(s.size() / 4 * 3);
+
+    for (size_t i = 0; i < s.size(); i += 4) {
+        if (s[i] == '=') return " ";
+        if (i + 1 >= s.size()) break;
+        int a = base64_ord(s[i]);
+        int b = base64_ord(s[i + 1]);
+        if (a < 0 || b < 0) break;
+        out.push_back(static_cast<char>((a << 2) | ((b & 0x30) >> 4)));
+
+        if (i + 2 < s.size() && s[i + 2] != '=') {
+            int c = base64_ord(s[i + 2]);
+            if (c < 0) break;
+            out.push_back(static_cast<char>(((b & 0x0f) << 4) | ((c & 0x3c) >> 2)));
+
+            if (i + 3 < s.size() && s[i + 3] != '=') {
+                int d = base64_ord(s[i + 3]);
+                if (d < 0) break;
+                out.push_back(static_cast<char>(((c & 0x03) << 6) | d));
+            }
+        }
+    }
+    return out;
+}
+
+std::vector<int64_t> parse_i64_list(const std::string& s) {
+    std::vector<int64_t> out;
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        item = trim(item);
+        if (!item.empty()) out.push_back(std::stoll(item));
+    }
+    return out;
+}
+
+std::vector<int32_t> parse_i32_list(const std::string& s) {
+    std::vector<int32_t> out;
+    for (int64_t v : parse_i64_list(s)) {
+        out.push_back(static_cast<int32_t>(v));
+    }
+    return out;
+}
+
+std::vector<std::string> parse_string_list(const std::string& s) {
+    std::vector<std::string> out;
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        item = trim(item);
+        if (!item.empty()) out.push_back(item);
+    }
+    return out;
+}
+
+std::vector<int64_t> tensor_shape(const OrtApi* api, OrtValue* value) {
+    OrtTensorTypeAndShapeInfo* info = nullptr;
+    ort_check(api, api->GetTensorTypeAndShape(value, &info));
+    size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(info, &rank));
+    std::vector<int64_t> shape(rank);
+    ort_check(api, api->GetDimensions(info, shape.data(), rank));
+    api->ReleaseTensorTypeAndShapeInfo(info);
+    return shape;
+}
+
+OrtValueHandle make_f32_tensor(
+    const OrtApi* api, OrtMemoryInfo* mem, float* data, size_t count,
+    const int64_t* shape, size_t rank) {
+    OrtValue* v = nullptr;
+    ort_check(api, api->CreateTensorWithDataAsOrtValue(
+        mem, data, count * sizeof(float), shape, rank,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &v));
+    return OrtValueHandle(api, v);
+}
+
+OrtValueHandle make_i64_tensor(
+    const OrtApi* api, OrtMemoryInfo* mem, int64_t* data, size_t count,
+    const int64_t* shape, size_t rank) {
+    OrtValue* v = nullptr;
+    ort_check(api, api->CreateTensorWithDataAsOrtValue(
+        mem, data, count * sizeof(int64_t), shape, rank,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &v));
+    return OrtValueHandle(api, v);
+}
+
+int argmax(const float* values, int n) {
+    int best = 0;
+    float best_value = -std::numeric_limits<float>::infinity();
+    for (int i = 0; i < n; ++i) {
+        float v = values[i];
+        if (std::isnan(v)) continue;
+        if (v > best_value) {
+            best_value = v;
+            best = i;
+        }
+    }
+    return best;
+}
+
+}  // namespace
+
+OnnxWhisperStt::OnnxWhisperStt(
+    const std::string& encoder_path,
+    const std::string& decoder_path,
+    const std::string& tokens_path,
+    bool hw_accel)
+    : OnnxWhisperStt(encoder_path, decoder_path, tokens_path, Config{}, hw_accel) {}
+
+OnnxWhisperStt::OnnxWhisperStt(
+    const std::string& encoder_path,
+    const std::string& decoder_path,
+    const std::string& tokens_path,
+    const Config& config,
+    bool hw_accel)
+    : cfg_(config)
+{
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    encoder_ = engine.load(encoder_path, hw_accel);
+    // Without IO binding, each decoder step would copy the full self-KV cache
+    // between host and accelerator. Keep the AR decoder on CPU by default.
+    decoder_ = engine.load(decoder_path, false);
+
+    load_metadata();
+    load_tokens(tokens_path);
+
+    if (cfg_.max_audio_samples == 0) {
+        int frames = std::max(1, cfg_.max_feature_frames - cfg_.reserve_tail_frames);
+        cfg_.max_audio_samples = static_cast<size_t>(frames * cfg_.hop_length);
+    }
+
+    if (!cfg_.language.empty() && !set_language(cfg_.language)) {
+        throw std::runtime_error("Unsupported Whisper language: " + cfg_.language);
+    }
+
+    LOGI("Whisper ONNX: mels=%d vocab=%d text_layers=%d text_ctx=%d tokens=%zu",
+         meta_.n_mels, meta_.n_vocab, meta_.n_text_layer, meta_.n_text_ctx,
+         token_table_.size());
+}
+
+OnnxWhisperStt::~OnnxWhisperStt() {
+    if (decoder_) api_->ReleaseSession(decoder_);
+    if (encoder_) api_->ReleaseSession(encoder_);
+}
+
+bool OnnxWhisperStt::set_language(const std::string& language) {
+    std::string normalized = normalize_language(language);
+    if (normalized.empty()) {
+        cfg_.language.clear();
+        return true;
+    }
+    if (!meta_.lang2id.empty() && !meta_.lang2id.count(normalized)) {
+        return false;
+    }
+    cfg_.language = std::move(normalized);
+    return true;
+}
+
+void OnnxWhisperStt::load_metadata() {
+    OrtAllocator* allocator = nullptr;
+    ort_check(api_, api_->GetAllocatorWithDefaultOptions(&allocator));
+
+    MetadataHandle meta{api_, nullptr};
+    ort_check(api_, api_->SessionGetModelMetadata(encoder_, &meta.value));
+
+    auto get = [&](const char* key) -> std::string {
+        char* raw = nullptr;
+        ort_check(api_, api_->ModelMetadataLookupCustomMetadataMap(
+            meta.value, allocator, key, &raw));
+        if (!raw) return {};
+        std::string value(raw);
+        ort_check(api_, api_->AllocatorFree(allocator, raw));
+        return value;
+    };
+    auto get_int = [&](const char* key, int fallback) -> int {
+        std::string v = get(key);
+        if (v.empty()) return fallback;
+        return std::stoi(v);
+    };
+
+    meta_.n_mels = get_int("n_mels", meta_.n_mels);
+    meta_.n_text_layer = get_int("n_text_layer", meta_.n_text_layer);
+    meta_.n_text_ctx = get_int("n_text_ctx", meta_.n_text_ctx);
+    meta_.n_text_state = get_int("n_text_state", meta_.n_text_state);
+    meta_.n_vocab = get_int("n_vocab", meta_.n_vocab);
+    meta_.sot = get_int("sot", meta_.sot);
+    meta_.eot = get_int("eot", meta_.eot);
+    meta_.transcribe = get_int("transcribe", meta_.transcribe);
+    meta_.translate = get_int("translate", meta_.translate);
+    meta_.no_timestamps = get_int("no_timestamps", meta_.no_timestamps);
+    meta_.is_multilingual = get_int("is_multilingual", meta_.is_multilingual);
+
+    meta_.sot_sequence = parse_i64_list(get("sot_sequence"));
+    if (meta_.sot_sequence.empty()) {
+        meta_.sot_sequence = {meta_.sot, 50259, meta_.transcribe};
+    }
+
+    meta_.all_language_tokens = parse_i32_list(get("all_language_tokens"));
+    meta_.all_language_codes = parse_string_list(get("all_language_codes"));
+    const size_t n = std::min(meta_.all_language_tokens.size(),
+                              meta_.all_language_codes.size());
+    for (size_t i = 0; i < n; ++i) {
+        std::string code = normalize_language(meta_.all_language_codes[i]);
+        int32_t id = meta_.all_language_tokens[i];
+        meta_.lang2id[code] = id;
+        meta_.id2lang[id] = code;
+    }
+}
+
+void OnnxWhisperStt::load_tokens(const std::string& path) {
+    std::string text = json::read_file(path);
+    if (text.empty()) {
+        throw std::runtime_error("Unable to read Whisper token file: " + path);
+    }
+
+    std::istringstream in(text);
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.empty()) continue;
+        std::istringstream ls(line);
+        std::string encoded;
+        int id = -1;
+        if (!(ls >> encoded >> id) || id < 0) continue;
+        if (static_cast<size_t>(id) >= token_table_.size()) {
+            token_table_.resize(static_cast<size_t>(id) + 1);
+        }
+        token_table_[static_cast<size_t>(id)] = base64_decode(encoded);
+    }
+    if (token_table_.empty()) {
+        throw std::runtime_error("Whisper token file has no usable entries: " + path);
+    }
+}
+
+std::vector<float> OnnxWhisperStt::make_mel_filterbank() const {
+    const int n_bins = cfg_.n_fft / 2 + 1;
+    const int n_mels = meta_.n_mels;
+
+    auto hz_to_mel = [](float hz) {
+        constexpr float f_sp = 200.0f / 3.0f;
+        constexpr float min_log_hz = 1000.0f;
+        constexpr float min_log_mel = min_log_hz / f_sp;
+        const float logstep = std::log(6.4f) / 27.0f;
+        if (hz < min_log_hz) return hz / f_sp;
+        return min_log_mel + std::log(hz / min_log_hz) / logstep;
+    };
+    auto mel_to_hz = [](float mel) {
+        constexpr float f_sp = 200.0f / 3.0f;
+        constexpr float min_log_hz = 1000.0f;
+        constexpr float min_log_mel = min_log_hz / f_sp;
+        const float logstep = std::log(6.4f) / 27.0f;
+        if (mel < min_log_mel) return f_sp * mel;
+        return min_log_hz * std::exp(logstep * (mel - min_log_mel));
+    };
+
+    std::vector<float> fft_freqs(n_bins);
+    for (int i = 0; i < n_bins; ++i) {
+        fft_freqs[i] = static_cast<float>(i * cfg_.sample_rate) / cfg_.n_fft;
+    }
+
+    std::vector<float> hz_points(n_mels + 2);
+    float mel_min = hz_to_mel(0.0f);
+    float mel_max = hz_to_mel(static_cast<float>(cfg_.sample_rate) / 2.0f);
+    for (int i = 0; i < n_mels + 2; ++i) {
+        float t = static_cast<float>(i) / static_cast<float>(n_mels + 1);
+        hz_points[i] = mel_to_hz(mel_min + (mel_max - mel_min) * t);
+    }
+
+    std::vector<float> fb(n_mels * n_bins, 0.0f);
+    for (int m = 0; m < n_mels; ++m) {
+        float left = hz_points[m];
+        float center = hz_points[m + 1];
+        float right = hz_points[m + 2];
+        float enorm = 2.0f / std::max(right - left, 1e-12f);
+        for (int b = 0; b < n_bins; ++b) {
+            float hz = fft_freqs[b];
+            float v = 0.0f;
+            if (hz >= left && hz <= center) {
+                v = (hz - left) / std::max(center - left, 1e-12f);
+            } else if (hz > center && hz <= right) {
+                v = (right - hz) / std::max(right - center, 1e-12f);
+            }
+            fb[m * n_bins + b] = v * enorm;
+        }
+    }
+    return fb;
+}
+
+std::vector<float> OnnxWhisperStt::compute_features(
+    const float* audio, size_t length, int* out_frames) const {
+    *out_frames = 0;
+    if (!audio || length == 0) return {};
+
+    const int pad = cfg_.n_fft / 2;
+    std::vector<float> padded(length + 2 * static_cast<size_t>(pad), 0.0f);
+    for (int i = 0; i < pad; ++i) {
+        size_t src = std::min(static_cast<size_t>(pad - i), length - 1);
+        padded[static_cast<size_t>(i)] = audio[src];
+    }
+    std::copy(audio, audio + length, padded.begin() + pad);
+    for (int i = 0; i < pad; ++i) {
+        int src = static_cast<int>(length) - 2 - i;
+        padded[static_cast<size_t>(pad) + length + static_cast<size_t>(i)] =
+            audio[static_cast<size_t>(std::max(src, 0))];
+    }
+
+    int n_frames_all = static_cast<int>(
+        (padded.size() - static_cast<size_t>(cfg_.n_fft)) / cfg_.hop_length) + 1;
+    int n_frames = std::max(0, n_frames_all - 1);
+    if (n_frames == 0) return {};
+
+    const int n_bins = cfg_.n_fft / 2 + 1;
+    const int n_mels = meta_.n_mels;
+    std::vector<float> window(cfg_.win_length);
+    for (int i = 0; i < cfg_.win_length; ++i) {
+        window[i] = 0.5f * (1.0f - std::cos(2.0f * kPi * i / cfg_.win_length));
+    }
+
+    std::vector<float> cos_table(n_bins * cfg_.n_fft);
+    std::vector<float> sin_table(n_bins * cfg_.n_fft);
+    for (int k = 0; k < n_bins; ++k) {
+        for (int n = 0; n < cfg_.n_fft; ++n) {
+            float angle = 2.0f * kPi * static_cast<float>(k * n) / cfg_.n_fft;
+            cos_table[k * cfg_.n_fft + n] = std::cos(angle);
+            sin_table[k * cfg_.n_fft + n] = std::sin(angle);
+        }
+    }
+
+    auto fb = make_mel_filterbank();
+    std::vector<float> frame(cfg_.n_fft, 0.0f);
+    std::vector<float> power(n_bins, 0.0f);
+    std::vector<float> mel(n_frames * n_mels, 0.0f);
+
+    for (int t = 0; t < n_frames; ++t) {
+        std::fill(frame.begin(), frame.end(), 0.0f);
+        size_t start = static_cast<size_t>(t * cfg_.hop_length);
+        for (int i = 0; i < cfg_.win_length; ++i) {
+            frame[i] = padded[start + static_cast<size_t>(i)] * window[i];
+        }
+
+        for (int k = 0; k < n_bins; ++k) {
+            const float* c = cos_table.data() + k * cfg_.n_fft;
+            const float* s = sin_table.data() + k * cfg_.n_fft;
+            float re = 0.0f;
+            float im = 0.0f;
+            for (int n = 0; n < cfg_.n_fft; ++n) {
+                re += frame[n] * c[n];
+                im -= frame[n] * s[n];
+            }
+            power[k] = re * re + im * im;
+        }
+
+        for (int m = 0; m < n_mels; ++m) {
+            float sum = 0.0f;
+            const float* filt = fb.data() + m * n_bins;
+            for (int k = 0; k < n_bins; ++k) sum += power[k] * filt[k];
+            mel[t * n_mels + m] = std::max(sum, 1e-10f);
+        }
+    }
+
+    float max_log = -std::numeric_limits<float>::infinity();
+    for (float& v : mel) {
+        v = std::log10(v);
+        if (v > max_log) max_log = v;
+    }
+    float floor = max_log - 8.0f;
+    for (float& v : mel) {
+        v = (std::max(v, floor) + 4.0f) / 4.0f;
+    }
+
+    *out_frames = n_frames;
+    return mel;
+}
+
+TranscriptionResult OnnxWhisperStt::transcribe(
+    const float* audio, size_t length, int sample_rate) {
+    TranscriptionResult out;
+    if (!audio || length == 0) return out;
+
+    std::vector<float> converted;
+    const float* pcm = audio;
+    size_t pcm_len = length;
+    if (sample_rate <= 0) sample_rate = cfg_.sample_rate;
+    if (sample_rate != cfg_.sample_rate) {
+        converted = Resampler::resample(audio, length, sample_rate, cfg_.sample_rate);
+        pcm = converted.data();
+        pcm_len = converted.size();
+    }
+
+    std::vector<std::string> texts;
+    std::string language;
+    size_t offset = 0;
+    const size_t chunk = std::max<size_t>(1, cfg_.max_audio_samples);
+    while (offset < pcm_len) {
+        size_t n = std::min(chunk, pcm_len - offset);
+        auto r = decode_chunk(pcm + offset, n);
+        if (!r.text.empty()) texts.push_back(std::move(r.text));
+        if (language.empty()) language = std::move(r.language);
+        offset += n;
+    }
+
+    std::string text;
+    for (const auto& part : texts) {
+        if (!text.empty()) text += ' ';
+        text += part;
+    }
+    out.text = trim(std::move(text));
+    out.language = std::move(language);
+    out.confidence = 1.0f;
+    out.end_time = static_cast<float>(length) / static_cast<float>(sample_rate);
+    return out;
+}
+
+OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_chunk(
+    const float* audio, size_t length) {
+    int num_frames = 0;
+    std::vector<float> features = compute_features(audio, length, &num_frames);
+    if (features.empty() || num_frames <= 0) return {};
+
+    const int max_real_frames =
+        std::max(1, cfg_.max_feature_frames - cfg_.reserve_tail_frames);
+    if (num_frames >= max_real_frames) num_frames = max_real_frames;
+
+    const int actual_frames = std::min(
+        cfg_.max_feature_frames, num_frames + std::max(0, cfg_.tail_padding_frames));
+
+    std::vector<float> mel(static_cast<size_t>(meta_.n_mels) * actual_frames, 0.0f);
+    for (int t = 0; t < num_frames; ++t) {
+        for (int m = 0; m < meta_.n_mels; ++m) {
+            mel[static_cast<size_t>(m) * actual_frames + t] =
+                features[static_cast<size_t>(t) * meta_.n_mels + m];
+        }
+    }
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+    int64_t mel_shape[] = {1, static_cast<int64_t>(meta_.n_mels),
+                           static_cast<int64_t>(actual_frames)};
+    auto t_mel = make_f32_tensor(api_, mem, mel.data(), mel.size(), mel_shape, 3);
+
+    const char* enc_in[] = {"mel"};
+    const char* enc_out[] = {"n_layer_cross_k", "n_layer_cross_v"};
+    OrtValue* enc_inputs[] = {t_mel.get()};
+    OrtValue* enc_outputs[] = {nullptr, nullptr};
+    ort_check(api_, api_->Run(encoder_, nullptr, enc_in, enc_inputs, 1,
+                              enc_out, 2, enc_outputs));
+
+    OrtValueHandle cross_k(api_, enc_outputs[0]);
+    OrtValueHandle cross_v(api_, enc_outputs[1]);
+    return decode_greedy(cross_k.get(), cross_v.get(), num_frames);
+}
+
+int32_t OnnxWhisperStt::detect_language(OrtValue* cross_k, OrtValue* cross_v) {
+    if (meta_.all_language_tokens.empty()) {
+        return meta_.sot_sequence.size() > 1
+            ? static_cast<int32_t>(meta_.sot_sequence[1])
+            : 50259;
+    }
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+    std::vector<float> self_k(static_cast<size_t>(meta_.n_text_layer)
+                              * meta_.n_text_ctx * meta_.n_text_state, 0.0f);
+    std::vector<float> self_v(self_k.size(), 0.0f);
+    int64_t cache_shape[] = {meta_.n_text_layer, 1, meta_.n_text_ctx, meta_.n_text_state};
+    auto t_self_k = make_f32_tensor(api_, mem, self_k.data(), self_k.size(), cache_shape, 4);
+    auto t_self_v = make_f32_tensor(api_, mem, self_v.data(), self_v.size(), cache_shape, 4);
+
+    int64_t token = meta_.sot;
+    int64_t token_shape[] = {1, 1};
+    auto t_tokens = make_i64_tensor(api_, mem, &token, 1, token_shape, 2);
+    int64_t offset = 0;
+    int64_t offset_shape[] = {1};
+    auto t_offset = make_i64_tensor(api_, mem, &offset, 1, offset_shape, 1);
+
+    const char* dec_in[] = {
+        "tokens", "in_n_layer_self_k_cache", "in_n_layer_self_v_cache",
+        "n_layer_cross_k", "n_layer_cross_v", "offset",
+    };
+    const char* dec_out[] = {
+        "logits", "out_n_layer_self_k_cache", "out_n_layer_self_v_cache",
+    };
+    OrtValue* inputs[] = {
+        t_tokens.get(), t_self_k.get(), t_self_v.get(),
+        cross_k, cross_v, t_offset.get(),
+    };
+    OrtValue* outputs[] = {nullptr, nullptr, nullptr};
+    ort_check(api_, api_->Run(decoder_, nullptr, dec_in, inputs, 6,
+                              dec_out, 3, outputs));
+    OrtValueHandle logits(api_, outputs[0]);
+    OrtValueHandle out_k(api_, outputs[1]);
+    OrtValueHandle out_v(api_, outputs[2]);
+
+    float* p = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(logits.get(), reinterpret_cast<void**>(&p)));
+    int32_t best = meta_.all_language_tokens[0];
+    float best_logit = p[best];
+    for (int32_t id : meta_.all_language_tokens) {
+        if (id >= 0 && id < meta_.n_vocab && p[id] > best_logit) {
+            best_logit = p[id];
+            best = id;
+        }
+    }
+    return best;
+}
+
+OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
+    OrtValue* cross_k, OrtValue* cross_v, int num_feature_frames) {
+    DecodeResult result;
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    std::vector<int64_t> initial = meta_.sot_sequence;
+    int32_t language_token = 0;
+    if (meta_.is_multilingual && initial.size() >= 2) {
+        if (!cfg_.language.empty()) {
+            auto it = meta_.lang2id.find(cfg_.language);
+            if (it == meta_.lang2id.end()) {
+                throw std::runtime_error("Unsupported Whisper language: " + cfg_.language);
+            }
+            language_token = it->second;
+        } else {
+            language_token = detect_language(cross_k, cross_v);
+        }
+        initial[1] = language_token;
+        auto lang = meta_.id2lang.find(language_token);
+        if (lang != meta_.id2lang.end()) result.language = lang->second;
+
+        if (initial.size() >= 3 && cfg_.task == "translate") {
+            initial[2] = meta_.translate;
+        } else if (cfg_.task != "transcribe") {
+            throw std::runtime_error("Unsupported Whisper task: " + cfg_.task);
+        }
+    }
+    initial.push_back(meta_.no_timestamps);
+
+    std::vector<float> self_k(static_cast<size_t>(meta_.n_text_layer)
+                              * meta_.n_text_ctx * meta_.n_text_state, 0.0f);
+    std::vector<float> self_v(self_k.size(), 0.0f);
+    int64_t cache_shape[] = {meta_.n_text_layer, 1, meta_.n_text_ctx, meta_.n_text_state};
+    OrtValueHandle t_self_k = make_f32_tensor(
+        api_, mem, self_k.data(), self_k.size(), cache_shape, 4);
+    OrtValueHandle t_self_v = make_f32_tensor(
+        api_, mem, self_v.data(), self_v.size(), cache_shape, 4);
+
+    const char* dec_in[] = {
+        "tokens", "in_n_layer_self_k_cache", "in_n_layer_self_v_cache",
+        "n_layer_cross_k", "n_layer_cross_v", "offset",
+    };
+    const char* dec_out[] = {
+        "logits", "out_n_layer_self_k_cache", "out_n_layer_self_v_cache",
+    };
+
+    auto run_decoder = [&](int64_t* tokens, size_t token_count, int64_t offset)
+        -> std::pair<OrtValueHandle, int32_t> {
+        int64_t token_shape[] = {1, static_cast<int64_t>(token_count)};
+        auto t_tokens = make_i64_tensor(api_, mem, tokens, token_count, token_shape, 2);
+        int64_t offset_shape[] = {1};
+        auto t_offset = make_i64_tensor(api_, mem, &offset, 1, offset_shape, 1);
+
+        OrtValue* inputs[] = {
+            t_tokens.get(), t_self_k.get(), t_self_v.get(),
+            cross_k, cross_v, t_offset.get(),
+        };
+        OrtValue* outputs[] = {nullptr, nullptr, nullptr};
+        ort_check(api_, api_->Run(decoder_, nullptr, dec_in, inputs, 6,
+                                  dec_out, 3, outputs));
+
+        OrtValueHandle logits(api_, outputs[0]);
+        OrtValueHandle next_k(api_, outputs[1]);
+        OrtValueHandle next_v(api_, outputs[2]);
+
+        auto shape = tensor_shape(api_, logits.get());
+        int vocab = (shape.size() >= 3 && shape[2] > 0)
+            ? static_cast<int>(shape[2])
+            : meta_.n_vocab;
+        int positions = (shape.size() >= 2 && shape[1] > 0)
+            ? static_cast<int>(shape[1])
+            : 1;
+        float* p = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(
+            logits.get(), reinterpret_cast<void**>(&p)));
+        int32_t next = argmax(p + static_cast<size_t>(positions - 1) * vocab, vocab);
+
+        t_self_k.reset(next_k.release());
+        t_self_v.reset(next_v.release());
+        return {std::move(logits), next};
+    };
+
+    auto first = run_decoder(initial.data(), initial.size(), 0);
+    (void)first.first;
+    int32_t next_token = first.second;
+
+    int limit = static_cast<int>(num_feature_frames / 100.0f * 6.0f);
+    if (meta_.n_text_ctx > 0) limit = std::min(limit, meta_.n_text_ctx / 2);
+    if (cfg_.max_decode_tokens > 0) limit = std::min(limit, cfg_.max_decode_tokens);
+
+    std::vector<int32_t> generated;
+    generated.reserve(static_cast<size_t>(std::max(limit, 0)));
+    int64_t offset = static_cast<int64_t>(initial.size());
+
+    for (int i = 0; i < limit; ++i) {
+        if (next_token == meta_.eot) break;
+        generated.push_back(next_token);
+
+        int64_t token = next_token;
+        auto step = run_decoder(&token, 1, offset);
+        (void)step.first;
+        next_token = step.second;
+        ++offset;
+        if (offset >= meta_.n_text_ctx - 1) break;
+    }
+
+    result.text = decode_tokens(generated);
+    return result;
+}
+
+std::string OnnxWhisperStt::decode_tokens(const std::vector<int32_t>& ids) const {
+    std::string text;
+    for (int32_t id : ids) {
+        if (id < 0 || static_cast<size_t>(id) >= token_table_.size()) continue;
+        text += token_table_[static_cast<size_t>(id)];
+    }
+    return trim(std::move(text));
+}
+
+}  // namespace speech_core

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -20,6 +20,7 @@
 #include "speech_core/models/kokoro_tts.h"
 #include "speech_core/models/onnx_engine.h"
 #include "speech_core/models/onnx_cosyvoice3_tts.h"
+#include "speech_core/models/onnx_whisper_stt.h"
 #include "speech_core/models/onnx_sidon_restorer.h"
 #include "speech_core/models/onnx_voxcpm2_tts.h"
 #include "speech_core/models/onnx_personaplex.h"
@@ -317,6 +318,60 @@ void test_parakeet_stt(const std::string& dir) {
 
     std::printf("ok (silence text=\"%s\" conf=%.3f)\n",
                 result.text.c_str(), result.confidence);
+}
+
+// ---------------------------------------------------------------------------
+
+void test_onnx_whisper_stt(const std::string& dir) {
+    const char* override_dir = std::getenv("SPEECH_WHISPER_ONNX_DIR");
+    std::string root = override_dir ? override_dir : dir;
+
+    struct Candidate { const char* prefix; const char* suffix; };
+    const Candidate candidates[] = {
+        {"turbo", ".int8"},
+        {"large-v3", ".int8"},
+        {"medium", ".int8"},
+        {"small", ".int8"},
+        {"turbo", ""},
+        {"large-v3", ""},
+        {"medium", ""},
+        {"small", ""},
+    };
+
+    std::string enc;
+    std::string dec;
+    std::string tok;
+    for (const auto& c : candidates) {
+        std::string e = root + "/" + c.prefix + "-encoder" + c.suffix + ".onnx";
+        std::string d = root + "/" + c.prefix + "-decoder" + c.suffix + ".onnx";
+        std::string t = root + "/" + c.prefix + "-tokens.txt";
+        if (file_exists(e) && file_exists(d) && file_exists(t)) {
+            enc = std::move(e);
+            dec = std::move(d);
+            tok = std::move(t);
+            break;
+        }
+    }
+    if (enc.empty()) {
+        std::printf("  [skip] whisper ONNX bundle not in %s\n", root.c_str());
+        return;
+    }
+
+    std::printf("  test_onnx_whisper_stt ... ");
+    speech_core::OnnxWhisperStt::Config cfg;
+    cfg.language = "en";
+    cfg.max_decode_tokens = 4;
+    cfg.tail_padding_frames = 50;
+    speech_core::OnnxWhisperStt stt(enc, dec, tok, cfg, /*hw_accel=*/false);
+    REQUIRE(stt.input_sample_rate() == 16000);
+
+    std::vector<float> silence(16000, 0.0f);
+    auto result = stt.transcribe(silence.data(), silence.size(), 16000);
+    REQUIRE(result.confidence >= 0.0f && result.confidence <= 1.0f);
+    REQUIRE(result.language.empty() || result.language == "en");
+
+    std::printf("ok (silence text=\"%.40s\" lang=%s)\n",
+                result.text.c_str(), result.language.c_str());
 }
 
 // ---------------------------------------------------------------------------
@@ -1098,6 +1153,7 @@ int main() {
     RUN(test_silero_vad);
     RUN(test_silero_vad_real_speech);
     RUN(test_parakeet_stt);
+    RUN(test_onnx_whisper_stt);
     RUN(test_nemotron_multilingual_stt);
     RUN(test_kokoro_tts);
     RUN(test_deepfilter);


### PR DESCRIPTION
## Summary
- Add a native ONNX Runtime Whisper STT implementation for the exported soniqo Whisper small/medium/large-v3/turbo graphs.
- Add the public API header, CMake integration, model smoke coverage, and a Hugging Face download helper.
- Document the new ONNX Whisper backend and supported model repositories.

## Test plan
- `cmake --build /tmp/speech-core-build-default -j2`
- `cmake --build /tmp/speech-core-build-onnx -j2`
- `ctest --test-dir /tmp/speech-core-build-default --output-on-failure`
- `DYLD_LIBRARY_PATH=/tmp/ort-macos-arm64/lib ctest --test-dir /tmp/speech-core-build-onnx --output-on-failure`
- `bash -n scripts/download_whisper_onnx.sh`
- `DYLD_LIBRARY_PATH=/tmp/ort-macos-arm64/lib SPEECH_MODEL_DIR=/tmp/whisper-onnx-turbo-int8 SPEECH_WHISPER_ONNX_DIR=/tmp/whisper-onnx-turbo-int8 /tmp/speech-core-build-onnx/test_models`