### PR TITLE
Kokoro: survive and fully speak long inputs (capacity clamp + sentence-chunked synthesis)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(speech_core
     src/diarization/diarization_pipeline.cpp
     src/speech_core_c.cpp
     src/tts_synthesis_options.cpp
+    src/util/text_chunker.cpp
 )
 
 target_include_directories(speech_core

--- a/include/speech_core/models/kokoro_tts.h
+++ b/include/speech_core/models/kokoro_tts.h
@@ -32,6 +32,11 @@ public:
 private:
     std::vector<float> load_voice_embedding(const std::string& name);
     void auto_switch_voice(const std::string& language);
+    /// Synthesize one already-budgeted chunk of text. May emit nothing when
+    /// the output fails the numerical-stability guard.
+    void synthesize_chunk(const std::string& text,
+                          const TTSChunkCallback& on_chunk,
+                          bool is_final);
 
     const OrtApi* api_;
     OrtSession* session_ = nullptr;

--- a/include/speech_core/util/text_chunker.h
+++ b/include/speech_core/util/text_chunker.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Counts synthesis tokens for a piece of text (e.g. phonemizer tokens,
+/// including any per-call BOS/EOS the tokenizer adds).
+using TokenCounter = std::function<size_t(const std::string&)>;
+
+/// Split text into chunks suitable for fixed-capacity TTS synthesis.
+///
+/// Chunks are packed greedily to at most `max_tokens` each, preferring
+/// sentence boundaries, then clause boundaries (,;:), then word boundaries,
+/// then UTF-8 character boundaries for a single oversized word. A trailing
+/// chunk smaller than `min_tail_tokens` is merged into the previous chunk
+/// when the combined count stays within `hard_cap_tokens` (the model's
+/// absolute input capacity, typically larger than the packing budget), so
+/// tiny tail utterances — which some models synthesize unreliably — are
+/// avoided. Whitespace-only input yields no chunks.
+std::vector<std::string> chunk_text_for_synthesis(
+    const std::string& text,
+    const TokenCounter& count_tokens,
+    size_t max_tokens,
+    size_t hard_cap_tokens,
+    size_t min_tail_tokens);
+
+}  // namespace speech_core

--- a/src/models/kokoro/kokoro_tts.cpp
+++ b/src/models/kokoro/kokoro_tts.cpp
@@ -1,6 +1,7 @@
 #include "speech_core/models/kokoro_tts.h"
 
 #include "speech_core/models/onnx_engine.h"
+#include "speech_core/util/text_chunker.h"
 
 #include <algorithm>
 #include <cmath>
@@ -11,6 +12,17 @@
 namespace speech_core {
 
 static constexpr int MAX_PHONEMES = 128;
+
+// Packing budget for one synthesis call, in phonemizer tokens (BOS/EOS
+// included). The E2E export emits at most 120000 samples (5 s at 24 kHz),
+// which real speech reaches at roughly 17 phonemes/s — well before the
+// 128-phoneme input cap — so budget for the output tensor, not the input.
+// 72 tokens is ~4.2 s of speech, leaving margin for slow prosody.
+static constexpr size_t CHUNK_TOKEN_BUDGET = 72;
+// Chunks below this are synthesized unreliably (the numerical-stability
+// guard below drops ≤5-token outputs); merge such tails into the previous
+// chunk instead, up to the MAX_PHONEMES hard cap.
+static constexpr size_t MIN_TAIL_TOKENS = 12;
 
 KokoroTts::KokoroTts(
     const std::string& model_path,
@@ -99,6 +111,30 @@ void KokoroTts::synthesize(
     std::string lang = language.empty() ? "en" : language;
     phonemizer_.set_language(lang);
     auto_switch_voice(lang);
+
+    // The E2E export bounds one synthesis call twice: the input tensor holds
+    // MAX_PHONEMES tokens (tokenize() silently truncates beyond it) and the
+    // output tensor holds 5 s of audio, reached at roughly 17 phonemes/s —
+    // well before the input cap. Split long text into sentence-preferring
+    // chunks whose real speech fits the output budget, and synthesize them
+    // sequentially; each chunk keeps natural prosody and the seams land on
+    // sentence/clause boundaries.
+    auto count_tokens = [this](const std::string& t) {
+        return phonemizer_.tokenize(t, 1 << 20).size();
+    };
+    auto chunks = chunk_text_for_synthesis(
+        text, count_tokens, CHUNK_TOKEN_BUDGET, MAX_PHONEMES,
+        MIN_TAIL_TOKENS);
+    for (size_t i = 0; i < chunks.size(); i++) {
+        if (cancelled_) return;
+        synthesize_chunk(chunks[i], on_chunk, i + 1 == chunks.size());
+    }
+}
+
+void KokoroTts::synthesize_chunk(
+    const std::string& text, const TTSChunkCallback& on_chunk,
+    bool is_final)
+{
     auto* mem = OnnxEngine::get().cpu_memory();
 
     // Text → phoneme token IDs
@@ -189,10 +225,14 @@ void KokoroTts::synthesize(
         OrtTensorTypeAndShapeInfo* audio_info = nullptr;
         ort_check(api_, api_->GetTensorTypeAndShape(outputs[0], &audio_info));
         size_t audio_capacity = 0;
-        ort_check(api_, api_->GetTensorShapeElementCount(audio_info, &audio_capacity));
+        // ort_check throws; release the info before checking the status so
+        // the failure path cannot leak it.
+        OrtStatus* count_status =
+            api_->GetTensorShapeElementCount(audio_info, &audio_capacity);
         api_->ReleaseTensorTypeAndShapeInfo(audio_info);
+        ort_check(api_, count_status);
         if (valid_samples > audio_capacity) {
-            LOGI("TTS: reported %zu samples exceeds audio tensor capacity %zu — "
+            LOGI("TTS: reported %zu samples exceeds audio tensor capacity %zu - "
                  "clamping (max-length input? text='%.40s')",
                  valid_samples, audio_capacity, text.c_str());
             valid_samples = audio_capacity;
@@ -258,9 +298,10 @@ void KokoroTts::synthesize(
             audio[i] *= static_cast<float>(i) / static_cast<float>(fade_in);
         }
 
-        LOGI("TTS: valid=%zu speech_end=%zu peak=%.4f", valid_samples, speech_end, peak);
+        LOGI("TTS: valid=%zu speech_end=%zu peak=%.4f final=%d",
+             valid_samples, speech_end, peak, is_final ? 1 : 0);
 
-        on_chunk(audio, speech_end, true);
+        on_chunk(audio, speech_end, is_final);
     }
 
     // --- cleanup ---

--- a/src/models/kokoro/kokoro_tts.cpp
+++ b/src/models/kokoro/kokoro_tts.cpp
@@ -177,7 +177,26 @@ void KokoroTts::synthesize(
         // Get valid sample count from model
         int64_t* len_ptr = nullptr;
         ort_check(api_, api_->GetTensorMutableData(outputs[1], (void**)&len_ptr));
-        size_t valid_samples = static_cast<size_t>(len_ptr[0]);
+        size_t valid_samples =
+            static_cast<size_t>(std::max<int64_t>(len_ptr[0], 0));
+
+        // audio_length_samples is predicted from summed durations, but the
+        // E2E export writes audio into a fixed-capacity tensor. Near the
+        // 128-phoneme input cap the prediction can exceed that capacity, and
+        // trusting it walked the loops below past the allocation (SIGSEGV on
+        // any text long enough to fill the input). Clamp to the tensor's
+        // real element count.
+        OrtTensorTypeAndShapeInfo* audio_info = nullptr;
+        ort_check(api_, api_->GetTensorTypeAndShape(outputs[0], &audio_info));
+        size_t audio_capacity = 0;
+        ort_check(api_, api_->GetTensorShapeElementCount(audio_info, &audio_capacity));
+        api_->ReleaseTensorTypeAndShapeInfo(audio_info);
+        if (valid_samples > audio_capacity) {
+            LOGI("TTS: reported %zu samples exceeds audio tensor capacity %zu — "
+                 "clamping (max-length input? text='%.40s')",
+                 valid_samples, audio_capacity, text.c_str());
+            valid_samples = audio_capacity;
+        }
 
         // Inspect peak before any processing — short prompts (≤5 tokens) can
         // make the E2E ONNX export numerically explode (peak in the hundreds).

--- a/src/util/text_chunker.cpp
+++ b/src/util/text_chunker.cpp
@@ -1,0 +1,165 @@
+#include "speech_core/util/text_chunker.h"
+
+namespace speech_core {
+
+namespace {
+
+bool is_sentence_end(char c) { return c == '.' || c == '!' || c == '?'; }
+bool is_clause_end(char c) { return c == ',' || c == ';' || c == ':'; }
+
+std::string trimmed(const std::string& s) {
+    const char* ws = " \t\r\n";
+    size_t begin = s.find_first_not_of(ws);
+    if (begin == std::string::npos) return "";
+    size_t end = s.find_last_not_of(ws);
+    return s.substr(begin, end - begin + 1);
+}
+
+// Split into units, keeping end-punctuation attached to the preceding unit.
+// Newlines are treated as boundaries too, so list-style text splits cleanly.
+std::vector<std::string> split_units(const std::string& text,
+                                     bool (*is_end)(char)) {
+    std::vector<std::string> units;
+    std::string current;
+    for (size_t i = 0; i < text.size(); i++) {
+        char c = text[i];
+        if (c == '\n') {
+            auto t = trimmed(current);
+            if (!t.empty()) units.push_back(t);
+            current.clear();
+            continue;
+        }
+        current.push_back(c);
+        if (is_end(c)) {
+            // Absorb runs of enders and a trailing closing quote so "..." or
+            // '?!"' stays with its sentence.
+            while (i + 1 < text.size() &&
+                   (is_end(text[i + 1]) || text[i + 1] == '"' ||
+                    text[i + 1] == '\'')) {
+                current.push_back(text[++i]);
+            }
+            auto t = trimmed(current);
+            if (!t.empty()) units.push_back(t);
+            current.clear();
+        }
+    }
+    auto t = trimmed(current);
+    if (!t.empty()) units.push_back(t);
+    return units;
+}
+
+std::vector<std::string> split_words(const std::string& text) {
+    std::vector<std::string> words;
+    std::string current;
+    for (char c : text) {
+        if (c == ' ' || c == '\t') {
+            if (!current.empty()) {
+                words.push_back(current);
+                current.clear();
+            }
+        } else {
+            current.push_back(c);
+        }
+    }
+    if (!current.empty()) words.push_back(current);
+    return words;
+}
+
+size_t utf8_char_len(unsigned char byte) {
+    if ((byte & 0x80) == 0x00) return 1;
+    if ((byte & 0xE0) == 0xC0) return 2;
+    if ((byte & 0xF0) == 0xE0) return 3;
+    if ((byte & 0xF8) == 0xF0) return 4;
+    return 1;  // invalid lead byte — advance one byte, never split worse
+}
+
+// Last resort for a single word the budget cannot hold: cut on UTF-8
+// character boundaries.
+std::vector<std::string> split_chars(const std::string& word,
+                                     const TokenCounter& count,
+                                     size_t max_tokens) {
+    std::vector<std::string> parts;
+    std::string current;
+    size_t i = 0;
+    while (i < word.size()) {
+        size_t len = utf8_char_len(static_cast<unsigned char>(word[i]));
+        if (i + len > word.size()) len = word.size() - i;
+        std::string candidate = current + word.substr(i, len);
+        if (!current.empty() && count(candidate) > max_tokens) {
+            parts.push_back(current);
+            current = word.substr(i, len);
+        } else {
+            current = std::move(candidate);
+        }
+        i += len;
+    }
+    if (!current.empty()) parts.push_back(current);
+    return parts;
+}
+
+// Greedily pack `units` into chunks of at most `max_tokens`; a unit that is
+// alone too large is refined at the next split level.
+void pack_units(const std::vector<std::string>& units,
+                const TokenCounter& count, size_t max_tokens, int level,
+                std::vector<std::string>& out) {
+    std::string acc;
+    auto flush = [&]() {
+        if (!acc.empty()) {
+            out.push_back(acc);
+            acc.clear();
+        }
+    };
+    for (const auto& unit : units) {
+        std::string candidate = acc.empty() ? unit : acc + " " + unit;
+        if (count(candidate) <= max_tokens) {
+            acc = std::move(candidate);
+            continue;
+        }
+        flush();
+        if (count(unit) <= max_tokens) {
+            acc = unit;
+            continue;
+        }
+        // The unit alone exceeds the budget — refine it.
+        std::vector<std::string> finer;
+        if (level == 0) {
+            finer = split_units(unit, is_clause_end);
+        } else if (level == 1) {
+            finer = split_words(unit);
+        }
+        if (level >= 2 || finer.size() <= 1) {
+            for (auto& part : split_chars(unit, count, max_tokens)) {
+                out.push_back(std::move(part));
+            }
+        } else {
+            pack_units(finer, count, max_tokens, level + 1, out);
+        }
+    }
+    flush();
+}
+
+}  // namespace
+
+std::vector<std::string> chunk_text_for_synthesis(
+    const std::string& text, const TokenCounter& count_tokens,
+    size_t max_tokens, size_t hard_cap_tokens, size_t min_tail_tokens) {
+    std::vector<std::string> chunks;
+    if (max_tokens == 0) return chunks;
+
+    pack_units(split_units(text, is_sentence_end), count_tokens, max_tokens,
+               0, chunks);
+
+    // Merge an unreliably-small tail into its predecessor when the model's
+    // hard input capacity allows it.
+    if (chunks.size() >= 2 &&
+        count_tokens(chunks.back()) < min_tail_tokens) {
+        std::string merged = chunks[chunks.size() - 2] + " " + chunks.back();
+        if (count_tokens(merged) <= hard_cap_tokens) {
+            chunks.pop_back();
+            chunks.back() = std::move(merged);
+        }
+    }
+    return chunks;
+}
+
+}  // namespace speech_core

--- a/tests/test_text_chunker.cpp
+++ b/tests/test_text_chunker.cpp
@@ -1,0 +1,177 @@
+#include "speech_core/util/text_chunker.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace speech_core;
+
+// Deterministic stand-in for the phonemizer: one token per non-space
+// character plus two for BOS/EOS, mirroring how real tokenizers charge a
+// fixed per-call overhead.
+static size_t fake_count(const std::string& text) {
+    size_t n = 2;
+    for (char c : text) {
+        if (c != ' ' && c != '\t') n++;
+    }
+    return n;
+}
+
+static std::vector<std::string> chunk(const std::string& text,
+                                      size_t budget,
+                                      size_t hard_cap = 128,
+                                      size_t min_tail = 12) {
+    return chunk_text_for_synthesis(text, fake_count, budget, hard_cap,
+                                    min_tail);
+}
+
+void test_empty_and_whitespace() {
+    assert(chunk("", 72).empty());
+    assert(chunk("   \n\t  ", 72).empty());
+    printf("  PASS: empty_and_whitespace\n");
+}
+
+void test_short_text_single_chunk() {
+    auto chunks = chunk("Music stopped.", 72);
+    assert(chunks.size() == 1);
+    assert(chunks[0] == "Music stopped.");
+    printf("  PASS: short_text_single_chunk\n");
+}
+
+void test_sentences_pack_together() {
+    // Two short sentences fit one budget: they must not be split apart.
+    auto chunks = chunk("Calling Anna. Please wait.", 72);
+    assert(chunks.size() == 1);
+    assert(chunks[0] == "Calling Anna. Please wait.");
+    printf("  PASS: sentences_pack_together\n");
+}
+
+void test_splits_on_sentence_boundary() {
+    std::string a = "The first sentence is fairly long already.";
+    std::string b = "The second sentence is also fairly long.";
+    size_t budget = fake_count(a) + 4;  // one fits, both do not
+    auto chunks = chunk(a + " " + b, budget);
+    assert(chunks.size() == 2);
+    assert(chunks[0] == a);
+    assert(chunks[1] == b);
+    printf("  PASS: splits_on_sentence_boundary\n");
+}
+
+void test_budget_respected() {
+    std::string text =
+        "I can call your contacts, dial numbers, look up phone numbers, "
+        "play or stop music, and set the volume, all offline, on this "
+        "device. Ask me anything you like. There is more where that came "
+        "from!";
+    size_t budget = 72;
+    auto chunks = chunk(text, budget);
+    assert(chunks.size() >= 2);
+    for (const auto& c : chunks) {
+        assert(fake_count(c) <= budget);
+        assert(!c.empty());
+    }
+    printf("  PASS: budget_respected\n");
+}
+
+void test_clause_fallback_for_run_on_sentence() {
+    // No sentence enders: must fall back to clause boundaries.
+    std::string text =
+        "first clause goes here, second clause goes here, third clause "
+        "goes here, fourth clause goes here";
+    size_t budget = 30;
+    auto chunks = chunk(text, budget);
+    assert(chunks.size() >= 2);
+    for (const auto& c : chunks) assert(fake_count(c) <= budget);
+    printf("  PASS: clause_fallback_for_run_on_sentence\n");
+}
+
+void test_word_fallback() {
+    // No punctuation at all.
+    std::string text = "one two three four five six seven eight nine ten";
+    size_t budget = 12;
+    auto chunks = chunk(text, budget, 128, 3);
+    assert(chunks.size() >= 3);
+    for (const auto& c : chunks) assert(fake_count(c) <= budget);
+    printf("  PASS: word_fallback\n");
+}
+
+void test_monster_word_char_split() {
+    std::string word(50, 'x');
+    size_t budget = 12;
+    auto chunks = chunk(word, budget, 128, 3);
+    assert(chunks.size() >= 4);
+    std::string rejoined;
+    for (const auto& c : chunks) {
+        assert(fake_count(c) <= budget);
+        rejoined += c;
+    }
+    assert(rejoined == word);
+    printf("  PASS: monster_word_char_split\n");
+}
+
+void test_utf8_never_split_mid_character() {
+    // Two-byte characters (ü, é) and a three-byte character (中) repeated
+    // into an unbroken word; chunks must never begin with a continuation
+    // byte (0b10xxxxxx).
+    std::string word;
+    for (int i = 0; i < 12; i++) word += "\xC3\xBC\xE4\xB8\xAD";  // ü中
+    auto chunks = chunk(word, 10, 128, 2);
+    assert(chunks.size() >= 2);
+    std::string rejoined;
+    for (const auto& c : chunks) {
+        assert(!c.empty());
+        assert((static_cast<unsigned char>(c[0]) & 0xC0) != 0x80);
+        rejoined += c;
+    }
+    assert(rejoined == word);
+    printf("  PASS: utf8_never_split_mid_character\n");
+}
+
+void test_tiny_tail_merges() {
+    std::string a = "This is a reasonably sized first sentence here.";
+    std::string b = "Ok.";
+    size_t budget = fake_count(a) + 2;  // tail cannot pack into the chunk
+    auto chunks = chunk(a + " " + b, budget, /*hard_cap=*/128,
+                        /*min_tail=*/12);
+    // "Ok." is below min_tail and the hard cap allows the merge.
+    assert(chunks.size() == 1);
+    assert(chunks[0] == a + " " + b);
+    printf("  PASS: tiny_tail_merges\n");
+}
+
+void test_tiny_tail_kept_when_hard_cap_blocks() {
+    std::string a = "This is a reasonably sized first sentence here.";
+    std::string b = "Ok.";
+    size_t budget = fake_count(a) + 2;
+    // Hard cap equal to the budget: the merge would overflow, keep the tail.
+    auto chunks = chunk(a + " " + b, budget, /*hard_cap=*/budget,
+                        /*min_tail=*/12);
+    assert(chunks.size() == 2);
+    assert(chunks[1] == b);
+    printf("  PASS: tiny_tail_kept_when_hard_cap_blocks\n");
+}
+
+void test_newlines_are_boundaries() {
+    auto chunks = chunk("Line one has words\nLine two has words", 18);
+    assert(chunks.size() == 2);
+    printf("  PASS: newlines_are_boundaries\n");
+}
+
+int main() {
+    printf("test_text_chunker:\n");
+    test_empty_and_whitespace();
+    test_short_text_single_chunk();
+    test_sentences_pack_together();
+    test_splits_on_sentence_boundary();
+    test_budget_respected();
+    test_clause_fallback_for_run_on_sentence();
+    test_word_fallback();
+    test_monster_word_char_split();
+    test_utf8_never_split_mid_character();
+    test_tiny_tail_merges();
+    test_newlines_are_boundaries();
+    test_tiny_tail_kept_when_hard_cap_blocks();
+    printf("All text_chunker tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
Two commits fixing long-input synthesis end to end.

**1. Capacity clamp (crash fix).** `KokoroTts::synthesize()` trusted the model-reported `audio_length_samples` when reading the output tensor. The E2E export writes audio into a fixed 120000-sample (5 s @ 24 kHz) tensor but predicts the length from summed durations — near the 128-phoneme input cap the prediction exceeds the tensor's real size (191400 samples observed), so the peak/trim/fade loops read up to ~285 KB past the allocation: deterministic SIGSEGV (SEGV_ACCERR, constant offset) on any sufficiently long text. Seen as 8 tombstones over two days in the Control demo. `valid_samples` is now clamped to the audio tensor's actual element count (negative-length guarded; shape info released before `ort_check` can throw).

**2. Sentence-chunked synthesis (content fix).** Even clamped, one call is bounded twice: `tokenize()` silently truncates past 128 phonemes, and real speech hits the 5 s output ceiling at ~17 phonemes/s — so long text lost its tail. New `chunk_text_for_synthesis()` in the core library packs text greedily to a token budget with sentence → clause → word → UTF-8-character fallbacks and a minimum-tail merge (the stability guard drops ≤5-token outputs, so tiny tails fold into their predecessor). `synthesize()` splits to a 72-token budget (~4.2 s per chunk) and synthesizes sequentially: natural pauses at sentence/clause seams, `cancel()` honored between chunks, `is_final` on the last chunk only. Both existing chunk consumers (JNI `synthesize_pcm16`, `VoicePipeline`) already accumulate multi-chunk output and guard per-chunk state.

## Test plan
- **Unit**: new `test_text_chunker` in the default ctest suite — 12 cases covering packing, boundary preference, all fallback levels, UTF-8 boundary safety, tail-merge and hard-cap interaction, budget invariants. Full suite: 19/19 pass on macOS host (default config).
- **On-emulator (arm64, API 35, NDK build via the speech-android composite)**: the ~130-char reply that previously crashed every time now synthesizes as two clause-boundary chunks (57 + 63 tokens, `final=0`/`final=1`), 7.6 s of complete speech, no clamp warnings, no new tombstones across repeated turns; short single-chunk replies unchanged.
- ONNX-config compilation covered by the Android NDK build (host ORT not configured in this environment).

## Follow-ups (out of scope)
- Pre-existing leak-on-throw pattern for ORT values throughout `synthesize_chunk` error paths.
- `tokenize()` still truncates silently if a single chunk ever exceeds the input cap (unreachable via the chunker's budget, reachable for direct callers).