### PR TITLE
Fix CosyVoice3 CFG conditioning, flow noise, and instruct layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,16 @@ if(SPEECH_CORE_WITH_ONNX)
             target_compile_definitions(speech_voxcpm2_clone_onnx PRIVATE _USE_MATH_DEFINES NOMINMAX)
         endif()
 
+        # CosyVoice3 ONNX synthesis CLI: renders text with a prepared
+        # conditioning blob through the full prefill/step/flow/hift pipeline.
+        # The in-repo runner for validating OnnxCosyVoice3Tts end-to-end.
+        # Desktop only.
+        add_executable(speech_cosyvoice3_synth_onnx examples/onnx/cosyvoice3_synth.cpp)
+        target_link_libraries(speech_cosyvoice3_synth_onnx PRIVATE speech_core_models)
+        if(MSVC)
+            target_compile_definitions(speech_cosyvoice3_synth_onnx PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+
         # Sidon speech-restoration CLI (ONNX): denoise + dereverb a clip to
         # 48 kHz. The in-repo runner for validating the predictor + DAC vocoder
         # pipeline (and the C++ SeamlessM4T front-end) end-to-end. Desktop only.

--- a/examples/onnx/cosyvoice3_synth.cpp
+++ b/examples/onnx/cosyvoice3_synth.cpp
@@ -1,0 +1,92 @@
+// CosyVoice3 ONNX synthesis example.
+//
+// Renders text with a prepared conditioning blob (see
+// OnnxCosyVoice3Tts::encode_conditioning_blob) whose prompt_text_ids may be
+// empty — they are filled here from --transcript via the bundle tokenizer.
+//
+// Usage:
+//   speech_cosyvoice3_synth_onnx <bundle_dir> <conditioning.blob> \
+//       <reference transcript> <text> <out.wav> [seed]
+
+#include <speech_core/models/onnx_cosyvoice3_tts.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<uint8_t> read_file(const std::string& path) {
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f.good()) throw std::runtime_error("cannot read " + path);
+    const std::streamsize n = f.tellg();
+    f.seekg(0);
+    std::vector<uint8_t> data(static_cast<size_t>(n));
+    if (!f.read(reinterpret_cast<char*>(data.data()), n)) {
+        throw std::runtime_error("short read " + path);
+    }
+    return data;
+}
+
+void write_wav(const std::string& path, const std::vector<float>& pcm, int rate) {
+    std::ofstream f(path, std::ios::binary);
+    auto u32 = [&](uint32_t v) { f.write(reinterpret_cast<const char*>(&v), 4); };
+    auto u16 = [&](uint16_t v) { f.write(reinterpret_cast<const char*>(&v), 2); };
+    const uint32_t data_bytes = static_cast<uint32_t>(pcm.size() * 2);
+    f.write("RIFF", 4); u32(36 + data_bytes); f.write("WAVE", 4);
+    f.write("fmt ", 4); u32(16); u16(1); u16(1);
+    u32(static_cast<uint32_t>(rate)); u32(static_cast<uint32_t>(rate * 2));
+    u16(2); u16(16);
+    f.write("data", 4); u32(data_bytes);
+    for (float v : pcm) {
+        const float c = v < -1.0f ? -1.0f : (v > 1.0f ? 1.0f : v);
+        const int16_t s = static_cast<int16_t>(c * 32767.0f);
+        f.write(reinterpret_cast<const char*>(&s), 2);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 6) {
+        std::fprintf(stderr,
+            "usage: %s <bundle_dir> <conditioning.blob> <transcript> <text> <out.wav> [seed]\n",
+            argv[0]);
+        return 2;
+    }
+    const std::string bundle_dir = argv[1];
+    const std::string blob_path = argv[2];
+    const std::string transcript = argv[3];
+    const std::string text = argv[4];
+    const std::string out_path = argv[5];
+    const uint32_t seed = argc > 6 ? static_cast<uint32_t>(std::stoul(argv[6])) : 7u;
+
+    speech_core::OnnxCosyVoice3Tts tts(bundle_dir, /*hw_accel=*/false);
+
+    const auto blob = read_file(blob_path);
+    auto cond = speech_core::OnnxCosyVoice3Tts::decode_conditioning_blob(
+        blob.data(), blob.size());
+    if (cond.prompt_text_ids.empty()) {
+        cond.prompt_text_ids = tts.encode_prompt_text(
+            speech_core::OnnxCosyVoice3Tts::prompt_text_from_transcript(transcript));
+    }
+    tts.set_conditioning(std::move(cond));
+    tts.set_seed(seed);
+
+    std::vector<float> pcm;
+    tts.synthesize(text, "english", [&](const float* data, size_t n, bool) {
+        pcm.insert(pcm.end(), data, data + n);
+    });
+
+    write_wav(out_path, pcm, tts.output_sample_rate());
+    std::printf("tokens=%d stop=%d prefill=%lldms ar=%lldms decode=%lldms samples=%zu -> %s\n",
+                tts.tokens_generated(), tts.stopped_on_stop_token() ? 1 : 0,
+                static_cast<long long>(tts.prefill_ms()),
+                static_cast<long long>(tts.ar_ms()),
+                static_cast<long long>(tts.audio_decode_ms()),
+                pcm.size(), out_path.c_str());
+    return 0;
+}

--- a/include/speech_core/models/onnx_cosyvoice3_tts.h
+++ b/include/speech_core/models/onnx_cosyvoice3_tts.h
@@ -57,6 +57,11 @@ public:
     int tokens_generated() const { return tokens_generated_; }
     bool stopped_on_stop_token() const { return stopped_on_stop_token_; }
 
+    /// Style instruction (upstream `instruct2` layout): sent to the LLM as
+    /// "instruction<|endofprompt|>" in place of the conditioning prompt text,
+    /// with the LLM prompt speech tokens withheld. The flow conditioning is
+    /// unchanged, so the reference voice still anchors timbre. Empty
+    /// (default) keeps the zero-shot transcript-led layout.
     void set_instruction(std::string instruction) { instruction_ = std::move(instruction); }
 
     int64_t prefill_ms() const { return prefill_ms_; }

--- a/include/speech_core/models/onnx_cosyvoice3_tts.h
+++ b/include/speech_core/models/onnx_cosyvoice3_tts.h
@@ -74,6 +74,11 @@ public:
     static std::string helper_prompt_prefix();
     static std::string prompt_text_from_transcript(const std::string& transcript);
 
+    /// Tokenize text with the bundle's Qwen BPE tokenizer. Conditioning
+    /// producers use this to build `prompt_text_ids` consistent with the
+    /// runtime (there is no other way to reach the bundled tokenizer).
+    std::vector<int64_t> encode_prompt_text(const std::string& prompt_text) const;
+
     static std::vector<uint8_t> encode_conditioning_blob(const Conditioning& c);
     static Conditioning decode_conditioning_blob(const uint8_t* data,
                                                  size_t size);

--- a/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
+++ b/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
@@ -961,6 +961,10 @@ void OnnxCosyVoice3Tts::synthesize(const std::string& text,
     on_chunk(wav.data(), wav.size(), true);
 }
 
+std::vector<int64_t> OnnxCosyVoice3Tts::encode_prompt_text(const std::string& prompt_text) const {
+    return impl_->encode_text(prompt_text);
+}
+
 std::string OnnxCosyVoice3Tts::helper_prompt_prefix() {
     return "You are a helpful assistant.<|endofprompt|>";
 }

--- a/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
+++ b/src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
@@ -333,6 +333,7 @@ struct OnnxCosyVoice3Tts::Impl {
         hift = engine.load(bundle_dir + "/hift.onnx", hw_accel);
         hift_128 = load_optional(engine, bundle_dir + "/hift_128.onnx", hw_accel);
         hift_256 = load_optional(engine, bundle_dir + "/hift_256.onnx", hw_accel);
+        load_flow_noise(bundle_dir + "/flow_noise.bin");
     }
 
     ~Impl() {
@@ -360,6 +361,10 @@ struct OnnxCosyVoice3Tts::Impl {
     Conditioning conditioning;
     bool has_conditioning = false;
     std::atomic<bool> cancelled{false};
+    // Upstream's fixed torch-seed-0 rand_noise ([80, N] row-major), loaded
+    // from the bundle's flow_noise.bin when present.
+    std::vector<float> flow_noise;
+    int flow_noise_frames = 0;
 
     static constexpr int kTextSlots = 192;
     static constexpr int kPromptSpeechSlots = 320;
@@ -380,6 +385,20 @@ struct OnnxCosyVoice3Tts::Impl {
         std::ifstream f(path);
         if (!f.good()) return nullptr;
         return engine.load(path, hw_accel);
+    }
+
+    void load_flow_noise(const std::string& path) {
+        std::ifstream f(path, std::ios::binary | std::ios::ate);
+        if (!f.good()) return;
+        const std::streamsize bytes = f.tellg();
+        if (bytes <= 0 || bytes % (80 * sizeof(float)) != 0) return;
+        f.seekg(0);
+        flow_noise.resize(static_cast<size_t>(bytes) / sizeof(float));
+        if (!f.read(reinterpret_cast<char*>(flow_noise.data()), bytes)) {
+            flow_noise.clear();
+            return;
+        }
+        flow_noise_frames = static_cast<int>(flow_noise.size() / 80);
     }
 
     OrtValue* make_i64(const int64_t* data, size_t n, const int64_t* shape, size_t rank) {
@@ -480,6 +499,7 @@ struct OnnxCosyVoice3Tts::Impl {
     }
 
     std::vector<int64_t> run_llm(const std::vector<int64_t>& target_ids,
+                                 const std::string& instruction,
                                  int max_tokens,
                                  uint32_t seed,
                                  int* prefill_ms,
@@ -489,17 +509,32 @@ struct OnnxCosyVoice3Tts::Impl {
             throw std::runtime_error("CosyVoice3 conditioning is required");
         }
         if (stopped_on_stop_token) *stopped_on_stop_token = false;
-        std::vector<int64_t> text_tokens_all = conditioning.prompt_text_ids;
+        // Zero-shot: prompt_text_ids ("You are a helpful
+        // assistant.<|endofprompt|>" + reference transcript) leads the text.
+        // Instruct (upstream `instruct2`): the instruction replaces that
+        // prefix as "instruction<|endofprompt|>" and the LLM prompt speech
+        // tokens are withheld — the flow conditioning still anchors timbre.
+        // Concatenating the instruction into the target text instead makes
+        // the model read the instruction aloud.
+        std::vector<int64_t> text_tokens_all;
+        size_t llm_prompt_count = conditioning.llm_prompt_speech_tokens.size();
+        if (!instruction.empty()) {
+            text_tokens_all = encode_text(instruction + "<|endofprompt|>");
+            llm_prompt_count = 0;
+        } else {
+            text_tokens_all = conditioning.prompt_text_ids;
+        }
         text_tokens_all.insert(text_tokens_all.end(), target_ids.begin(), target_ids.end());
 
         std::vector<int64_t> text_ids(kTextSlots, 0);
         std::vector<int64_t> prompt_ids(kPromptSpeechSlots, 0);
         const int text_len = std::min<int>(kTextSlots, text_tokens_all.size());
-        const int prompt_len = std::min<int>(kPromptSpeechSlots,
-            conditioning.llm_prompt_speech_tokens.size());
+        const int prompt_len = std::min<int>(kPromptSpeechSlots, llm_prompt_count);
         std::copy_n(text_tokens_all.begin(), text_len, text_ids.begin());
-        std::copy_n(conditioning.llm_prompt_speech_tokens.begin(), prompt_len,
-                    prompt_ids.begin());
+        if (prompt_len > 0) {
+            std::copy_n(conditioning.llm_prompt_speech_tokens.begin(), prompt_len,
+                        prompt_ids.begin());
+        }
         int64_t text_len_v[1] = {text_len};
         int64_t prompt_len_v[1] = {prompt_len};
         const int target_text_len = std::max<int>(1, target_ids.size());
@@ -737,36 +772,55 @@ struct OnnxCosyVoice3Tts::Impl {
         }
         std::copy_n(mask_full.data(), total_frames, mask.data());
 
-        std::mt19937 rng(1986);
-        std::normal_distribution<float> normal(0.0f, 1.0f);
+        // Initial ODE noise. Upstream never samples fresh noise — it slices a
+        // fixed torch-seed-0 buffer (rand_noise = randn([1, 80, 50*300])), an
+        // implicitly validated draw for the Euler solver. Use the bundle's
+        // flow_noise.bin when present; the fixed-seed local draw keeps
+        // renders deterministic without it.
         std::vector<float> x(static_cast<size_t>(80) * total_frames);
-        for (float& v : x) v = normal(rng);
+        if (flow_noise_frames >= total_frames) {
+            for (int c = 0; c < 80; ++c) {
+                std::copy_n(
+                    flow_noise.data() + static_cast<size_t>(c) * flow_noise_frames,
+                    total_frames,
+                    x.data() + static_cast<size_t>(c) * total_frames);
+            }
+        } else {
+            std::mt19937 rng(1986);
+            std::normal_distribution<float> normal(0.0f, 1.0f);
+            for (float& v : x) v = normal(rng);
+        }
 
         auto cosine_t = [flow_steps](int i) {
             constexpr float kPi = 3.14159265358979323846f;
             const float u = static_cast<float>(i) / static_cast<float>(flow_steps);
             return 1.0f - std::cos(u * kPi / 2.0f);
         };
+        // Classifier-free guidance batch. The conditional half carries
+        // mu/spks/cond; the UNCONDITIONAL half must run with all three zeroed
+        // (upstream solve_euler: mu_in[1] = 0, spks_in[1] = 0, cond_in[1] = 0)
+        // — only x, mask and t are duplicated. With mu in both halves the
+        // guidance term cancels and CFG stops sharpening the content.
+        // Everything except x is step-invariant, so build it once.
+        std::vector<float> mu2(static_cast<size_t>(2) * 80 * total_frames, 0.0f);
+        std::copy(mu.begin(), mu.end(), mu2.begin());
+        std::vector<float> cond2(mu2.size(), 0.0f);
+        std::copy(cond.begin(), cond.end(), cond2.begin());
+        std::vector<float> mask2(static_cast<size_t>(2) * total_frames);
+        std::copy(mask.begin(), mask.end(), mask2.begin());
+        std::copy(mask.begin(), mask.end(), mask2.begin() + mask.size());
+        std::vector<float> spks2(160, 0.0f);
+        std::copy(spks.begin(), spks.end(), spks2.begin());
+        std::vector<float> x2(mu2.size());
+
         const int64_t s_dyn[3] = {2, 80, total_frames};
         const int64_t s_mask[3] = {2, 1, total_frames};
         const int64_t s_t[1] = {2};
         const int64_t s_spks[2] = {2, 80};
         auto flow_estimator_t0 = Clock::now();
         for (int i = 0; i < flow_steps; ++i) {
-            std::vector<float> x2(static_cast<size_t>(2) * 80 * total_frames);
-            std::vector<float> mu2(x2.size());
-            std::vector<float> cond2(x2.size(), 0.0f);
             std::copy(x.begin(), x.end(), x2.begin());
             std::copy(x.begin(), x.end(), x2.begin() + x.size());
-            std::copy(mu.begin(), mu.end(), mu2.begin());
-            std::copy(mu.begin(), mu.end(), mu2.begin() + mu.size());
-            std::copy(cond.begin(), cond.end(), cond2.begin());
-            std::vector<float> mask2(static_cast<size_t>(2) * total_frames);
-            std::copy(mask.begin(), mask.end(), mask2.begin());
-            std::copy(mask.begin(), mask.end(), mask2.begin() + mask.size());
-            std::vector<float> spks2(160);
-            std::copy(spks.begin(), spks.end(), spks2.begin());
-            std::copy(spks.begin(), spks.end(), spks2.begin() + 80);
             float t[2] = {cosine_t(i), cosine_t(i)};
 
             OrtValue* est_in[6] = {
@@ -879,12 +933,12 @@ void OnnxCosyVoice3Tts::synthesize(const std::string& text,
     flow_estimator_ms_ = -1;
     hift_ms_ = -1;
 
-    std::string prompt = instruction_.empty() ? text : instruction_ + " " + text;
-    std::vector<int64_t> target = impl_->encode_text(prompt);
+    std::vector<int64_t> target = impl_->encode_text(text);
     int prefill_ms = 0;
     int ar_ms = 0;
     bool stopped_on_stop_token = false;
-    auto speech_tokens = impl_->run_llm(target, max_steps_, seed_used_,
+    auto speech_tokens = impl_->run_llm(target, instruction_, max_steps_,
+                                        seed_used_,
                                         &prefill_ms, &ar_ms,
                                         &stopped_on_stop_token);
     tokens_generated_ = static_cast<int>(speech_tokens.size());


### PR DESCRIPTION
## Summary

Line-level review of the CosyVoice3 ONNX runtime against the reference implementation (the same audit that fixed the MLX port in speech-swift#378) found three glue-level divergences. The exported graphs themselves check out — `flow_frontend` traces the upstream modules and `hift` carries the reference SineGen2/ISTFT semantics.

## What changed

- **Classifier-free guidance**: the unconditional batch half kept `mu` and `spks` (only `cond` was zeroed), so the guidance term largely cancelled and CFG stopped sharpening content. The unconditional half now zeroes `mu`, `spks`, and `cond` like the reference `solve_euler`; step-invariant tensors are assembled once outside the ODE loop.
- **Initial ODE noise**: load the bundle's optional `flow_noise.bin` (the reference fixed seed-0 `rand_noise`, float32 `[80, N]`); the fixed-seed local draw remains the fallback.
- **`set_instruction`**: previously concatenated into the spoken text, so the model read the instruction aloud. Now follows the instruct2 layout — `"instruction<|endofprompt|>"` replaces the conditioning prompt text and the LLM prompt speech tokens are withheld; flow conditioning is unchanged so the reference voice still anchors timbre.
- **New `speech_cosyvoice3_synth_onnx` example**: renders text through prefill/step/flow/hift from a prepared conditioning blob, filling `prompt_text_ids` via the new `encode_prompt_text()` accessor — conditioning producers previously had no way to reach the bundle tokenizer.

## Test plan

- Default and `SPEECH_CORE_WITH_ONNX=ON` configurations build; ctest 17/17 pass.
- End-to-end render through the new example against the published bundle is being validated; results will be posted on this PR.
