### PR TITLE
Add Whisper ONNX profiling and tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,16 @@ scripts/download_models_litert.sh            # public soniqo/* models, no token
 scripts/download_whisper_onnx.sh turbo int8  # optional large Whisper bundle
 cmake -B build -DSPEECH_CORE_WITH_LITERT=ON -DLITERT_DIR=$PWD/build/litert && cmake --build build
 SPEECH_LITERT_MODEL_DIR=scripts/models-litert ctest --test-dir build --output-on-failure
+
+# Optional Whisper ONNX CPU latency/RSS benchmark.
+cmake -B build-onnx -DSPEECH_CORE_WITH_ONNX=ON -DORT_DIR=/path/to/onnxruntime
+cmake --build build-onnx --target bench_ort_models
+SPEECH_MODEL_DIR=scripts/models/whisper-turbo \
+SPEECH_WHISPER_ONNX_DIR=scripts/models/whisper-turbo \
+SPEECH_BENCH_ONLY=whisper \
+SPEECH_WHISPER_BENCH_CONFIG=en-tail50 \
+SPEECH_CORE_WHISPER_ORT_THREADS=16 \
+./build-onnx/bench_ort_models
 ```
 
 CI builds + tests across **Linux, Windows, and macOS** (LiteRT on Linux + Windows, ONNX on Linux), plus an **aarch64** cross-compile; a **nightly** lane runs the model integration tests against the public model files.

--- a/docs/models.md
+++ b/docs/models.md
@@ -186,12 +186,36 @@ speech_core::OnnxWhisperStt stt(
     "/models/whisper-turbo/turbo-tokens.txt");
 
 auto result = stt.transcribe(audio, length, 16000);
+auto profile = stt.last_profile();
 ```
 
 - OpenAI Whisper small, medium, large-v3, and large-v3-turbo exported through the sherpa-onnx encoder/decoder graph contract.
 - Native ONNX Runtime implementation in `speech_core_models`: Whisper log-mel frontend, encoder cross-attention KV, greedy decoder self-KV cache, metadata-driven language detection, and base64 token-table decoding.
 - Fixed language prompts are available with `Config.language` or `set_language("de")`; empty language auto-detects on multilingual models.
 - The default chunk size leaves room for sherpa-style tail padding, so long audio is processed in approximately 29.5 second windows.
+- `last_profile()` reports the most recent transcription's total, feature, encoder, language-detection, first-token, and decoder timings.
+- CPU Whisper uses larger encoder matmuls than the short-call ONNX models. Keep the global `SPEECH_CORE_ORT_THREADS` default conservative for those models, and tune Whisper separately with `Config.intra_threads` or `SPEECH_CORE_WHISPER_ORT_THREADS`.
+- Low-latency fixed-language usage typically sets `Config.language`, lowers `Config.tail_padding_frames` after WER validation, and raises `Config.intra_threads` on CPU:
+
+```cpp
+speech_core::OnnxWhisperStt::Config cfg;
+cfg.language = "en";
+cfg.tail_padding_frames = 50;
+cfg.intra_threads = 16;
+speech_core::OnnxWhisperStt stt(enc, dec, tok, cfg);
+```
+
+- Whisper benchmark:
+
+```bash
+SPEECH_MODEL_DIR=/models/whisper-turbo \
+SPEECH_WHISPER_ONNX_DIR=/models/whisper-turbo \
+SPEECH_BENCH_ONLY=whisper \
+SPEECH_WHISPER_BENCH_CONFIG=en-tail50 \
+SPEECH_CORE_WHISPER_ORT_THREADS=16 \
+./build/bench_ort_models
+```
+
 - Download helper:
 
 ```bash

--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -95,7 +95,8 @@ public:
     ///   intra=16 CPU 24.25x RTF / CUDA 26.49x RTF (15–20% slower)
     /// The env var stays available for long-utterance / large-batch
     /// workloads where the parallel win does dominate.
-    static int resolve_intra_threads() {
+    static int resolve_intra_threads(int override_threads = 0) {
+        if (override_threads > 0) return override_threads;
         if (const char* env = std::getenv("SPEECH_CORE_ORT_THREADS")) {
             int v = std::atoi(env);
             if (v > 0) return v;
@@ -104,7 +105,7 @@ public:
     }
 
     OrtSession* load(const std::string& path, bool nnapi = true,
-                     bool capture_hint = false) {
+                     bool capture_hint = false, int intra_threads = 0) {
         OrtSessionOptions* opts = nullptr;
         ort_check(api_, api_->CreateSessionOptions(&opts));
         // Optimization level — default ORT_ENABLE_ALL, lowered via
@@ -123,8 +124,9 @@ public:
             else if (v == "extended")  opt_level = ORT_ENABLE_EXTENDED;
             else if (v == "all")       opt_level = ORT_ENABLE_ALL;
         }
-        api_->SetSessionGraphOptimizationLevel(opts, opt_level);
-        api_->SetIntraOpNumThreads(opts, resolve_intra_threads());
+        ort_check(api_, api_->SetSessionGraphOptimizationLevel(opts, opt_level));
+        ort_check(api_, api_->SetIntraOpNumThreads(
+            opts, resolve_intra_threads(intra_threads)));
         // EXPERIMENT: share a single CPU arena across all sessions. Each
         // session.use_env_allocators=1 routes its CPU allocations through
         // the env's registered arena instead of creating a per-session one.
@@ -247,8 +249,9 @@ public:
 
             opts = nullptr;
             ort_check(api_, api_->CreateSessionOptions(&opts));
-            api_->SetSessionGraphOptimizationLevel(opts, ORT_ENABLE_ALL);
-            api_->SetIntraOpNumThreads(opts, resolve_intra_threads());
+            ort_check(api_, api_->SetSessionGraphOptimizationLevel(opts, ORT_ENABLE_ALL));
+            ort_check(api_, api_->SetIntraOpNumThreads(
+                opts, resolve_intra_threads(intra_threads)));
             ort_check(api_, api_->AddSessionConfigEntry(
                 opts, "session.use_env_allocators", "1"));
             if (const char* skip = std::getenv("SPEECH_CORE_ORT_DISABLE_OPTIMIZERS")) {

--- a/include/speech_core/models/onnx_whisper_stt.h
+++ b/include/speech_core/models/onnx_whisper_stt.h
@@ -38,6 +38,26 @@ public:
 
         // 0 uses sherpa's heuristic: min(audio_seconds * 6, n_text_ctx / 2).
         int max_decode_tokens = 0;
+
+        // 0 uses SPEECH_CORE_WHISPER_ORT_THREADS when set, otherwise the
+        // engine default. CPU Whisper benefits from more threads than the
+        // short-call STT/TTS wrappers.
+        int intra_threads = 0;
+    };
+
+    struct Profile {
+        double total_ms = 0.0;
+        double feature_ms = 0.0;
+        double encoder_ms = 0.0;
+        double language_ms = 0.0;
+        double decoder_prompt_ms = 0.0;
+        double decoder_ms = 0.0;
+        double first_token_ms = 0.0;
+        int chunks = 0;
+        int feature_frames = 0;
+        int encoded_frames = 0;
+        int prompt_tokens = 0;
+        int generated_tokens = 0;
     };
 
     OnnxWhisperStt(const std::string& encoder_path,
@@ -57,6 +77,8 @@ public:
         const float* audio, size_t length, int sample_rate) override;
 
     int input_sample_rate() const override { return cfg_.sample_rate; }
+
+    Profile last_profile() const;
 
     /// Set a fixed language prompt. Passing an empty string re-enables
     /// auto-detection on multilingual models.
@@ -86,10 +108,12 @@ private:
         std::string text;
         std::string language;
         float confidence = 1.0f;
+        Profile profile;
     };
 
     void load_metadata();
     void load_tokens(const std::string& path);
+    void prepare_feature_tables();
 
     std::vector<float> compute_features(
         const float* audio, size_t length, int* out_frames) const;
@@ -107,6 +131,11 @@ private:
     Config cfg_;
     Metadata meta_;
     std::vector<std::string> token_table_;
+    std::vector<float> window_;
+    std::vector<float> cos_table_;
+    std::vector<float> sin_table_;
+    std::vector<float> mel_filterbank_;
+    Profile last_profile_;
 };
 
 }  // namespace speech_core

--- a/src/models/whisper/onnx_whisper_stt.cpp
+++ b/src/models/whisper/onnx_whisper_stt.cpp
@@ -5,9 +5,11 @@
 #include "speech_core/util/json.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <sstream>
@@ -19,6 +21,11 @@ namespace speech_core {
 namespace {
 
 constexpr float kPi = 3.14159265358979323846f;
+using Clock = std::chrono::steady_clock;
+
+double ms_since(Clock::time_point t0) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - t0).count();
+}
 
 struct OrtValueHandle {
     const OrtApi* api = nullptr;
@@ -193,6 +200,15 @@ int argmax(const float* values, int n) {
     return best;
 }
 
+int resolve_whisper_threads(int config_threads) {
+    if (config_threads > 0) return config_threads;
+    if (const char* env = std::getenv("SPEECH_CORE_WHISPER_ORT_THREADS")) {
+        int v = std::atoi(env);
+        if (v > 0) return v;
+    }
+    return 0;
+}
+
 }  // namespace
 
 OnnxWhisperStt::OnnxWhisperStt(
@@ -212,12 +228,14 @@ OnnxWhisperStt::OnnxWhisperStt(
 {
     auto& engine = OnnxEngine::get();
     api_ = engine.api();
-    encoder_ = engine.load(encoder_path, hw_accel);
+    const int intra_threads = resolve_whisper_threads(cfg_.intra_threads);
+    encoder_ = engine.load(encoder_path, hw_accel, false, intra_threads);
     // Without IO binding, each decoder step would copy the full self-KV cache
     // between host and accelerator. Keep the AR decoder on CPU by default.
-    decoder_ = engine.load(decoder_path, false);
+    decoder_ = engine.load(decoder_path, false, false, intra_threads);
 
     load_metadata();
+    prepare_feature_tables();
     load_tokens(tokens_path);
 
     if (cfg_.max_audio_samples == 0) {
@@ -237,6 +255,10 @@ OnnxWhisperStt::OnnxWhisperStt(
 OnnxWhisperStt::~OnnxWhisperStt() {
     if (decoder_) api_->ReleaseSession(decoder_);
     if (encoder_) api_->ReleaseSession(encoder_);
+}
+
+OnnxWhisperStt::Profile OnnxWhisperStt::last_profile() const {
+    return last_profile_;
 }
 
 bool OnnxWhisperStt::set_language(const std::string& language) {
@@ -381,6 +403,27 @@ std::vector<float> OnnxWhisperStt::make_mel_filterbank() const {
     return fb;
 }
 
+void OnnxWhisperStt::prepare_feature_tables() {
+    window_.resize(static_cast<size_t>(cfg_.win_length));
+    for (int i = 0; i < cfg_.win_length; ++i) {
+        window_[static_cast<size_t>(i)] =
+            0.5f * (1.0f - std::cos(2.0f * kPi * i / cfg_.win_length));
+    }
+
+    const int n_bins = cfg_.n_fft / 2 + 1;
+    cos_table_.resize(static_cast<size_t>(n_bins) * cfg_.n_fft);
+    sin_table_.resize(cos_table_.size());
+    for (int k = 0; k < n_bins; ++k) {
+        for (int n = 0; n < cfg_.n_fft; ++n) {
+            float angle = 2.0f * kPi * static_cast<float>(k * n) / cfg_.n_fft;
+            cos_table_[static_cast<size_t>(k) * cfg_.n_fft + n] = std::cos(angle);
+            sin_table_[static_cast<size_t>(k) * cfg_.n_fft + n] = std::sin(angle);
+        }
+    }
+
+    mel_filterbank_ = make_mel_filterbank();
+}
+
 std::vector<float> OnnxWhisperStt::compute_features(
     const float* audio, size_t length, int* out_frames) const {
     *out_frames = 0;
@@ -406,22 +449,6 @@ std::vector<float> OnnxWhisperStt::compute_features(
 
     const int n_bins = cfg_.n_fft / 2 + 1;
     const int n_mels = meta_.n_mels;
-    std::vector<float> window(cfg_.win_length);
-    for (int i = 0; i < cfg_.win_length; ++i) {
-        window[i] = 0.5f * (1.0f - std::cos(2.0f * kPi * i / cfg_.win_length));
-    }
-
-    std::vector<float> cos_table(n_bins * cfg_.n_fft);
-    std::vector<float> sin_table(n_bins * cfg_.n_fft);
-    for (int k = 0; k < n_bins; ++k) {
-        for (int n = 0; n < cfg_.n_fft; ++n) {
-            float angle = 2.0f * kPi * static_cast<float>(k * n) / cfg_.n_fft;
-            cos_table[k * cfg_.n_fft + n] = std::cos(angle);
-            sin_table[k * cfg_.n_fft + n] = std::sin(angle);
-        }
-    }
-
-    auto fb = make_mel_filterbank();
     std::vector<float> frame(cfg_.n_fft, 0.0f);
     std::vector<float> power(n_bins, 0.0f);
     std::vector<float> mel(n_frames * n_mels, 0.0f);
@@ -430,12 +457,12 @@ std::vector<float> OnnxWhisperStt::compute_features(
         std::fill(frame.begin(), frame.end(), 0.0f);
         size_t start = static_cast<size_t>(t * cfg_.hop_length);
         for (int i = 0; i < cfg_.win_length; ++i) {
-            frame[i] = padded[start + static_cast<size_t>(i)] * window[i];
+            frame[i] = padded[start + static_cast<size_t>(i)] * window_[i];
         }
 
         for (int k = 0; k < n_bins; ++k) {
-            const float* c = cos_table.data() + k * cfg_.n_fft;
-            const float* s = sin_table.data() + k * cfg_.n_fft;
+            const float* c = cos_table_.data() + static_cast<size_t>(k) * cfg_.n_fft;
+            const float* s = sin_table_.data() + static_cast<size_t>(k) * cfg_.n_fft;
             float re = 0.0f;
             float im = 0.0f;
             for (int n = 0; n < cfg_.n_fft; ++n) {
@@ -447,7 +474,7 @@ std::vector<float> OnnxWhisperStt::compute_features(
 
         for (int m = 0; m < n_mels; ++m) {
             float sum = 0.0f;
-            const float* filt = fb.data() + m * n_bins;
+            const float* filt = mel_filterbank_.data() + static_cast<size_t>(m) * n_bins;
             for (int k = 0; k < n_bins; ++k) sum += power[k] * filt[k];
             mel[t * n_mels + m] = std::max(sum, 1e-10f);
         }
@@ -470,7 +497,10 @@ std::vector<float> OnnxWhisperStt::compute_features(
 TranscriptionResult OnnxWhisperStt::transcribe(
     const float* audio, size_t length, int sample_rate) {
     TranscriptionResult out;
+    last_profile_ = {};
     if (!audio || length == 0) return out;
+    const auto t_total = Clock::now();
+    Profile profile;
 
     std::vector<float> converted;
     const float* pcm = audio;
@@ -488,7 +518,21 @@ TranscriptionResult OnnxWhisperStt::transcribe(
     const size_t chunk = std::max<size_t>(1, cfg_.max_audio_samples);
     while (offset < pcm_len) {
         size_t n = std::min(chunk, pcm_len - offset);
+        double chunk_start_ms = ms_since(t_total);
         auto r = decode_chunk(pcm + offset, n);
+        ++profile.chunks;
+        profile.feature_ms += r.profile.feature_ms;
+        profile.encoder_ms += r.profile.encoder_ms;
+        profile.language_ms += r.profile.language_ms;
+        profile.decoder_prompt_ms += r.profile.decoder_prompt_ms;
+        profile.decoder_ms += r.profile.decoder_ms;
+        profile.feature_frames += r.profile.feature_frames;
+        profile.encoded_frames += r.profile.encoded_frames;
+        profile.prompt_tokens += r.profile.prompt_tokens;
+        profile.generated_tokens += r.profile.generated_tokens;
+        if (profile.first_token_ms == 0.0 && r.profile.first_token_ms > 0.0) {
+            profile.first_token_ms = chunk_start_ms + r.profile.first_token_ms;
+        }
         if (!r.text.empty()) texts.push_back(std::move(r.text));
         if (language.empty()) language = std::move(r.language);
         offset += n;
@@ -503,14 +547,20 @@ TranscriptionResult OnnxWhisperStt::transcribe(
     out.language = std::move(language);
     out.confidence = 1.0f;
     out.end_time = static_cast<float>(length) / static_cast<float>(sample_rate);
+    profile.total_ms = ms_since(t_total);
+    last_profile_ = profile;
     return out;
 }
 
 OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_chunk(
     const float* audio, size_t length) {
+    DecodeResult result;
     int num_frames = 0;
+    const auto t_feature = Clock::now();
     std::vector<float> features = compute_features(audio, length, &num_frames);
-    if (features.empty() || num_frames <= 0) return {};
+    result.profile.feature_ms = ms_since(t_feature);
+    result.profile.feature_frames = num_frames;
+    if (features.empty() || num_frames <= 0) return result;
 
     const int max_real_frames =
         std::max(1, cfg_.max_feature_frames - cfg_.reserve_tail_frames);
@@ -518,6 +568,8 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_chunk(
 
     const int actual_frames = std::min(
         cfg_.max_feature_frames, num_frames + std::max(0, cfg_.tail_padding_frames));
+    result.profile.feature_frames = num_frames;
+    result.profile.encoded_frames = actual_frames;
 
     std::vector<float> mel(static_cast<size_t>(meta_.n_mels) * actual_frames, 0.0f);
     for (int t = 0; t < num_frames; ++t) {
@@ -536,12 +588,23 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_chunk(
     const char* enc_out[] = {"n_layer_cross_k", "n_layer_cross_v"};
     OrtValue* enc_inputs[] = {t_mel.get()};
     OrtValue* enc_outputs[] = {nullptr, nullptr};
+    const auto t_encoder = Clock::now();
     ort_check(api_, api_->Run(encoder_, nullptr, enc_in, enc_inputs, 1,
                               enc_out, 2, enc_outputs));
+    result.profile.encoder_ms = ms_since(t_encoder);
 
     OrtValueHandle cross_k(api_, enc_outputs[0]);
     OrtValueHandle cross_v(api_, enc_outputs[1]);
-    return decode_greedy(cross_k.get(), cross_v.get(), num_frames);
+    auto decoded = decode_greedy(cross_k.get(), cross_v.get(), num_frames);
+    decoded.profile.feature_ms = result.profile.feature_ms;
+    decoded.profile.encoder_ms = result.profile.encoder_ms;
+    decoded.profile.feature_frames = result.profile.feature_frames;
+    decoded.profile.encoded_frames = result.profile.encoded_frames;
+    decoded.profile.first_token_ms = result.profile.feature_ms
+        + result.profile.encoder_ms
+        + decoded.profile.language_ms
+        + decoded.profile.decoder_prompt_ms;
+    return decoded;
 }
 
 int32_t OnnxWhisperStt::detect_language(OrtValue* cross_k, OrtValue* cross_v) {
@@ -600,6 +663,7 @@ int32_t OnnxWhisperStt::detect_language(OrtValue* cross_k, OrtValue* cross_v) {
 OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
     OrtValue* cross_k, OrtValue* cross_v, int num_feature_frames) {
     DecodeResult result;
+    const auto t_decoder_total = Clock::now();
     auto* mem = OnnxEngine::get().cpu_memory();
 
     std::vector<int64_t> initial = meta_.sot_sequence;
@@ -612,7 +676,9 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
             }
             language_token = it->second;
         } else {
+            const auto t_language = Clock::now();
             language_token = detect_language(cross_k, cross_v);
+            result.profile.language_ms = ms_since(t_language);
         }
         initial[1] = language_token;
         auto lang = meta_.id2lang.find(language_token);
@@ -625,6 +691,7 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
         }
     }
     initial.push_back(meta_.no_timestamps);
+    result.profile.prompt_tokens = static_cast<int>(initial.size());
 
     std::vector<float> self_k(static_cast<size_t>(meta_.n_text_layer)
                               * meta_.n_text_ctx * meta_.n_text_state, 0.0f);
@@ -679,9 +746,13 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
         return {std::move(logits), next};
     };
 
+    const auto t_prompt = Clock::now();
     auto first = run_decoder(initial.data(), initial.size(), 0);
+    result.profile.decoder_prompt_ms = ms_since(t_prompt);
     (void)first.first;
     int32_t next_token = first.second;
+    std::vector<float>().swap(self_k);
+    std::vector<float>().swap(self_v);
 
     int limit = static_cast<int>(num_feature_frames / 100.0f * 6.0f);
     if (meta_.n_text_ctx > 0) limit = std::min(limit, meta_.n_text_ctx / 2);
@@ -704,6 +775,8 @@ OnnxWhisperStt::DecodeResult OnnxWhisperStt::decode_greedy(
     }
 
     result.text = decode_tokens(generated);
+    result.profile.generated_tokens = static_cast<int>(generated.size());
+    result.profile.decoder_ms = ms_since(t_decoder_total);
     return result;
 }
 

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -1,4 +1,5 @@
-// Micro-benchmark for the ORT models (Silero VAD, Parakeet STT, Kokoro TTS).
+// Micro-benchmark for the ORT models (Silero VAD, Parakeet STT, Whisper,
+// Kokoro TTS).
 // Runs each model on the test fixture, reports load time / latency / RTF /
 // peak RSS.
 //
@@ -14,6 +15,7 @@
 #include "speech_core/models/onnx_cosyvoice3_tts.h"
 #include "speech_core/models/onnx_nemotron_streaming_stt.h"
 #include "speech_core/models/onnx_voxcpm2_tts.h"
+#include "speech_core/models/onnx_whisper_stt.h"
 #include "speech_core/models/parakeet_stt.h"
 #include "speech_core/models/silero_vad.h"
 
@@ -34,8 +36,11 @@
 #include <windows.h>
 #include <psapi.h>
 #pragma comment(lib, "psapi.lib")
+#elif defined(__APPLE__)
+#include <mach/mach.h>
 #else
 #include <sys/resource.h>
+#include <unistd.h>
 #endif
 
 namespace {
@@ -60,6 +65,36 @@ double peak_rss_mb() {
 #else
     return static_cast<double>(r.ru_maxrss) / 1024.0;
 #endif
+#endif
+}
+
+double current_rss_mb() {
+#ifdef _WIN32
+    PROCESS_MEMORY_COUNTERS pmc{};
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+        return static_cast<double>(pmc.WorkingSetSize) / (1024.0 * 1024.0);
+    }
+    return 0.0;
+#elif defined(__APPLE__)
+    mach_task_basic_info info{};
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS) {
+        return static_cast<double>(info.resident_size) / (1024.0 * 1024.0);
+    }
+    return 0.0;
+#else
+    FILE* f = std::fopen("/proc/self/statm", "r");
+    if (!f) return 0.0;
+    long pages = 0;
+    long resident = 0;
+    if (std::fscanf(f, "%ld %ld", &pages, &resident) != 2) {
+        std::fclose(f);
+        return 0.0;
+    }
+    std::fclose(f);
+    long page_size = sysconf(_SC_PAGESIZE);
+    return static_cast<double>(resident) * page_size / (1024.0 * 1024.0);
 #endif
 }
 
@@ -218,6 +253,126 @@ void bench_parakeet(const std::string& dir) {
     std::snprintf(ex, sizeof(ex), "p50=%.0fms p95=%.0fms text=\"%s\"",
                   pct(runs, 50), pct(runs, 95), last_text.c_str());
     emit("parakeet-tdt", "batch", load_ms, med, audio_s / (med / 1000.0), peak_rss_mb(), ex);
+}
+
+struct WhisperBundle {
+    std::string encoder;
+    std::string decoder;
+    std::string tokens;
+    std::string label;
+};
+
+bool find_whisper_bundle(const std::string& dir, WhisperBundle* out) {
+    const char* override_dir = std::getenv("SPEECH_WHISPER_ONNX_DIR");
+    std::string root = override_dir ? override_dir : dir;
+
+    struct Candidate { const char* prefix; const char* suffix; const char* label; };
+    const Candidate candidates[] = {
+        {"turbo", ".int8", "turbo-int8"},
+        {"large-v3", ".int8", "large-v3-int8"},
+        {"medium", ".int8", "medium-int8"},
+        {"small", ".int8", "small-int8"},
+        {"turbo", ".fp16", "turbo-fp16"},
+        {"large-v3", ".fp16", "large-v3-fp16"},
+        {"medium", ".fp16", "medium-fp16"},
+        {"small", ".fp16", "small-fp16"},
+        {"turbo", "", "turbo-fp32"},
+        {"large-v3", "", "large-v3-fp32"},
+        {"medium", "", "medium-fp32"},
+        {"small", "", "small-fp32"},
+    };
+    for (const auto& c : candidates) {
+        std::string e = root + "/" + c.prefix + "-encoder" + c.suffix + ".onnx";
+        std::string d = root + "/" + c.prefix + "-decoder" + c.suffix + ".onnx";
+        std::string t = root + "/" + c.prefix + "-tokens.txt";
+        if (file_exists(e) && file_exists(d) && file_exists(t)) {
+            out->encoder = std::move(e);
+            out->decoder = std::move(d);
+            out->tokens = std::move(t);
+            out->label = c.label;
+            return true;
+        }
+    }
+    std::fprintf(stderr, "[skip] whisper ONNX bundle in %s\n", root.c_str());
+    return false;
+}
+
+void emit_whisper_profile(const std::string& metric,
+                          const WhisperBundle& bundle,
+                          const speech_core::OnnxWhisperStt::Profile& p,
+                          double load_ms,
+                          double audio_s,
+                          const std::string& text) {
+    std::string transcript = text;
+    for (char& c : transcript) if (c == ',') c = ' ';
+    if (transcript.size() > 80) transcript.resize(80);
+    char ex[512];
+    std::snprintf(ex, sizeof(ex),
+                  "variant=%s current_rss=%.1fMB first_token=%.1fms feature=%.1fms encoder=%.1fms language=%.1fms prompt=%.1fms decoder=%.1fms chunks=%d feature_frames=%d encoded_frames=%d prompt_tokens=%d generated_tokens=%d text=\"%s\"",
+                  bundle.label.c_str(), current_rss_mb(), p.first_token_ms,
+                  p.feature_ms, p.encoder_ms, p.language_ms,
+                  p.decoder_prompt_ms, p.decoder_ms, p.chunks,
+                  p.feature_frames, p.encoded_frames, p.prompt_tokens,
+                  p.generated_tokens, transcript.c_str());
+    emit("whisper", metric, load_ms, p.total_ms,
+         audio_s / (p.total_ms / 1000.0), peak_rss_mb(), ex);
+}
+
+void bench_whisper_config(const WhisperBundle& bundle,
+                          const std::string& metric,
+                          speech_core::OnnxWhisperStt::Config cfg,
+                          const std::vector<float>& audio) {
+    auto t_load = clk::now();
+    speech_core::OnnxWhisperStt stt(
+        bundle.encoder, bundle.decoder, bundle.tokens, cfg, /*hw_accel=*/true);
+    double load_ms = ms_since(t_load);
+    double audio_s = static_cast<double>(audio.size()) / 16000.0;
+
+    auto cold = stt.transcribe(audio.data(), audio.size(), 16000);
+    emit_whisper_profile(metric + "-cold", bundle, stt.last_profile(),
+                         load_ms, audio_s, cold.text);
+
+    std::vector<double> walls;
+    speech_core::OnnxWhisperStt::Profile last_profile;
+    std::string last_text;
+    for (int i = 0; i < 3; ++i) {
+        auto r = stt.transcribe(audio.data(), audio.size(), 16000);
+        last_profile = stt.last_profile();
+        walls.push_back(last_profile.total_ms);
+        last_text = r.text;
+    }
+    double med = pct(walls, 50);
+    (void)med;
+    emit_whisper_profile(metric, bundle, last_profile, load_ms, audio_s, last_text);
+}
+
+void bench_whisper(const std::string& dir) {
+    WhisperBundle bundle;
+    if (!find_whisper_bundle(dir, &bundle)) return;
+    auto audio = load_audio_16k();
+    if (audio.empty()) { std::fprintf(stderr, "[skip] no fixture\n"); return; }
+
+    const char* mode_env = std::getenv("SPEECH_WHISPER_BENCH_CONFIG");
+    std::string mode = mode_env ? mode_env : "";
+
+    if (mode.empty() || mode == "auto") {
+        speech_core::OnnxWhisperStt::Config default_cfg;
+        bench_whisper_config(bundle, "batch-auto", default_cfg, audio);
+    }
+
+    if (mode.empty() || mode == "en-tail50") {
+        speech_core::OnnxWhisperStt::Config low_latency_cfg;
+        low_latency_cfg.language = "en";
+        low_latency_cfg.tail_padding_frames = 50;
+        bench_whisper_config(bundle, "batch-en-tail50", low_latency_cfg, audio);
+    }
+
+    if (mode == "en-tail0") {
+        speech_core::OnnxWhisperStt::Config low_latency_cfg;
+        low_latency_cfg.language = "en";
+        low_latency_cfg.tail_padding_frames = 0;
+        bench_whisper_config(bundle, "batch-en-tail0", low_latency_cfg, audio);
+    }
 }
 
 void bench_kokoro(const std::string& dir) {
@@ -685,8 +840,15 @@ int main(int argc, char** argv) {
     if (!nemotron_manifest.empty()) return run_corpus_nemotron(dir, nemotron_manifest);
     if (!manifest.empty()) return run_corpus(dir, manifest, batch_size);
     std::printf("#model,provider,metric,load_ms,wall_ms,rtf,rss_mb,extra\n");
+    if (const char* only = std::getenv("SPEECH_BENCH_ONLY")) {
+        if (std::string(only) == "whisper") {
+            bench_whisper(dir);
+            return 0;
+        }
+    }
     bench_silero(dir);
     bench_parakeet(dir);
+    bench_whisper(dir);
     bench_kokoro(dir);
     bench_cosyvoice3(dir);
     bench_voxcpm2(dir);

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -332,6 +332,10 @@ void test_onnx_whisper_stt(const std::string& dir) {
         {"large-v3", ".int8"},
         {"medium", ".int8"},
         {"small", ".int8"},
+        {"turbo", ".fp16"},
+        {"large-v3", ".fp16"},
+        {"medium", ".fp16"},
+        {"small", ".fp16"},
         {"turbo", ""},
         {"large-v3", ""},
         {"medium", ""},
@@ -367,8 +371,12 @@ void test_onnx_whisper_stt(const std::string& dir) {
 
     std::vector<float> silence(16000, 0.0f);
     auto result = stt.transcribe(silence.data(), silence.size(), 16000);
+    auto profile = stt.last_profile();
     REQUIRE(result.confidence >= 0.0f && result.confidence <= 1.0f);
     REQUIRE(result.language.empty() || result.language == "en");
+    REQUIRE(profile.chunks == 1);
+    REQUIRE(profile.total_ms >= 0.0);
+    REQUIRE(profile.feature_frames > 0);
 
     std::printf("ok (silence text=\"%.40s\" lang=%s)\n",
                 result.text.c_str(), result.language.c_str());


### PR DESCRIPTION
## Summary
- Add `OnnxWhisperStt::last_profile()` for total, frontend, encoder, language detection, first-token, and decoder timing.
- Add Whisper-specific ORT thread tuning via `Config.intra_threads` and `SPEECH_CORE_WHISPER_ORT_THREADS`, without changing the global default used by smaller ONNX models.
- Extend `bench_ort_models` with Whisper latency/RTF/RSS rows and benchmark selectors.
- Update README and model docs for Whisper ONNX benchmarking and tuning.
- Extend the Whisper smoke test to cover fp16 discovery and profile population.

## Measured result
Turbo int8 ONNX, CPU ORT, 20s fixture, fixed English, tail padding 50, `SPEECH_CORE_WHISPER_ORT_THREADS=16`:
- warm wall: 1394.0 ms
- warm first token: 1178.0 ms
- warm throughput: 14.347x realtime
- peak RSS: 1300.9 MB

## Test plan
- `git diff --check`
- `cmake --build /tmp/speech-core-build-default -j2`
- `ctest --test-dir /tmp/speech-core-build-default --output-on-failure`
- `cmake --build /tmp/speech-core-build-onnx -j2`
- `DYLD_LIBRARY_PATH=/tmp/ort-macos-arm64/lib ctest --test-dir /tmp/speech-core-build-onnx --output-on-failure`
- `DYLD_LIBRARY_PATH=/tmp/ort-macos-arm64/lib SPEECH_MODEL_DIR=/tmp/whisper-onnx-turbo-int8 SPEECH_WHISPER_ONNX_DIR=/tmp/whisper-onnx-turbo-int8 /tmp/speech-core-build-onnx/test_models`
- `DYLD_LIBRARY_PATH=/tmp/ort-macos-arm64/lib SPEECH_CORE_WHISPER_ORT_THREADS=16 SPEECH_BENCH_ONLY=whisper SPEECH_WHISPER_BENCH_CONFIG=en-tail50 SPEECH_MODEL_DIR=/tmp/whisper-onnx-turbo-int8 SPEECH_WHISPER_ONNX_DIR=/tmp/whisper-onnx-turbo-int8 /tmp/speech-core-build-onnx/bench_ort_models`