### PR TITLE
Add Parakeet language guidance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(speech_core
     src/audio/mel.cpp
     src/audio/stft.cpp
     src/audio/seamless_fbank.cpp
+    src/models/parakeet_language_guidance.cpp
     src/tools/tool_registry.cpp
     src/tools/intent_matcher.cpp
     src/tools/tool_executor.cpp

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + 
 speech_core::LiteRTParakeetStt stt(
     "parakeet-encoder.tflite", "parakeet-decoder-joint.tflite", "vocab.json");
 
+stt.set_allowed_languages({"en-US", "fr"});         // optional language-token guidance
 auto r = stt.transcribe(audio, n_samples, 16000);   // r.text / r.language / r.confidence
 ```
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -176,12 +176,23 @@ speech_core::ParakeetStt stt(
 
 auto result = stt.transcribe(audio, length, 16000);
 // result.text, result.language, result.confidence
+
+// Optional language-token guidance for multilingual TDT vocabularies.
+stt.set_language("en-US");                         // one fixed language
+stt.set_allowed_languages({"en-US", "fr", "de"});  // or a shortlist
+stt.clear_language_guidance();                      // return to unconstrained auto-detect
 ```
 
 - Parakeet TDT v3 (0.6B params), NeMo-exported as encoder + decoder_joint
 - 128-bin mel spectrogram preprocessing
 - Greedy TDT decoding with per-frame duration prediction
 - Language detection via `<|xx|>` BPE tokens
+- `set_language()` / `set_allowed_languages()` provide language-token
+  guidance for multilingual exports. Inputs may be ISO codes or BCP-47 tags
+  (`"en"`, `"en-US"`). Guidance does not force a synthetic prompt at the start
+  of decoding; when the decoder emits a language token, the wrapper chooses the
+  highest-scoring allowed language token and reports it through
+  `result.language`.
 - Streaming supported via `begin_stream` / `push_chunk` / `end_stream` (accumulates audio and re-transcribes each chunk; not a true streaming decoder)
 - Model files: [soniqo/Parakeet-TDT-0.6B-ONNX](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-ONNX) — `parakeet-encoder.onnx` (FP32, plus external `.onnx.data`) or `parakeet-encoder-int8.onnx` (~840 MB / ~100 MB INT8), `parakeet-decoder-joint.onnx` / `parakeet-decoder-joint-int8.onnx`, `vocab.json`. Decoder-joint inputs `targets` + `target_length` are INT32; encoder length input stays INT64.
 
@@ -266,6 +277,7 @@ auto result = stt.transcribe(audio, length, 16000);
 ```
 
 - Same public contract and TDT decode loop as `ParakeetStt`
+- Supports the same language-token guidance API: `set_language("en-US")`, `set_allowed_languages({...})`, and `clear_language_guidance()`.
 - Encoder INT8 weight-quantized (~595 MB on disk vs ~840 MB ONNX FP32), decoder-joint stays FP32 to avoid LSTM drift
 - Decoder-joint exposes `(encoder_out, target, h, c)` as four discrete tensors (ORT bundles `target_length` and uses suffix-`_1`/`_2` for h/c)
 - Model files: [soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) — `parakeet-encoder.tflite`, `parakeet-decoder-joint.tflite`, `vocab.json`

--- a/include/speech_core/models/litert_parakeet_stt.h
+++ b/include/speech_core/models/litert_parakeet_stt.h
@@ -52,6 +52,15 @@ public:
     TranscriptionResult end_stream() override;
     void cancel_stream() override;
 
+    /// Restrict Parakeet's language-token choice to one language.
+    /// Accepts ISO codes or BCP-47 tags ("en", "en-US"). "auto" clears it.
+    bool set_language(const std::string& language);
+
+    /// Restrict Parakeet's language-token choice to this shortlist.
+    /// Unknown languages are ignored; returns false if none resolve.
+    bool set_allowed_languages(const std::vector<std::string>& languages);
+    void clear_language_guidance();
+
 private:
     struct DecodeResult {
         std::string text;
@@ -73,6 +82,7 @@ private:
 
     std::unordered_map<int, std::string> vocab_;
     std::unordered_map<int, std::string> lang_tokens_;
+    std::vector<int> guided_lang_tokens_;
 
     std::vector<float> stream_buffer_;
     int  stream_sample_rate_ = 16000;

--- a/include/speech_core/models/parakeet_language_guidance.h
+++ b/include/speech_core/models/parakeet_language_guidance.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace speech_core::parakeet {
+
+/// Convert a locale or language tag ("en-US", "fr_FR") to the lower-case
+/// ISO 639 language token used by Parakeet ("en", "fr").
+std::string normalize_language_code(const std::string& language);
+
+/// Resolve language tags to Parakeet token IDs. Unknown languages are skipped.
+std::vector<int> resolve_language_tokens(
+    const std::unordered_map<int, std::string>& token_to_language,
+    const std::vector<std::string>& languages);
+
+/// If greedy_token is a Parakeet language token and guidance is configured,
+/// replace it with the highest-scoring guided language token.
+int apply_language_guidance(
+    const float* token_logits,
+    int greedy_token,
+    float* greedy_score,
+    const std::unordered_map<int, std::string>& token_to_language,
+    const std::vector<int>& guided_language_tokens);
+
+}  // namespace speech_core::parakeet

--- a/include/speech_core/models/parakeet_stt.h
+++ b/include/speech_core/models/parakeet_stt.h
@@ -56,6 +56,15 @@ public:
     TranscriptionResult end_stream() override;
     void cancel_stream() override;
 
+    /// Restrict Parakeet's language-token choice to one language.
+    /// Accepts ISO codes or BCP-47 tags ("en", "en-US"). "auto" clears it.
+    bool set_language(const std::string& language);
+
+    /// Restrict Parakeet's language-token choice to this shortlist.
+    /// Unknown languages are ignored; returns false if none resolve.
+    bool set_allowed_languages(const std::vector<std::string>& languages);
+    void clear_language_guidance();
+
 private:
     /// Internal decode result — converted to TranscriptionResult / PartialResult at the boundary.
     struct DecodeResult {
@@ -85,6 +94,7 @@ private:
 
     // Language tokens: token ID → ISO 639-1 code (e.g. 64 → "en", 71 → "fr")
     std::unordered_map<int, std::string> lang_tokens_;
+    std::vector<int> guided_lang_tokens_;
 
     // Streaming state
     std::vector<float> stream_buffer_;

--- a/src/models/litert/litert_parakeet_stt.cpp
+++ b/src/models/litert/litert_parakeet_stt.cpp
@@ -1,11 +1,13 @@
 #include "speech_core/models/litert_parakeet_stt.h"
 
 #include "speech_core/audio/mel.h"
+#include "speech_core/models/parakeet_language_guidance.h"
 #include "speech_core/util/json.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <utility>
 
 namespace speech_core {
 
@@ -62,6 +64,26 @@ bool LiteRTParakeetStt::load_vocab(const std::string& path) {
     LOGI("LiteRT Parakeet vocab: %zu tokens, %zu language tokens, blank=%d",
          vocab_.size(), lang_tokens_.size(), cfg_.blank_id);
     return !vocab_.empty();
+}
+
+bool LiteRTParakeetStt::set_language(const std::string& language) {
+    const std::string code = parakeet::normalize_language_code(language);
+    if (code.empty() || code == "auto") {
+        clear_language_guidance();
+        return true;
+    }
+    return set_allowed_languages({code});
+}
+
+bool LiteRTParakeetStt::set_allowed_languages(const std::vector<std::string>& languages) {
+    auto resolved = parakeet::resolve_language_tokens(lang_tokens_, languages);
+    if (resolved.empty()) return false;
+    guided_lang_tokens_ = std::move(resolved);
+    return true;
+}
+
+void LiteRTParakeetStt::clear_language_guidance() {
+    guided_lang_tokens_.clear();
 }
 
 // Decode token ids → text. SentencePiece ▁ (U+2581, UTF-8 E2 96 81) marks a
@@ -315,6 +337,8 @@ LiteRTParakeetStt::DecodeResult LiteRTParakeetStt::tdt_decode(
         for (int i = 1; i <= kVocab; ++i) {
             if (logits[i] > best_logit) { best_logit = logits[i]; best_token = i; }
         }
+        best_token = parakeet::apply_language_guidance(
+            logits.data(), best_token, &best_logit, lang_tokens_, guided_lang_tokens_);
 
         // argmax over the duration bins stored at [kBlank+1 ..].
         int   best_dur       = 0;

--- a/src/models/parakeet/parakeet_stt.cpp
+++ b/src/models/parakeet/parakeet_stt.cpp
@@ -2,11 +2,13 @@
 
 #include "speech_core/audio/mel.h"
 #include "speech_core/models/onnx_engine.h"
+#include "speech_core/models/parakeet_language_guidance.h"
 #include "speech_core/util/json.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <utility>
 
 namespace speech_core {
 
@@ -113,6 +115,26 @@ bool ParakeetStt::load_vocab(const std::string& path) {
     LOGI("Parakeet vocab: %zu tokens, %zu language tokens, blank=%d",
          vocab_.size(), lang_tokens_.size(), cfg_.blank_id);
     return !vocab_.empty();
+}
+
+bool ParakeetStt::set_language(const std::string& language) {
+    const std::string code = parakeet::normalize_language_code(language);
+    if (code.empty() || code == "auto") {
+        clear_language_guidance();
+        return true;
+    }
+    return set_allowed_languages({code});
+}
+
+bool ParakeetStt::set_allowed_languages(const std::vector<std::string>& languages) {
+    auto resolved = parakeet::resolve_language_tokens(lang_tokens_, languages);
+    if (resolved.empty()) return false;
+    guided_lang_tokens_ = std::move(resolved);
+    return true;
+}
+
+void ParakeetStt::clear_language_guidance() {
+    guided_lang_tokens_.clear();
 }
 
 std::string ParakeetStt::decode_tokens(const std::vector<int>& token_ids) {
@@ -495,6 +517,8 @@ ParakeetStt::DecodeResult ParakeetStt::tdt_decode(
                 best_token = i;
             }
         }
+        best_token = parakeet::apply_language_guidance(
+            logits, best_token, &best_score, lang_tokens_, guided_lang_tokens_);
 
         if (best_token == cfg_.blank_id) {
             // Blank: advance time, keep LSTM state unchanged

--- a/src/models/parakeet_language_guidance.cpp
+++ b/src/models/parakeet_language_guidance.cpp
@@ -1,0 +1,74 @@
+#include "speech_core/models/parakeet_language_guidance.h"
+
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <unordered_set>
+
+namespace speech_core::parakeet {
+
+std::string normalize_language_code(const std::string& language) {
+    std::string out;
+    out.reserve(language.size());
+    for (char ch : language) {
+        if (ch == '-' || ch == '_') break;
+        out.push_back(static_cast<char>(
+            std::tolower(static_cast<unsigned char>(ch))));
+    }
+    return out;
+}
+
+std::vector<int> resolve_language_tokens(
+    const std::unordered_map<int, std::string>& token_to_language,
+    const std::vector<std::string>& languages)
+{
+    std::unordered_map<std::string, int> language_to_token;
+    language_to_token.reserve(token_to_language.size());
+    for (const auto& [token, language] : token_to_language) {
+        language_to_token[normalize_language_code(language)] = token;
+    }
+
+    std::vector<int> resolved;
+    std::unordered_set<int> seen;
+    for (const auto& language : languages) {
+        const std::string code = normalize_language_code(language);
+        if (code.empty() || code == "auto") continue;
+        auto it = language_to_token.find(code);
+        if (it == language_to_token.end()) continue;
+        if (seen.insert(it->second).second) {
+            resolved.push_back(it->second);
+        }
+    }
+    return resolved;
+}
+
+int apply_language_guidance(
+    const float* token_logits,
+    int greedy_token,
+    float* greedy_score,
+    const std::unordered_map<int, std::string>& token_to_language,
+    const std::vector<int>& guided_language_tokens)
+{
+    if (token_logits == nullptr || guided_language_tokens.empty()) {
+        return greedy_token;
+    }
+    if (token_to_language.find(greedy_token) == token_to_language.end()) {
+        return greedy_token;
+    }
+
+    int best_token = greedy_token;
+    float best_score = -std::numeric_limits<float>::infinity();
+    for (int token : guided_language_tokens) {
+        const float score = token_logits[token];
+        if (score > best_score) {
+            best_score = score;
+            best_token = token;
+        }
+    }
+    if (greedy_score != nullptr) {
+        *greedy_score = best_score;
+    }
+    return best_token;
+}
+
+}  // namespace speech_core::parakeet

--- a/tests/test_litert_models.cpp
+++ b/tests/test_litert_models.cpp
@@ -254,6 +254,10 @@ void test_litert_parakeet_stt(const std::string& dir) {
     speech_core::LiteRTParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
     REQUIRE(stt.input_sample_rate() == 16000);
     REQUIRE(stt.supports_streaming());
+    REQUIRE(stt.set_language("en-US"));
+    REQUIRE(stt.set_allowed_languages({"fr-FR", "en-US"}));
+    REQUIRE(!stt.set_allowed_languages({"zz-ZZ"}));
+    REQUIRE(stt.set_language("auto"));
 
     std::vector<float> silence(16000 * 1, 0.0f);
     auto result = stt.transcribe(silence.data(), silence.size(), 16000);

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -310,6 +310,10 @@ void test_parakeet_stt(const std::string& dir) {
     speech_core::ParakeetStt stt(enc, dec, vocab, /*hw_accel=*/false);
     REQUIRE(stt.input_sample_rate() == 16000);
     REQUIRE(stt.supports_streaming());
+    REQUIRE(stt.set_language("en-US"));
+    REQUIRE(stt.set_allowed_languages({"fr-FR", "en-US"}));
+    REQUIRE(!stt.set_allowed_languages({"zz-ZZ"}));
+    REQUIRE(stt.set_language("auto"));
 
     // Pure silence → empty or near-empty transcription, no crash
     std::vector<float> silence(16000 * 1, 0.0f);

--- a/tests/test_parakeet_language_guidance.cpp
+++ b/tests/test_parakeet_language_guidance.cpp
@@ -1,0 +1,83 @@
+#include "speech_core/models/parakeet_language_guidance.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace speech_core;
+
+void test_normalize_language_code() {
+    assert(parakeet::normalize_language_code("en-US") == "en");
+    assert(parakeet::normalize_language_code("FR_fr") == "fr");
+    assert(parakeet::normalize_language_code("auto") == "auto");
+    assert(parakeet::normalize_language_code("") == "");
+    std::printf("  PASS: normalize_language_code\n");
+}
+
+void test_resolve_language_tokens() {
+    const std::unordered_map<int, std::string> tokens = {
+        {10, "en"},
+        {11, "fr"},
+        {12, "de"},
+    };
+
+    const auto resolved = parakeet::resolve_language_tokens(
+        tokens, {"fr-FR", "xx", "EN_us", "fr"});
+
+    assert(resolved.size() == 2);
+    assert(resolved[0] == 11);
+    assert(resolved[1] == 10);
+    std::printf("  PASS: resolve_language_tokens\n");
+}
+
+void test_guidance_leaves_non_language_tokens_alone() {
+    const std::unordered_map<int, std::string> tokens = {
+        {10, "en"},
+        {11, "fr"},
+    };
+    float logits[12] = {};
+    logits[4] = 9.0f;
+    logits[10] = 5.0f;
+    logits[11] = 6.0f;
+    float score = logits[4];
+
+    const int chosen = parakeet::apply_language_guidance(
+        logits, 4, &score, tokens, {10, 11});
+
+    assert(chosen == 4);
+    assert(std::abs(score - 9.0f) < 1e-6f);
+    std::printf("  PASS: guidance_leaves_non_language_tokens_alone\n");
+}
+
+void test_guidance_replaces_disallowed_language_token() {
+    const std::unordered_map<int, std::string> tokens = {
+        {10, "en"},
+        {11, "fr"},
+        {12, "de"},
+    };
+    float logits[13] = {};
+    logits[10] = 4.0f;
+    logits[11] = 6.0f;
+    logits[12] = 10.0f;
+    float score = logits[12];
+
+    const int chosen = parakeet::apply_language_guidance(
+        logits, 12, &score, tokens, {10, 11});
+
+    assert(chosen == 11);
+    assert(std::abs(score - 6.0f) < 1e-6f);
+    std::printf("  PASS: guidance_replaces_disallowed_language_token\n");
+}
+
+int main() {
+    std::printf("test_parakeet_language_guidance:\n");
+    test_normalize_language_code();
+    test_resolve_language_tokens();
+    test_guidance_leaves_non_language_tokens_alone();
+    test_guidance_replaces_disallowed_language_token();
+    std::printf("All Parakeet language guidance tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add shared Parakeet language-token guidance helpers.
- Expose set_language(), set_allowed_languages(), and clear_language_guidance() on ONNX and LiteRT Parakeet wrappers.
- Document the language-guidance behavior and add deterministic/unit plus model-smoke regression coverage.

## Test plan
- cmake -S . -B build-language-guidance -DCMAKE_BUILD_TYPE=Release -DSPEECH_CORE_WITH_ONNX=OFF -DSPEECH_CORE_WITH_LITERT=OFF -DSPEECH_CORE_BUILD_TESTS=ON
- cmake --build build-language-guidance
- ctest --test-dir build-language-guidance --output-on-failure (18/18 passed)
- cmake -S . -B build-language-guidance-onnx -DCMAKE_BUILD_TYPE=Release -DSPEECH_CORE_WITH_ONNX=ON -DSPEECH_CORE_WITH_LITERT=OFF -DSPEECH_CORE_BUILD_TESTS=ON -DORT_DIR=$PWD/build-ort-homebrew
- cmake --build build-language-guidance-onnx
- ctest --test-dir build-language-guidance-onnx --output-on-failure (19/19 passed)