### PR TITLE
Optimize Kokoro short-turn synthesis

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -85,7 +85,8 @@ The callback is invoked for each audio chunk during synthesis. `is_final=true` m
 
 `synthesize()` is the streaming API and is not deprecated. `synthesize_with_options()` is the uniform delivery/post-processing API for all TTS implementations through the base default. `Streaming` with no post-processing delegates to `synthesize()`. `Buffered` accumulates all PCM for the submitted text input, applies the requested offline post-processing chain, then invokes the callback once with `is_final=true`. Any offline post-processing belongs on the complete buffered result, not on individual streaming chunks or internal text chunks. Models only need to override `synthesize_with_options()` when they need custom buffering around internal decoder chunks. `VoicePipeline` currently calls `synthesize()` unless a future pipeline config threads synthesis options through.
 
-**Reference implementation:** `KokoroTts` (Kokoro 82M via ONNX Runtime, single-chunk output).
+**Reference implementation:** `KokoroTts` (Kokoro 82M via ONNX Runtime;
+sentence/chunk-split output with a final marker).
 
 **Swift counterpart:** `SpeechGenerationModel`.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -541,9 +541,9 @@ auto final = stt.end_stream();
 ```
 
 - Parakeet-EOU-120M — multilingual (25 European) streaming RNN-T with inline
-  end-of-utterance detection. **~231 MB peak RSS on a Galaxy S23** (arm64 CPU,
+  end-of-utterance detection. **~231 MB peak RSS on a Galaxy S23 Ultra** (arm64 CPU,
   native; ~377 MB on desktop) — 5–6× lighter than Parakeet-TDT 0.6B (~1.1–1.3 GB)
-  and comfortably real-time on a phone (RTF 0.21 on the S23).
+  and comfortably real-time on a phone (RTF 0.21 on the S23 Ultra).
 - Streaming windowing mirrors the reference session: a `melFrames * hop` window
   advanced by `outputFrames * subsamplingFactor * hop` samples (overlapping),
   committing `outputFrames` encoder frames per step. Pre-emphasis (config
@@ -558,8 +558,8 @@ auto final = stt.end_stream();
 
 ## On-device benchmarks
 
-Measured on a Samsung Galaxy S23 (SM-S918B, arm64), CPU only, INT8 where noted.
-RTF is wall-seconds ÷ audio-seconds (lower = faster than real time; <1.0 = real time); RSS is peak
+Measured on a Samsung Galaxy S23 Ultra (SM-S918B, arm64), CPU only, INT8 where noted.
+RTF is wall-seconds ÷ audio-seconds (lower is faster; <1.0 is faster than real time); RSS is peak
 resident set. STT rows use a 20 s clip; TTS reports RTF or time-to-first-audio (TTFA);
 the LLM row reports tool-call decode throughput in tokens/s.
 
@@ -570,12 +570,19 @@ the LLM row reports tool-call decode throughput in tokens/s.
 | Nemotron streaming 0.6B | streaming STT | LiteRT | ~1.30 GB | 0.67 RTF |
 | Parakeet-TDT 0.6B | STT (batch) | ONNX INT8 | ~1.15 GB | 0.082 RTF |
 | SupertonicTTS-3 (99M) | TTS (preset voice) | LiteRT | ~832 MB | 0.34 RTF · ~1.1 s TTFA |
-| Kokoro-82M | TTS (preset voice) | ONNX FP32 | ~640 MB | 0.53 RTF |
+| Kokoro-82M (full graph, published two-thread CPU default) | TTS (preset voice) | ONNX FP32 | ~604 MiB | 1.81 RTF |
+| Kokoro-82M (full graph, four-thread local tuning) | TTS (preset voice) | ONNX FP32 | ~604 MiB | 1.16 RTF |
+| Kokoro-82M (realtime 3.0 s short-turn graph) | TTS (preset voice) | ONNX FP32 | ~527 MiB | **0.75–0.88 RTF** |
 | FunctionGemma-270M | LLM (tool calls) | LiteRT-LM | ~611 MB | ~118 tok/s |
 
 - Supertonic runs 3 diffusion steps and streams (first audio ~1.1 s while the rest
-  synthesizes); Kokoro is single-pass and one-shot, so its first audio equals full
-  synthesis (~2.6 s for a 5 s line at 0.53 RTF).
+  synthesizes). Each Kokoro text chunk is one non-autoregressive graph run, so its
+  first audio for that chunk equals its synthesis time. The published two-thread
+  full graph measured ~4.16 s for a 2.3 s line; four-thread local tuning measured
+  ~2.66 s. The published 120-frame realtime graph measured a 1.73 s p50 for that line.
+  Physical-device runs vary with thermal state (0.75–0.88 RTF here). The short-turn
+  result describes an in-profile English reply, not a worst-case long-form result;
+  output beyond the 2.8 s guarded limit is split and retried safely.
 - Disabling the ONNX CPU memory arena (now the default) cut Parakeet-TDT peak RSS
   from ~1.34 GB to ~1.15 GB (−15%) for ~1% throughput.
 - Parakeet-EOU is the lightest STT here while staying multilingual + streaming —
@@ -834,7 +841,7 @@ auto segments = diar.diarize(audio, length, 16000, cfg);  // [{start,end,speaker
 #include <speech_core/models/kokoro_tts.h>
 
 speech_core::KokoroTts tts(
-    "/models/kokoro.onnx",
+    "/models/kokoro-e2e.onnx",
     "/models/kokoro_voices",   // directory of .bin voice embeddings
     "/models/kokoro_data");    // directory of vocab + dictionaries
 
@@ -844,13 +851,41 @@ tts.synthesize("Hello world", "en",
     });
 ```
 
-- Kokoro 82M, non-autoregressive single-pass synthesis
+For tightly bounded voice-agent replies, select a compatible 120-frame
+short-turn graph. The official `kokoro-e2e-realtime.onnx` filename selects the
+matching runtime profile automatically. The graph is published in the linked
+public model repository and reuses the full graph's external weight file.
+
+```cpp
+auto profile = speech_core::KokoroTts::Config::short_turn_3s();
+speech_core::KokoroTts tts(
+    "/models/kokoro-e2e-realtime.onnx",
+    "/models/voices", "/models", profile);
+```
+
+The explicit profile remains useful for a renamed graph. With the official
+filename, the existing bool constructor selects it automatically:
+
+```cpp
+speech_core::KokoroTts tts(
+    "/models/kokoro-e2e-realtime.onnx",
+    "/models/voices", "/models", /*hw_accel=*/false);
+```
+
+`short_turn_3p5s()` remains available for a compatible 140-frame graph when
+fewer split/retries are more important than the shorter graph's latency.
+
+- Kokoro 82M, non-autoregressive synthesis; long input is sentence/chunk split
 - 24 kHz Float32 output
-- Single chunk per call (E2E model, not streaming-capable)
+- One callback per safe internal text chunk; `is_final=true` marks the final one
 - Auto-switches voice on language change (en → af_heart, fr → ff_siwis, …)
 - Phonemizer: GPL-free three-tier (dict + suffix stemming + rule-based G2P), no eSpeak dependency. See `kokoro_phonemizer.h` + `kokoro_multilingual.h`.
-- Output post-processing: peak-clip detection (drops numerically unstable short prompts), trailing-silence trim, 5 ms fade-in / 10 ms fade-out at the speech boundary
-- Model files: [soniqo/Kokoro-82M-ONNX](https://huggingface.co/soniqo/Kokoro-82M-ONNX) — `kokoro-e2e.onnx` + `kokoro-e2e.onnx.data` (~90 MB total), `vocab_index.json`, `us_gold.json`, `us_silver.json`, `dict_{fr,es,it,pt,hi}.json`, `voices/*.bin`
+- Unsafe length, non-finite PCM, or numerical instability triggers bounded split/retry; output is never clamped or silently dropped
+- Output post-processing: trailing-silence trim, 5 ms fade-in / 10 ms fade-out at the speech boundary
+- Kokoro CPU sessions use four intra-op threads by default for its large
+  inference run in each internal chunk. `SPEECH_CORE_KOKORO_ORT_THREADS` overrides the
+  global `SPEECH_CORE_ORT_THREADS` setting when a device needs separate tuning.
+- Default public bundle files: [soniqo/Kokoro-82M-ONNX](https://huggingface.co/soniqo/Kokoro-82M-ONNX) — `kokoro-e2e-realtime.onnx` (the Android default) or `kokoro-e2e.onnx`, one shared `kokoro-e2e.onnx.data` weight file (~310 MiB), plus `vocab_index.json`, `us_gold.json`, `us_silver.json`, `dict_{fr,es,it,pt,hi}.json`, and `voices/*.bin`.
 
 ### Voice files
 

--- a/include/speech_core/models/kokoro_tts.h
+++ b/include/speech_core/models/kokoro_tts.h
@@ -4,20 +4,57 @@
 #include "speech_core/models/kokoro_phonemizer.h"
 
 #include <onnxruntime_c_api.h>
+#include <atomic>
+#include <cstddef>
 #include <string>
 #include <vector>
 
 namespace speech_core {
 
 /// Kokoro 82M — lightweight text-to-speech via ONNX Runtime.
-/// Non-autoregressive, single-pass synthesis.
+/// Non-autoregressive synthesis, sentence-chunked for bounded model exports.
 /// Output: 24 kHz PCM Float32.
 class KokoroTts : public TTSInterface {
 public:
+    struct Config {
+        bool hw_accel = true;
+
+        /// Preferred packing budget and absolute phoneme-token ceiling for
+        /// each internal model run. Tiny tails may first merge with the prior
+        /// text chunk, but a preflight split keeps every actual run at or
+        /// below `chunk_token_hard_cap`.
+        size_t chunk_token_budget = 72;
+        size_t chunk_token_hard_cap = 128;
+
+        /// Optional additional output limit validated for this graph. The
+        /// runtime always reserves a structural tail margin below the tensor
+        /// capacity; nonzero values can lower that safe limit further.
+        size_t max_safe_output_samples = 0;
+
+        /// Published 120-frame (3.0 s physical / 2.8 s guarded) graph profile
+        /// for tightly bounded voice-agent replies. The caller must supply the
+        /// matching graph; unsafe outputs split and retry safely.
+        static Config short_turn_3s(bool hw_accel = true);
+
+        /// Selects the matching profile for an official Kokoro graph path.
+        /// `kokoro-e2e-realtime.onnx` uses the 3.0 s short-turn default;
+        /// all other paths retain the full-graph configuration.
+        static Config default_for_model_path(const std::string& model_path,
+                                             bool hw_accel = true);
+
+        /// Validated 140-frame (3.5 s physical / 3.3 s guarded) graph profile
+        /// for bounded Android voice-agent replies.
+        static Config short_turn_3p5s(bool hw_accel = true);
+    };
+
     KokoroTts(const std::string& model_path,
               const std::string& voices_dir,
               const std::string& data_dir,
               bool hw_accel = true);
+    KokoroTts(const std::string& model_path,
+              const std::string& voices_dir,
+              const std::string& data_dir,
+              const Config& config);
     ~KokoroTts() override;
 
     // --- TTSInterface ---
@@ -30,13 +67,18 @@ public:
     void set_voice(const std::string& name);
 
 private:
+    enum class ChunkResult { Emitted, RetrySmaller, Cancelled };
+
     std::vector<float> load_voice_embedding(const std::string& name);
     void auto_switch_voice(const std::string& language);
-    /// Synthesize one already-budgeted chunk of text. May emit nothing when
-    /// the output fails the numerical-stability guard.
-    void synthesize_chunk(const std::string& text,
-                          const TTSChunkCallback& on_chunk,
-                          bool is_final);
+    bool synthesize_with_retry(const std::string& text,
+                               const TTSChunkCallback& on_chunk,
+                               bool is_final,
+                               size_t depth,
+                               size_t& inference_attempts);
+    ChunkResult synthesize_chunk(const std::string& text,
+                                 const TTSChunkCallback& on_chunk,
+                                 bool is_final);
 
     const OrtApi* api_;
     OrtSession* session_ = nullptr;
@@ -45,7 +87,8 @@ private:
     std::vector<float> voice_embedding_;
     std::string voices_dir_;
     std::string current_lang_;
-    bool cancelled_ = false;
+    Config config_;
+    std::atomic<bool> cancelled_{false};
 };
 
 }  // namespace speech_core

--- a/include/speech_core/models/onnx_engine.h
+++ b/include/speech_core/models/onnx_engine.h
@@ -91,8 +91,8 @@ public:
     /// short calls per utterance (decoder-joint runs ~50 times, each on
     /// tiny tensors; thread-pool overhead per call > parallel-GEMM win).
     /// Measured on the LibriSpeech-100 bench (LiteRT v2.1, ORT 1.26 CUDA):
-    ///   intra=2  CPU 28.77x RTF / CUDA 32.91x RTF (baseline)
-    ///   intra=16 CPU 24.25x RTF / CUDA 26.49x RTF (15–20% slower)
+    ///   intra=2  CPU 28.77x real-time / CUDA 32.91x (baseline)
+    ///   intra=16 CPU 24.25x real-time / CUDA 26.49x (15–20% slower)
     /// The env var stays available for long-utterance / large-batch
     /// workloads where the parallel win does dominate.
     static int resolve_intra_threads(int override_threads = 0) {
@@ -108,6 +108,7 @@ public:
                      bool capture_hint = false, int intra_threads = 0) {
         OrtSessionOptions* opts = nullptr;
         ort_check(api_, api_->CreateSessionOptions(&opts));
+        enable_profiling_if_requested(opts);
         // Optimization level — default ORT_ENABLE_ALL, lowered via
         // SPEECH_CORE_ORT_OPT_LEVEL=disable_all/basic/extended. For INT8
         // dynamic-quantized models the heavier passes (DequantizeLinearFusion,
@@ -186,9 +187,9 @@ public:
         // large pool up front, and the memory-pattern planner reserves a
         // contiguous activation buffer sized for the whole graph. Disabling
         // both drops peak resident memory materially at a small throughput
-        // cost. Measured on a Galaxy S23 (Parakeet-TDT-0.6B INT8, CPU):
-        // 1342 MB -> 1147 MB peak RSS (-15%), RTF 12.9x -> 12.2x (-6%, still
-        // ~12x real time). On-device / embedded targets are memory-bound, not
+        // cost. Measured on a Galaxy S23 Ultra (Parakeet-TDT-0.6B INT8, CPU):
+        // 1342 MB -> 1147 MB peak RSS (-15%), throughput 12.9x -> 12.2x
+        // real-time (-6%). On-device / embedded targets are memory-bound, not
         // throughput-bound here, so this is the right default.
         ort_check(api_, api_->DisableCpuMemArena(opts));
         ort_check(api_, api_->DisableMemPattern(opts));
@@ -260,6 +261,7 @@ public:
 
             opts = nullptr;
             ort_check(api_, api_->CreateSessionOptions(&opts));
+            enable_profiling_if_requested(opts);
             ort_check(api_, api_->SetSessionGraphOptimizationLevel(opts, ORT_ENABLE_ALL));
             ort_check(api_, api_->SetIntraOpNumThreads(
                 opts, resolve_intra_threads(intra_threads)));
@@ -294,6 +296,16 @@ public:
     }
 
 private:
+    /// Write an ORT JSON trace when explicitly requested. ORT appends its own
+    /// timestamp/suffix to this prefix, so multiple sessions remain distinct.
+    /// Kept opt-in because profiling itself changes latency measurements.
+    void enable_profiling_if_requested(OrtSessionOptions* opts) const {
+        const char* prefix = std::getenv("SPEECH_CORE_ORT_PROFILE_PREFIX");
+        if (!prefix || prefix[0] == '\0') return;
+        const OrtPathStr ort_prefix = to_ort_path(prefix);
+        ort_check(api_, api_->EnableProfiling(opts, ort_prefix.c_str()));
+    }
+
     OnnxEngine() {
         api_ = OrtGetApiBase()->GetApi(ORT_API_VERSION);
         ort_check(api_, api_->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "speech", &env_));

--- a/include/speech_core/util/text_chunker.h
+++ b/include/speech_core/util/text_chunker.h
@@ -27,4 +27,16 @@ std::vector<std::string> chunk_text_for_synthesis(
     size_t hard_cap_tokens,
     size_t min_tail_tokens);
 
+/// Split one unsafe synthesis chunk into two balanced, strictly smaller
+/// pieces. Semantic boundary class (sentence, clause, then word) takes
+/// priority over balance; UTF-8 character boundaries are the last resort.
+/// Candidates inside a punctuation/closing-quote run are skipped so the run
+/// stays on the left. Returns empty when no split can keep both children
+/// within [`min_tokens`, `max_tokens`].
+std::vector<std::string> split_text_for_synthesis_retry(
+    const std::string& text,
+    const TokenCounter& count_tokens,
+    size_t min_tokens,
+    size_t max_tokens);
+
 }  // namespace speech_core

--- a/scripts/nemotron_wer_rtf.py
+++ b/scripts/nemotron_wer_rtf.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import math
 import re
 import statistics
 import sys
@@ -182,7 +183,8 @@ def compute_stats(label: str, rows: List[EngineRow], refs: Dict[str, str]) -> En
     wer_p95 = _percentile(wers, 95.0)
     wall_p50 = _percentile(walls, 50.0)
     wall_p95 = _percentile(walls, 95.0)
-    rtf = (audio_total / (wall_total / 1000.0)) if wall_total > 0 else 0.0
+    rtf = ((wall_total / 1000.0) / audio_total
+           if audio_total > 0.0 else float("inf"))
 
     return EngineStats(
         label=label,
@@ -202,7 +204,9 @@ def _fmt_pct(v: float) -> str:
 
 
 def _fmt_rtf(v: float) -> str:
-    return f"{v:.2f}x"
+    if not math.isfinite(v):
+        return "n/a"
+    return f"{v:.2f}"
 
 
 def _fmt_ms(v: float) -> str:

--- a/src/models/kokoro/kokoro_phonemizer.cpp
+++ b/src/models/kokoro/kokoro_phonemizer.cpp
@@ -34,13 +34,6 @@ static std::string to_lower(const std::string& s) {
     return result;
 }
 
-static std::string capitalize(const std::string& s) {
-    if (s.empty()) return s;
-    std::string result = s;
-    result[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(result[0])));
-    return result;
-}
-
 static bool is_punct(char c) {
     return std::ispunct(static_cast<unsigned char>(c)) != 0;
 }
@@ -116,14 +109,14 @@ void KokoroPhonemizer::set_language(const std::string& lang) {
 void KokoroPhonemizer::grow_dictionary(
     std::unordered_map<std::string, json::DictEntry>& dict)
 {
+    // Word lookup is always lowercase. Preserve lowercase aliases for source
+    // entries that contain capitals, but do not manufacture capitalized copies
+    // of every lowercase entry: those copies are unreachable and nearly double
+    // the two English dictionaries' heap footprint.
     std::unordered_map<std::string, json::DictEntry> additions;
     for (auto& [key, entry] : dict) {
         auto lower = to_lower(key);
-        if (key == lower && !key.empty()) {
-            auto cap = capitalize(key);
-            if (dict.find(cap) == dict.end()) additions[cap] = entry;
-        }
-        if (!key.empty() && std::isupper(static_cast<unsigned char>(key[0]))) {
+        if (!key.empty() && key != lower) {
             if (dict.find(lower) == dict.end()) additions[lower] = entry;
         }
     }

--- a/src/models/kokoro/kokoro_tts.cpp
+++ b/src/models/kokoro/kokoro_tts.cpp
@@ -5,41 +5,140 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <stdexcept>
 
 namespace speech_core {
 
 static constexpr int MAX_PHONEMES = 128;
 
-// Packing budget for one synthesis call, in phonemizer tokens (BOS/EOS
-// included). The E2E export emits at most 120000 samples (5 s at 24 kHz),
-// which real speech reaches at roughly 17 phonemes/s — well before the
-// 128-phoneme input cap — so budget for the output tensor, not the input.
-// 72 tokens is ~4.2 s of speech, leaving margin for slow prosody.
-static constexpr size_t CHUNK_TOKEN_BUDGET = 72;
 // Chunks below this are synthesized unreliably (the numerical-stability
 // guard below drops ≤5-token outputs); merge such tails into the previous
-// chunk instead, up to the MAX_PHONEMES hard cap.
+// chunk when the selected graph profile's hard budget permits it.
 static constexpr size_t MIN_TAIL_TOKENS = 12;
+static constexpr size_t MIN_RETRY_TOKENS = 6;
+static constexpr size_t MAX_RETRY_DEPTH = 4;
+static constexpr size_t MAX_INFERENCE_ATTEMPTS = 15;
+// Parity testing found a sharp quality cliff in the final two 25 ms decoder
+// frames of the bounded export. Reserve a conservative eight-frame (200 ms)
+// margin for the initial profile, regardless of profile-specific limits.
+static constexpr size_t OUTPUT_TAIL_GUARD_SAMPLES = 4800;
+
+namespace {
+
+constexpr size_t guarded_output_capacity(
+    size_t tensor_capacity, size_t configured_limit) {
+    size_t safe = tensor_capacity > OUTPUT_TAIL_GUARD_SAMPLES
+        ? tensor_capacity - OUTPUT_TAIL_GUARD_SAMPLES
+        : 0;
+    return configured_limit > 0 && configured_limit < safe
+        ? configured_limit
+        : safe;
+}
+
+static_assert(61200 <= guarded_output_capacity(72000, 67200));
+static_assert(67800 > guarded_output_capacity(72000, 67200));
+static_assert(71400 > guarded_output_capacity(72000, 67200));
+static_assert(73800 <= guarded_output_capacity(84000, 79200));
+static_assert(79800 > guarded_output_capacity(84000, 79200));
+static_assert(83400 > guarded_output_capacity(84000, 79200));
+
+class OrtValuesGuard {
+public:
+    OrtValuesGuard(const OrtApi* api, OrtValue** values, size_t count)
+        : api_(api), values_(values), count_(count) {}
+
+    ~OrtValuesGuard() {
+        for (size_t i = count_; i > 0; --i) {
+            if (values_[i - 1]) api_->ReleaseValue(values_[i - 1]);
+        }
+    }
+
+    OrtValuesGuard(const OrtValuesGuard&) = delete;
+    OrtValuesGuard& operator=(const OrtValuesGuard&) = delete;
+
+private:
+    const OrtApi* api_;
+    OrtValue** values_;
+    size_t count_;
+};
+
+int resolve_kokoro_threads() {
+    if (const char* value = std::getenv("SPEECH_CORE_KOKORO_ORT_THREADS")) {
+        const int threads = std::atoi(value);
+        if (threads > 0) return threads;
+    }
+    if (const char* value = std::getenv("SPEECH_CORE_ORT_THREADS")) {
+        const int threads = std::atoi(value);
+        if (threads > 0) return threads;
+    }
+    // Kokoro is one large Conv-heavy Run, unlike Parakeet's many tiny decoder
+    // calls that motivated OnnxEngine's conservative two-thread default.
+    return 4;
+}
+
+}  // namespace
+
+KokoroTts::Config KokoroTts::Config::short_turn_3s(bool hw_accel) {
+    Config config;
+    config.hw_accel = hw_accel;
+    config.chunk_token_budget = 44;
+    config.chunk_token_hard_cap = 49;
+    config.max_safe_output_samples = 67200;
+    return config;
+}
+
+KokoroTts::Config KokoroTts::Config::default_for_model_path(
+    const std::string& model_path, bool hw_accel) {
+    constexpr const char* kRealtimeGraph = "kokoro-e2e-realtime.onnx";
+    const size_t slash = model_path.find_last_of("/\\");
+    const std::string filename = slash == std::string::npos
+        ? model_path
+        : model_path.substr(slash + 1);
+    if (filename == kRealtimeGraph) return short_turn_3s(hw_accel);
+    return Config{hw_accel, 72, MAX_PHONEMES, 0};
+}
+
+KokoroTts::Config KokoroTts::Config::short_turn_3p5s(bool hw_accel) {
+    Config config;
+    config.hw_accel = hw_accel;
+    config.chunk_token_budget = 44;
+    config.chunk_token_hard_cap = 49;
+    config.max_safe_output_samples = 79200;
+    return config;
+}
 
 KokoroTts::KokoroTts(
     const std::string& model_path,
     const std::string& voices_dir,
     const std::string& data_dir,
     bool hw_accel)
-    : voices_dir_(voices_dir)
+    : KokoroTts(model_path, voices_dir, data_dir,
+                Config::default_for_model_path(model_path, hw_accel))
+{}
+
+KokoroTts::KokoroTts(
+    const std::string& model_path,
+    const std::string& voices_dir,
+    const std::string& data_dir,
+    const Config& config)
+    : voices_dir_(voices_dir), config_(config)
 {
+    if (config_.chunk_token_budget == 0 ||
+        config_.chunk_token_budget > MAX_PHONEMES ||
+        config_.chunk_token_hard_cap < config_.chunk_token_budget ||
+        config_.chunk_token_hard_cap > MAX_PHONEMES) {
+        throw std::invalid_argument("invalid Kokoro chunk token budgets");
+    }
+
     auto& engine = OnnxEngine::get();
     api_ = engine.api();
-    // The engine's intra-op default (2 threads) is tuned for Parakeet's
-    // profile of many tiny decoder calls. Kokoro is the opposite workload:
-    // one large single-pass graph per chunk, seconds of GEMM-heavy compute,
-    // where the parallel win dominates thread-pool overhead — measured ~1.5x
-    // real-time on 2 phone cores. Give it 4.
-    session_ = engine.load(model_path, hw_accel, /*capture_hint=*/false,
-                           /*intra_threads=*/4);
+    session_ = engine.load(model_path, config_.hw_accel,
+                           /*capture_hint=*/false,
+                           resolve_kokoro_threads());
 
     // Load phonemizer vocabulary and dictionaries
     phonemizer_.load_vocab(data_dir + "/vocab_index.json");
@@ -53,6 +152,7 @@ KokoroTts::KokoroTts(
 
     // Load default voice
     set_voice("af_heart");
+    current_lang_ = "en";
 }
 
 KokoroTts::~KokoroTts() {
@@ -111,41 +211,105 @@ void KokoroTts::synthesize(
     const std::string& text, const std::string& language,
     TTSChunkCallback on_chunk)
 {
-    cancelled_ = false;
+    cancelled_.store(false, std::memory_order_relaxed);
 
     // Set language and auto-switch voice if language changed
     std::string lang = language.empty() ? "en" : language;
     phonemizer_.set_language(lang);
     auto_switch_voice(lang);
 
-    // The E2E export bounds one synthesis call twice: the input tensor holds
-    // MAX_PHONEMES tokens (tokenize() silently truncates beyond it) and the
-    // output tensor holds 5 s of audio, reached at roughly 17 phonemes/s —
-    // well before the input cap. Split long text into sentence-preferring
-    // chunks whose real speech fits the output budget, and synthesize them
-    // sequentially; each chunk keeps natural prosody and the seams land on
-    // sentence/clause boundaries.
+    // The E2E export bounds both its input and output tensors. Split long text
+    // into sentence-preferring chunks using the selected graph profile's
+    // validated token budget.
     auto count_tokens = [this](const std::string& t) {
         return phonemizer_.tokenize(t, 1 << 20).size();
     };
     auto chunks = chunk_text_for_synthesis(
-        text, count_tokens, CHUNK_TOKEN_BUDGET, MAX_PHONEMES,
+        text, count_tokens, config_.chunk_token_budget,
+        MAX_PHONEMES,
         MIN_TAIL_TOKENS);
     for (size_t i = 0; i < chunks.size(); i++) {
-        if (cancelled_) return;
-        synthesize_chunk(chunks[i], on_chunk, i + 1 == chunks.size());
+        if (cancelled_.load(std::memory_order_relaxed)) return;
+        const bool is_final = i + 1 == chunks.size();
+        size_t inference_attempts = 0;
+        if (!synthesize_with_retry(
+                chunks[i], on_chunk, is_final, 0, inference_attempts)) return;
     }
 }
 
-void KokoroTts::synthesize_chunk(
+bool KokoroTts::synthesize_with_retry(
+    const std::string& text, const TTSChunkCallback& on_chunk,
+    bool is_final, size_t depth, size_t& inference_attempts)
+{
+    auto count_tokens = [this](const std::string& t) {
+        return phonemizer_.tokenize(t, 1 << 20).size();
+    };
+    const size_t token_count = count_tokens(text);
+
+    ChunkResult result = ChunkResult::RetrySmaller;
+    if (token_count <= config_.chunk_token_hard_cap) {
+        if (++inference_attempts > MAX_INFERENCE_ATTEMPTS) {
+            throw std::runtime_error("Kokoro retry inference-attempt limit exceeded");
+        }
+        result = synthesize_chunk(text, on_chunk, is_final);
+    } else {
+        LOGI("TTS: preflight split for %zu tokens above model-run cap=%zu",
+             token_count, config_.chunk_token_hard_cap);
+    }
+    if (result == ChunkResult::Emitted) return true;
+    if (result == ChunkResult::Cancelled ||
+        cancelled_.load(std::memory_order_relaxed)) return false;
+    if (depth >= MAX_RETRY_DEPTH) {
+        throw std::runtime_error("Kokoro output remained unsafe after retry limit");
+    }
+
+    if (token_count <= MIN_RETRY_TOKENS * 2) {
+        throw std::runtime_error("Kokoro output is unsafe and too short to split");
+    }
+
+    auto pieces = split_text_for_synthesis_retry(
+        text, count_tokens, MIN_RETRY_TOKENS, token_count - 1);
+    if (pieces.size() < 2) {
+        throw std::runtime_error("Kokoro retry splitter made no progress");
+    }
+
+    for (const auto& piece : pieces) {
+        const size_t child_tokens = count_tokens(piece);
+        if (piece.empty() || child_tokens < MIN_RETRY_TOKENS ||
+            child_tokens >= token_count) {
+            throw std::runtime_error("Kokoro retry splitter produced an unsafe chunk");
+        }
+    }
+
+    LOGI("TTS: retrying %zu-token chunk as %zu smaller chunks",
+         token_count, pieces.size());
+    for (size_t i = 0; i < pieces.size(); ++i) {
+        if (cancelled_.load(std::memory_order_relaxed)) return false;
+        const bool child_final = is_final && i + 1 == pieces.size();
+        if (!synthesize_with_retry(
+                pieces[i], on_chunk, child_final, depth + 1,
+                inference_attempts)) return false;
+    }
+    return true;
+}
+
+KokoroTts::ChunkResult KokoroTts::synthesize_chunk(
     const std::string& text, const TTSChunkCallback& on_chunk,
     bool is_final)
 {
     auto* mem = OnnxEngine::get().cpu_memory();
 
     // Text → phoneme token IDs
-    auto raw_tokens = phonemizer_.tokenize(text, MAX_PHONEMES);
-    if (raw_tokens.empty() || cancelled_) return;
+    auto raw_tokens = phonemizer_.tokenize(text, MAX_PHONEMES + 1);
+    if (cancelled_.load(std::memory_order_relaxed)) {
+        return ChunkResult::Cancelled;
+    }
+    if (raw_tokens.empty()) return ChunkResult::RetrySmaller;
+    if (raw_tokens.size() > MAX_PHONEMES) {
+        LOGI("TTS: input exceeds %d phonemes; splitting and retrying",
+             MAX_PHONEMES);
+        return ChunkResult::RetrySmaller;
+    }
 
     size_t token_count = raw_tokens.size();
 
@@ -163,71 +327,62 @@ void KokoroTts::synthesize_chunk(
 
     const int64_t ids_shape[] = {1, MAX_PHONEMES};
 
+    OrtValue* inputs[] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+    OrtValuesGuard input_guard(api_, inputs, 5);
+
     // input_ids [1, 128]
-    OrtValue* t_ids = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
         mem, input_ids.data(), input_ids.size() * sizeof(int64_t),
-        ids_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_ids));
+        ids_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &inputs[0]));
 
     // attention_mask [1, 128]
-    OrtValue* t_mask = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
         mem, attention_mask.data(), attention_mask.size() * sizeof(int64_t),
-        ids_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_mask));
+        ids_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &inputs[1]));
 
     // ref_s / voice embedding [1, 256]
     const int64_t style_shape[] = {1, 256};
-    OrtValue* t_style = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
         mem, voice_embedding_.data(), voice_embedding_.size() * sizeof(float),
-        style_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_style));
+        style_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &inputs[2]));
 
     // speed [1]
     float speed = 0.85f;
     const int64_t speed_shape[] = {1};
-    OrtValue* t_speed = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
         mem, &speed, sizeof(float),
-        speed_shape, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_speed));
+        speed_shape, 1, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &inputs[3]));
 
     // random_phases [1, 9]
     float phases[9];
     for (int i = 0; i < 9; i++)
         phases[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     const int64_t phases_shape[] = {1, 9};
-    OrtValue* t_phases = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
         mem, phases, sizeof(phases),
-        phases_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_phases));
+        phases_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &inputs[4]));
 
     // --- run ---
 
     const char* in_names[]  = {"input_ids", "attention_mask", "ref_s", "speed", "random_phases"};
     const char* out_names[] = {"audio", "audio_length_samples", "pred_dur"};
-    OrtValue* inputs[]  = {t_ids, t_mask, t_style, t_speed, t_phases};
     OrtValue* outputs[] = {nullptr, nullptr, nullptr};
+    OrtValuesGuard output_guard(api_, outputs, 3);
 
     ort_check(api_, api_->Run(
         session_, nullptr,
         in_names, inputs, 5,
         out_names, 3, outputs));
 
-    if (!cancelled_) {
+    if (!cancelled_.load(std::memory_order_relaxed)) {
         float* audio = nullptr;
         ort_check(api_, api_->GetTensorMutableData(outputs[0], (void**)&audio));
 
         // Get valid sample count from model
         int64_t* len_ptr = nullptr;
         ort_check(api_, api_->GetTensorMutableData(outputs[1], (void**)&len_ptr));
-        size_t valid_samples =
-            static_cast<size_t>(std::max<int64_t>(len_ptr[0], 0));
+        const int64_t reported_samples = len_ptr[0];
 
-        // audio_length_samples is predicted from summed durations, but the
-        // E2E export writes audio into a fixed-capacity tensor. Near the
-        // 128-phoneme input cap the prediction can exceed that capacity, and
-        // trusting it walked the loops below past the allocation (SIGSEGV on
-        // any text long enough to fill the input). Clamp to the tensor's
-        // real element count.
         OrtTensorTypeAndShapeInfo* audio_info = nullptr;
         ort_check(api_, api_->GetTensorTypeAndShape(outputs[0], &audio_info));
         size_t audio_capacity = 0;
@@ -237,31 +392,43 @@ void KokoroTts::synthesize_chunk(
             api_->GetTensorShapeElementCount(audio_info, &audio_capacity);
         api_->ReleaseTensorTypeAndShapeInfo(audio_info);
         ort_check(api_, count_status);
-        if (valid_samples > audio_capacity) {
-            LOGI("TTS: reported %zu samples exceeds audio tensor capacity %zu - "
-                 "clamping (max-length input? text='%.40s')",
-                 valid_samples, audio_capacity, text.c_str());
-            valid_samples = audio_capacity;
+
+        if (reported_samples <= 0 || audio_capacity == 0) {
+            LOGI("TTS: invalid output length=%lld capacity=%zu; retrying",
+                 static_cast<long long>(reported_samples), audio_capacity);
+            return ChunkResult::RetrySmaller;
         }
+
+        const size_t safe_capacity = guarded_output_capacity(
+            audio_capacity, config_.max_safe_output_samples);
+        if (static_cast<uint64_t>(reported_samples) >
+            static_cast<uint64_t>(safe_capacity)) {
+            LOGI("TTS: output length=%lld exceeds safe capacity=%zu "
+                 "(tensor=%zu); splitting and retrying",
+                 static_cast<long long>(reported_samples), safe_capacity,
+                 audio_capacity);
+            return ChunkResult::RetrySmaller;
+        }
+        const size_t valid_samples = static_cast<size_t>(reported_samples);
 
         // Inspect peak before any processing — short prompts (≤5 tokens) can
         // make the E2E ONNX export numerically explode (peak in the hundreds).
-        // Treat that as a synthesis failure rather than amplifying garbage.
+        // Non-finite or exploded outputs are split and retried once the input
+        // is large enough; they are never emitted.
         float peak = 0.0f;
+        bool finite = true;
         for (size_t i = 0; i < valid_samples; i++) {
             float a = std::abs(audio[i]);
+            if (!std::isfinite(a)) {
+                finite = false;
+                break;
+            }
             if (a > peak) peak = a;
         }
-        if (peak > 2.0f) {
-            LOGI("TTS: dropping output, peak=%.2f indicates numerical instability "
-                 "(short prompt? text='%.40s')", peak, text.c_str());
-            for (int i = 2; i >= 0; i--) api_->ReleaseValue(outputs[i]);
-            api_->ReleaseValue(t_phases);
-            api_->ReleaseValue(t_speed);
-            api_->ReleaseValue(t_style);
-            api_->ReleaseValue(t_mask);
-            api_->ReleaseValue(t_ids);
-            return;
+        if (!finite || peak > 2.0f) {
+            LOGI("TTS: unstable output finite=%d peak=%.2f; splitting and retrying "
+                 "(text='%.40s')", finite ? 1 : 0, peak, text.c_str());
+            return ChunkResult::RetrySmaller;
         }
 
         // Trim trailing artifacts — Kokoro's E2E model often emits 100-300 ms
@@ -308,20 +475,14 @@ void KokoroTts::synthesize_chunk(
              valid_samples, speech_end, peak, is_final ? 1 : 0);
 
         on_chunk(audio, speech_end, is_final);
+        return ChunkResult::Emitted;
     }
 
-    // --- cleanup ---
-
-    for (int i = 2; i >= 0; i--) api_->ReleaseValue(outputs[i]);
-    api_->ReleaseValue(t_phases);
-    api_->ReleaseValue(t_speed);
-    api_->ReleaseValue(t_style);
-    api_->ReleaseValue(t_mask);
-    api_->ReleaseValue(t_ids);
+    return ChunkResult::Cancelled;
 }
 
 void KokoroTts::cancel() {
-    cancelled_ = true;
+    cancelled_.store(true, std::memory_order_relaxed);
 }
 
 }  // namespace speech_core

--- a/src/models/parakeet/parakeet_stt.cpp
+++ b/src/models/parakeet/parakeet_stt.cpp
@@ -66,7 +66,7 @@ ParakeetStt::ParakeetStt(
     // Decoder-joint stays CPU even when hw_accel=true. The published
     // file is FP32 (the "-int8.onnx" filename is misleading — only the
     // encoder is INT8), so we tried the GPU path: WER stayed at 5.63%
-    // on LibriSpeech-100 but wall time went UP 8% (32.9x -> 30.5x RTF).
+    // on LibriSpeech-100 but wall time went UP 8% (32.9x -> 30.5x real-time).
     // Each decoder-joint call ships ~640-hidden tensors over the PCIe
     // bus 50+ times per utterance; for tensors this small the GPU
     // dispatch + memcpy beats the FP32 LSTM kernel's compute time. Same

--- a/src/util/text_chunker.cpp
+++ b/src/util/text_chunker.cpp
@@ -1,5 +1,9 @@
 #include "speech_core/util/text_chunker.h"
 
+#include <algorithm>
+#include <limits>
+#include <tuple>
+
 namespace speech_core {
 
 namespace {
@@ -124,6 +128,11 @@ void pack_units(const std::vector<std::string>& units,
         std::vector<std::string> finer;
         if (level == 0) {
             finer = split_units(unit, is_clause_end);
+            // A long sentence with no comma/semicolon must still fall back
+            // to whole words. Previously this skipped directly to UTF-8
+            // character cuts, which could emit fragments such as
+            // "voice-age" / "nt replies" for a normal hyphenated word.
+            if (finer.size() <= 1) finer = split_words(unit);
         } else if (level == 1) {
             finer = split_words(unit);
         }
@@ -160,6 +169,79 @@ std::vector<std::string> chunk_text_for_synthesis(
         }
     }
     return chunks;
+}
+
+std::vector<std::string> split_text_for_synthesis_retry(
+    const std::string& text, const TokenCounter& count_tokens,
+    size_t min_tokens, size_t max_tokens) {
+    if (text.empty() || min_tokens == 0 || min_tokens > max_tokens) return {};
+
+    std::vector<std::string> best;
+    auto best_score = std::make_tuple(
+        std::numeric_limits<int>::max(),
+        std::numeric_limits<size_t>::max(),
+        std::numeric_limits<size_t>::max());
+
+    size_t split = 0;
+    while (split < text.size()) {
+        size_t len = utf8_char_len(static_cast<unsigned char>(text[split]));
+        if (split + len > text.size()) len = text.size() - split;
+        split += len;
+        if (split >= text.size()) break;
+
+        std::string left = trimmed(text.substr(0, split));
+        std::string right = trimmed(text.substr(split));
+        if (left.empty() || right.empty()) continue;
+
+        const size_t left_tokens = count_tokens(left);
+        const size_t right_tokens = count_tokens(right);
+        if (left_tokens < min_tokens || right_tokens < min_tokens ||
+            left_tokens > max_tokens || right_tokens > max_tokens) {
+            continue;
+        }
+
+        int boundary_rank = 3;  // UTF-8 character boundary
+        const char before = text[split - 1];
+        const char after = text[split];
+
+        // Treat a run such as `...`, `?!`, or `?!"` as one boundary. Never
+        // leave part of that run at the beginning of the retry's right half.
+        bool saw_sentence_end = false;
+        bool saw_clause_end = false;
+        size_t run_begin = split;
+        while (run_begin > 0) {
+            const char c = text[run_begin - 1];
+            if (is_sentence_end(c)) {
+                saw_sentence_end = true;
+            } else if (is_clause_end(c)) {
+                saw_clause_end = true;
+            } else if (c != '\'' && c != '"') {
+                break;
+            }
+            --run_begin;
+        }
+        if (saw_sentence_end || saw_clause_end) {
+            if (is_sentence_end(after) || is_clause_end(after) ||
+                after == '\'' || after == '"') {
+                continue;
+            }
+            boundary_rank = saw_sentence_end ? 0 : 1;
+        } else if (before == ' ' || before == '\t' ||
+                   after == ' ' || after == '\t') {
+            boundary_rank = 2;
+        }
+
+        const size_t largest = std::max(left_tokens, right_tokens);
+        const size_t imbalance = left_tokens > right_tokens
+            ? left_tokens - right_tokens
+            : right_tokens - left_tokens;
+        const auto score = std::make_tuple(boundary_rank, largest, imbalance);
+        if (score < best_score) {
+            best_score = score;
+            best = {std::move(left), std::move(right)};
+        }
+    }
+    return best;
 }
 
 }  // namespace speech_core

--- a/tests/bench_litert_stt.cpp
+++ b/tests/bench_litert_stt.cpp
@@ -8,7 +8,7 @@
 //       ./build/bench_litert_stt [warmup_runs] [measured_runs]
 //
 // Reports, for streaming: first-partial latency, per-chunk compute p50/p95/max,
-// and stream RTF (audio_seconds / wall_seconds). For batch Parakeet: end-to-end
+// and stream RTF (wall_seconds / audio_seconds). For batch Parakeet: end-to-end
 // wall time and RTF. Skips cleanly when models/fixture are missing.
 
 #include "speech_core/audio/resampler.h"
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -106,6 +107,15 @@ double pct(std::vector<double> v, double p) {
     return v[std::min(idx, v.size() - 1)];
 }
 
+constexpr double classic_rtf(double wall_ms, double audio_s) {
+    if (audio_s <= 0.0 || wall_ms < 0.0) {
+        return std::numeric_limits<double>::infinity();
+    }
+    return (wall_ms / 1000.0) / audio_s;
+}
+static_assert(classic_rtf(2000.0, 4.0) == 0.5,
+              "RTF must be wall seconds divided by audio seconds");
+
 std::vector<float> load_audio_16k() {
     auto wav = load_wav_mono_pcm16(test_audio_path());
     if (wav.samples.empty()) return {};
@@ -161,19 +171,20 @@ void bench_nemotron_streaming(const std::string& dir, int warmup, int runs) {
             }
             if (first_partial_ms < 0 && !p.text.empty()) first_partial_ms = ms_since(t_stream);
         }
-        double wall_s = ms_since(t_stream) / 1000.0;
         stt.end_stream();
+        double wall_s = ms_since(t_stream) / 1000.0;
         if (measured) {
             all_first_partial.push_back(first_partial_ms);
-            all_rtf.push_back(audio_seconds / wall_s);
-            std::printf("  run %d: wall=%.2fs RTF=%.3fx first_partial=%.0fms "
+            const double rtf = classic_rtf(wall_s * 1000.0, audio_seconds);
+            all_rtf.push_back(rtf);
+            std::printf("  run %d: wall=%.2fs RTF=%.3f first_partial=%.0fms "
                         "chunk p50=%.1f p95=%.1f max=%.1f ms\n",
-                        r - warmup, wall_s, audio_seconds / wall_s, first_partial_ms,
+                        r - warmup, wall_s, rtf, first_partial_ms,
                         pct(chunk_ms, 50), pct(chunk_ms, 95), max_chunk);
         }
     }
 
-    std::printf("  SUMMARY nemotron: RTF=%.3fx first_partial=%.0fms "
+    std::printf("  SUMMARY nemotron: RTF=%.3f first_partial=%.0fms "
                 "chunk p50=%.1fms p95=%.1fms max=%.1fms\n",
                 pct(all_rtf, 50), pct(all_first_partial, 50),
                 pct(chunk_ms_pooled, 50), pct(chunk_ms_pooled, 95), pct(chunk_ms_pooled, 100));
@@ -203,13 +214,13 @@ void bench_parakeet_batch(const std::string& dir, int warmup, int runs) {
         double dt = ms_since(t);
         if (r >= warmup) {
             all_ms.push_back(dt);
-            std::printf("  run %d: %.0f ms RTF=%.3fx text_len=%zu\n",
-                        r - warmup, dt, audio_seconds / (dt / 1000.0), res.text.size());
+            std::printf("  run %d: %.0f ms RTF=%.3f text_len=%zu\n",
+                        r - warmup, dt, classic_rtf(dt, audio_seconds), res.text.size());
         }
     }
     double med = pct(all_ms, 50);
-    std::printf("  SUMMARY parakeet batch: %.0f ms RTF=%.3fx\n",
-                med, audio_seconds / (med / 1000.0));
+    std::printf("  SUMMARY parakeet batch: %.0f ms RTF=%.3f\n",
+                med, classic_rtf(med, audio_seconds));
 }
 
 double peak_rss_mb() {
@@ -232,7 +243,7 @@ double peak_rss_mb() {
 
 // ---------------------------------------------------------------------------
 // VoxCPM2 — autoregressive TTS, the heaviest model. Wall time per step is the
-// thing that scales; RTF is steps × 160ms / wall_time. Single measured run
+// thing that scales; RTF is wall_time / (steps × 160ms). Single measured run
 // because each takes ~25 s and runs are deterministic with a pinned seed.
 // ---------------------------------------------------------------------------
 
@@ -264,11 +275,11 @@ void bench_voxcpm2(const std::string& dir, int /*warmup*/, int /*runs*/) {
     double wall_ms = ms_since(t);
     int tokens = tts.tokens_generated();
     double audio_s = static_cast<double>(samples) / 48000.0;  // VoxCPM2 = 48 kHz
-    double rtf = audio_s / (wall_ms / 1000.0);
+    double rtf = classic_rtf(wall_ms, audio_s);
     double ms_per_step = wall_ms / std::max(1, tokens);
-    std::printf("  wall=%.0fms tokens=%d audio=%.2fs RTF=%.3fx ms_per_step=%.0fms rss=%.0fMB\n",
+    std::printf("  wall=%.0fms tokens=%d audio=%.2fs RTF=%.3f ms_per_step=%.0fms rss=%.0fMB\n",
                 wall_ms, tokens, audio_s, rtf, ms_per_step, peak_rss_mb());
-    std::printf("  SUMMARY voxcpm2: RTF=%.3fx ms_per_step=%.0fms\n", rtf, ms_per_step);
+    std::printf("  SUMMARY voxcpm2: RTF=%.3f ms_per_step=%.0fms\n", rtf, ms_per_step);
 }
 
 // ---------------------------------------------------------------------------
@@ -300,13 +311,13 @@ void bench_omnilingual(const std::string& dir, int warmup, int runs) {
         if (r >= warmup) {
             all_ms.push_back(dt);
             text = res.text;
-            std::printf("  run %d: %.0f ms RTF=%.3fx text_len=%zu\n",
-                        r - warmup, dt, audio_seconds / (dt / 1000.0), res.text.size());
+            std::printf("  run %d: %.0f ms RTF=%.3f text_len=%zu\n",
+                        r - warmup, dt, classic_rtf(dt, audio_seconds), res.text.size());
         }
     }
     double med = pct(all_ms, 50);
-    std::printf("  SUMMARY omnilingual: %.0f ms RTF=%.3fx rss=%.0fMB text=\"%.80s\"\n",
-                med, audio_seconds / (med / 1000.0), peak_rss_mb(), text.c_str());
+    std::printf("  SUMMARY omnilingual: %.0f ms RTF=%.3f rss=%.0fMB text=\"%.80s\"\n",
+                med, classic_rtf(med, audio_seconds), peak_rss_mb(), text.c_str());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -162,6 +163,17 @@ double pct(std::vector<double> v, double p) {
     return v[(std::min)(idx, v.size() - 1)];
 }
 
+// Conventional real-time factor: inference wall time divided by the amount
+// of audio processed or produced. Values below 1.0 are faster than real time.
+constexpr double classic_rtf(double wall_ms, double audio_s) {
+    if (audio_s <= 0.0 || wall_ms < 0.0) {
+        return std::numeric_limits<double>::infinity();
+    }
+    return (wall_ms / 1000.0) / audio_s;
+}
+static_assert(classic_rtf(2000.0, 4.0) == 0.5,
+              "RTF must be wall seconds divided by audio seconds");
+
 std::vector<float> load_audio_16k() {
     auto wav = load_wav_mono_pcm16(test_audio_path());
     if (wav.samples.empty()) return {};
@@ -210,7 +222,8 @@ void bench_silero(const std::string& dir) {
     char ex[128];
     std::snprintf(ex, sizeof(ex), "p50=%.3fms p95=%.3fms n=%zu",
                   pct(per_chunk, 50), pct(per_chunk, 95), per_chunk.size());
-    emit("silero-vad", "stream", load_ms, wall, audio_s / (wall / 1000.0), peak_rss_mb(), ex);
+    emit("silero-vad", "stream", load_ms, wall,
+         classic_rtf(wall, audio_s), peak_rss_mb(), ex);
 }
 
 void bench_parakeet(const std::string& dir) {
@@ -252,7 +265,8 @@ void bench_parakeet(const std::string& dir) {
     char ex[256];
     std::snprintf(ex, sizeof(ex), "p50=%.0fms p95=%.0fms text=\"%s\"",
                   pct(runs, 50), pct(runs, 95), last_text.c_str());
-    emit("parakeet-tdt", "batch", load_ms, med, audio_s / (med / 1000.0), peak_rss_mb(), ex);
+    emit("parakeet-tdt", "batch", load_ms, med,
+         classic_rtf(med, audio_s), peak_rss_mb(), ex);
 }
 
 struct WhisperBundle {
@@ -315,7 +329,7 @@ void emit_whisper_profile(const std::string& metric,
                   p.feature_frames, p.encoded_frames, p.prompt_tokens,
                   p.generated_tokens, transcript.c_str());
     emit("whisper", metric, load_ms, p.total_ms,
-         audio_s / (p.total_ms / 1000.0), peak_rss_mb(), ex);
+         classic_rtf(p.total_ms, audio_s), peak_rss_mb(), ex);
 }
 
 void bench_whisper_config(const WhisperBundle& bundle,
@@ -376,15 +390,43 @@ void bench_whisper(const std::string& dir) {
 }
 
 void bench_kokoro(const std::string& dir) {
-    std::string m = dir + "/kokoro-e2e.onnx";
+    const char* model_override = std::getenv("SPEECH_KOKORO_ONNX_PATH");
+    std::string m = model_override ? model_override : dir + "/kokoro-e2e.onnx";
     if (!file_exists(m) || !file_exists(dir + "/vocab_index.json")) {
         std::fprintf(stderr, "[skip] kokoro files\n"); return;
     }
     auto t_load = clk::now();
-    speech_core::KokoroTts tts(m, dir + "/voices", dir, /*hw_accel=*/true);
+    // Keep this row an explicit CPU baseline. Hardware-provider experiments
+    // belong in separate runs where provider assignment is verified.
+    auto config = speech_core::KokoroTts::Config::default_for_model_path(
+        m, /*hw_accel=*/false);
+    const char* config_label =
+        config.max_safe_output_samples > 0 ? "short-3.0s-auto" : "full-auto";
+    if (const char* profile = std::getenv("SPEECH_KOKORO_REALTIME_PROFILE");
+        profile && profile[0] != '\0') {
+        if (std::strcmp(profile, "3") == 0 ||
+            std::strcmp(profile, "3.0") == 0) {
+            config = speech_core::KokoroTts::Config::short_turn_3s(
+                /*hw_accel=*/false);
+            config_label = "short-3.0s";
+        } else if (std::strcmp(profile, "3.5") == 0) {
+            config = speech_core::KokoroTts::Config::short_turn_3p5s(
+                /*hw_accel=*/false);
+            config_label = "short-3.5s";
+        } else {
+            std::fprintf(stderr,
+                         "unknown SPEECH_KOKORO_REALTIME_PROFILE=%s\n",
+                         profile);
+            std::exit(2);
+        }
+    }
+    speech_core::KokoroTts tts(m, dir + "/voices", dir, config);
     double load_ms = ms_since(t_load);
 
-    const std::string text = "The quick brown fox jumps over the lazy dog";
+    const char* text_override = std::getenv("SPEECH_KOKORO_TEXT");
+    const std::string text = text_override
+        ? text_override
+        : "The quick brown fox jumps over the lazy dog";
 
     // Warmup
     size_t warm_samples = 0;
@@ -392,21 +434,48 @@ void bench_kokoro(const std::string& dir) {
                    [&](const float*, size_t n, bool) { warm_samples += n; });
 
     std::vector<double> runs;
-    size_t last_samples = 0;
+    std::vector<double> audio_durations;
+    std::vector<double> rtfs;
+    size_t last_chunks = 0;
+    size_t last_finals = 0;
+    bool last_finite = true;
     for (int i = 0; i < 3; ++i) {
         size_t samples = 0;
+        size_t chunks = 0;
+        size_t finals = 0;
+        bool finite = true;
         auto t = clk::now();
         tts.synthesize(text, "en",
-                       [&](const float*, size_t n, bool) { samples += n; });
-        runs.push_back(ms_since(t));
-        last_samples = samples;
+                       [&](const float* pcm, size_t n, bool is_final) {
+                           ++chunks;
+                           if (is_final) ++finals;
+                           for (size_t j = 0; j < n; ++j) {
+                               if (!std::isfinite(pcm[j])) finite = false;
+                           }
+                           samples += n;
+                       });
+        const double wall_ms = ms_since(t);
+        const double audio_s = static_cast<double>(samples) / 24000.0;
+        runs.push_back(wall_ms);
+        audio_durations.push_back(audio_s);
+        rtfs.push_back(classic_rtf(wall_ms, audio_s));
+        last_chunks = chunks;
+        last_finals = finals;
+        last_finite = finite;
     }
     double med = pct(runs, 50);
-    double audio_s = static_cast<double>(last_samples) / 24000.0;  // Kokoro outputs 24 kHz
-    char ex[160];
-    std::snprintf(ex, sizeof(ex), "p50=%.0fms p95=%.0fms audio=%.2fs",
-                  pct(runs, 50), pct(runs, 95), audio_s);
-    emit("kokoro-tts", "synth", load_ms, med, audio_s / (med / 1000.0), peak_rss_mb(), ex);
+    double audio_s = pct(audio_durations, 50);
+    const size_t slash = m.find_last_of("/\\");
+    const std::string graph = slash == std::string::npos
+        ? m
+        : m.substr(slash + 1);
+    char ex[384];
+    std::snprintf(ex, sizeof(ex),
+                  "config=%s graph=%s p50=%.0fms p95=%.0fms audio_p50=%.2fs chunks=%zu finals=%zu finite=%d",
+                  config_label, graph.c_str(), pct(runs, 50), pct(runs, 95), audio_s,
+                  last_chunks, last_finals, last_finite ? 1 : 0);
+    emit("kokoro-tts", "synth", load_ms, med, pct(rtfs, 50),
+         peak_rss_mb(), ex);
 }
 
 void bench_cosyvoice3(const std::string& /*dir*/) {
@@ -494,11 +563,12 @@ void bench_cosyvoice3(const std::string& /*dir*/) {
                   static_cast<double>(flow_estimator_ms),
                   static_cast<double>(hift_ms));
     emit("cosyvoice3-tts", "synth", load_ms, med,
-         audio_s / (med / 1000.0), peak_rss_mb(), ex);
+         classic_rtf(med, audio_s), peak_rss_mb(), ex);
 }
 
 // ---------------------------------------------------------------------------
-// VoxCPM2 ONNX TTS — the comparison the LiteRT bench shows at 0.10x RTF / ~12 GB
+// VoxCPM2 ONNX TTS — the comparison the LiteRT bench shows at ~10 RTF
+// (0.10x real-time throughput) / ~12 GB
 // RSS / 1.55 s per AR step on CPU. The ONNX wrapper drives the same 4-graph
 // pipeline; with hw_accel=true (CUDA) the per-step compute should drop
 // substantially (text_prefill once + token_step ×N is where the GPU win lives).
@@ -553,9 +623,9 @@ void bench_nemotron(const std::string& dir) {
             chunk_ms.push_back(ms_since(t_c));
             if (first_partial_ms < 0 && !p.text.empty()) first_partial_ms = ms_since(t_stream);
         }
+        last_text = stt.end_stream().text;
         walls.push_back(ms_since(t_stream));
         first_partials.push_back(first_partial_ms);
-        last_text = stt.end_stream().text;
     }
     double wall_ms = pct(walls, 50);
     double audio_s = static_cast<double>(audio.size()) / 16000.0;
@@ -568,7 +638,7 @@ void bench_nemotron(const std::string& dir) {
                   pct(chunk_ms, 50), pct(chunk_ms, 95),
                   pct(first_partials, 50), last_text.c_str());
     emit("nemotron-streaming", "stream", load_ms, wall_ms,
-         audio_s / (wall_ms / 1000.0), peak_rss_mb(), ex);
+         classic_rtf(wall_ms, audio_s), peak_rss_mb(), ex);
 }
 
 void bench_voxcpm2(const std::string& /*dir*/) {
@@ -627,7 +697,7 @@ void bench_voxcpm2(const std::string& /*dir*/) {
     std::snprintf(ex, sizeof(ex),
                   "p50=%.0fms p95=%.0fms audio=%.2fs steps=%d ms_per_step=%.0fms",
                   med, pct(walls, 95), audio_s, last_tokens, ms_per_step);
-    emit("voxcpm2-tts", "synth", load_ms, med, audio_s / (med / 1000.0),
+    emit("voxcpm2-tts", "synth", load_ms, med, classic_rtf(med, audio_s),
          peak_rss_mb(), ex);
 }
 
@@ -840,11 +910,22 @@ int main(int argc, char** argv) {
     if (!nemotron_manifest.empty()) return run_corpus_nemotron(dir, nemotron_manifest);
     if (!manifest.empty()) return run_corpus(dir, manifest, batch_size);
     std::printf("#model,provider,metric,load_ms,wall_ms,rtf,rss_mb,extra\n");
-    if (const char* only = std::getenv("SPEECH_BENCH_ONLY")) {
-        if (std::string(only) == "whisper") {
-            bench_whisper(dir);
-            return 0;
+    if (const char* only_env = std::getenv("SPEECH_BENCH_ONLY")) {
+        const std::string only(only_env);
+        if (only == "silero") bench_silero(dir);
+        else if (only == "parakeet") bench_parakeet(dir);
+        else if (only == "whisper") bench_whisper(dir);
+        else if (only == "kokoro") bench_kokoro(dir);
+        else if (only == "cosyvoice3") bench_cosyvoice3(dir);
+        else if (only == "voxcpm2") bench_voxcpm2(dir);
+        else if (only == "nemotron") bench_nemotron(dir);
+        else {
+            std::fprintf(stderr,
+                         "unknown SPEECH_BENCH_ONLY=%s\n",
+                         only.c_str());
+            return 2;
         }
+        return 0;
     }
     bench_silero(dir);
     bench_parakeet(dir);

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -443,6 +443,84 @@ void test_kokoro_tts(const std::string& dir) {
     std::printf("ok (samples=%zu)\n", total_samples);
 }
 
+void test_kokoro_short_turn_profile(const std::string& dir) {
+    const char* model_env = std::getenv("SPEECH_KOKORO_REALTIME_ONNX_PATH");
+    if (!model_env || !file_exists(model_env) ||
+        !file_exists(dir + "/vocab_index.json")) {
+        std::printf("  [skip] set SPEECH_KOKORO_REALTIME_ONNX_PATH for short-turn Kokoro test\n");
+        return;
+    }
+    std::printf("  test_kokoro_short_turn_profile ... ");
+
+    auto fast_config = speech_core::KokoroTts::Config::short_turn_3s(
+        /*hw_accel=*/false);
+    REQUIRE(fast_config.chunk_token_budget == 44);
+    REQUIRE(fast_config.chunk_token_hard_cap == 49);
+    REQUIRE(fast_config.max_safe_output_samples == 67200);
+
+    auto inferred_short =
+        speech_core::KokoroTts::Config::default_for_model_path(
+            "/models/kokoro-e2e-realtime.onnx", /*hw_accel=*/false);
+    REQUIRE(inferred_short.chunk_token_budget == 44);
+    REQUIRE(inferred_short.chunk_token_hard_cap == 49);
+    REQUIRE(inferred_short.max_safe_output_samples == 67200);
+
+    auto inferred_full =
+        speech_core::KokoroTts::Config::default_for_model_path(
+            "/models/kokoro-e2e.onnx", /*hw_accel=*/false);
+    REQUIRE(inferred_full.chunk_token_budget == 72);
+    REQUIRE(inferred_full.chunk_token_hard_cap == 128);
+    REQUIRE(inferred_full.max_safe_output_samples == 0);
+
+    // The bool constructor is the public default path. With the official
+    // realtime filename it must pick the 3.0 s guard without requiring an
+    // Android-specific configuration call. This text fits the 3.5 s graph
+    // but exceeds the 3.0 s guarded limit, so a split proves the default.
+    speech_core::KokoroTts auto_profile_tts(
+        model_env, dir + "/voices", dir, /*hw_accel=*/false);
+    size_t auto_chunks = 0;
+    size_t auto_finals = 0;
+    auto_profile_tts.synthesize(
+        "The package arrives tomorrow morning at nine.", "en",
+        [&](const float*, size_t, bool is_final) {
+            ++auto_chunks;
+            if (is_final) ++auto_finals;
+        });
+    REQUIRE(auto_chunks >= 2);
+    REQUIRE(auto_finals == 1);
+
+    auto config = speech_core::KokoroTts::Config::short_turn_3p5s(
+        /*hw_accel=*/false);
+    REQUIRE(config.chunk_token_budget == 44);
+    REQUIRE(config.chunk_token_hard_cap == 49);
+    REQUIRE(config.max_safe_output_samples == 79200);
+
+    speech_core::KokoroTts tts(
+        model_env, dir + "/voices", dir, config);
+    size_t chunks = 0;
+    size_t finals = 0;
+    size_t total_samples = 0;
+    bool finite = true;
+    // This phrase produces 82,200 raw samples: above the profile's 79,200
+    // validated limit while still fitting its input-token hard cap. It must
+    // therefore exercise the runtime output-length split/retry path.
+    tts.synthesize("The package arrives tomorrow morning safely today.", "en",
+        [&](const float* samples, size_t len, bool is_final) {
+            ++chunks;
+            if (is_final) ++finals;
+            total_samples += len;
+            for (size_t i = 0; i < len; ++i) {
+                if (!std::isfinite(samples[i])) finite = false;
+            }
+        });
+
+    REQUIRE(chunks >= 2);
+    REQUIRE(finals == 1);
+    REQUIRE(total_samples > 0);
+    REQUIRE(finite);
+    std::printf("ok (chunks=%zu samples=%zu)\n", chunks, total_samples);
+}
+
 // ---------------------------------------------------------------------------
 
 void test_deepfilter(const std::string& dir) {
@@ -1168,6 +1246,7 @@ int main() {
     RUN(test_onnx_whisper_stt);
     RUN(test_nemotron_multilingual_stt);
     RUN(test_kokoro_tts);
+    RUN(test_kokoro_short_turn_profile);
     RUN(test_deepfilter);
     RUN(test_sidon_restorer);
     RUN(test_kokoro_parakeet_roundtrip);

--- a/tests/test_text_chunker.cpp
+++ b/tests/test_text_chunker.cpp
@@ -96,6 +96,29 @@ void test_word_fallback() {
     printf("  PASS: word_fallback\n");
 }
 
+void test_long_sentence_preserves_whole_words() {
+    // A normal sentence with no clause punctuation must fall back to words,
+    // not character fragments. This specifically protects hyphenated words
+    // in short-turn TTS prompts.
+    std::string text =
+        "The new short-turn graph is ready for quick replies.";
+    auto chunks = chunk(text, /*budget=*/14, /*hard_cap=*/14,
+                        /*min_tail=*/0);
+    assert(chunks.size() >= 2);
+
+    std::string rejoined;
+    bool found_hyphenated_word = false;
+    for (const auto& c : chunks) {
+        assert(fake_count(c) <= 14);
+        if (!rejoined.empty()) rejoined += " ";
+        rejoined += c;
+        if (c == "short-turn") found_hyphenated_word = true;
+    }
+    assert(rejoined == text);
+    assert(found_hyphenated_word);
+    printf("  PASS: long_sentence_preserves_whole_words\n");
+}
+
 void test_monster_word_char_split() {
     std::string word(50, 'x');
     size_t budget = 12;
@@ -158,6 +181,100 @@ void test_newlines_are_boundaries() {
     printf("  PASS: newlines_are_boundaries\n");
 }
 
+void test_retry_split_progress_for_13_to_42_tokens() {
+    for (size_t parent_tokens = 13; parent_tokens <= 42; ++parent_tokens) {
+        std::string word(parent_tokens - 2, 'x');
+        auto pieces = split_text_for_synthesis_retry(
+            word, fake_count, /*min_tokens=*/6,
+            /*max_tokens=*/parent_tokens - 1);
+        assert(pieces.size() == 2);
+        std::string rejoined;
+        for (const auto& piece : pieces) {
+            const size_t child_tokens = fake_count(piece);
+            assert(!piece.empty());
+            assert(child_tokens >= 6);
+            assert(child_tokens < parent_tokens);
+            rejoined += piece;
+        }
+        assert(rejoined == word);
+    }
+    printf("  PASS: retry_split_progress_for_13_to_42_tokens\n");
+}
+
+void test_retry_split_utf8_is_balanced_and_intact() {
+    std::string word;
+    for (int i = 0; i < 14; ++i) word += "\xC3\xBC\xE4\xB8\xAD";  // ü中
+    const size_t parent_tokens = fake_count(word);
+    auto pieces = split_text_for_synthesis_retry(
+        word, fake_count, /*min_tokens=*/6,
+        /*max_tokens=*/parent_tokens - 1);
+    assert(pieces.size() == 2);
+    std::string rejoined;
+    for (const auto& piece : pieces) {
+        assert(!piece.empty());
+        assert((static_cast<unsigned char>(piece[0]) & 0xC0) != 0x80);
+        assert(fake_count(piece) >= 6);
+        assert(fake_count(piece) < parent_tokens);
+        rejoined += piece;
+    }
+    assert(rejoined == word);
+    printf("  PASS: retry_split_utf8_is_balanced_and_intact\n");
+}
+
+void test_retry_split_prefers_word_boundary_when_balanced() {
+    auto pieces = split_text_for_synthesis_retry(
+        "alpha bravo", fake_count, /*min_tokens=*/6, /*max_tokens=*/12);
+    assert(pieces.size() == 2);
+    assert(pieces[0] == "alpha");
+    assert(pieces[1] == "bravo");
+    printf("  PASS: retry_split_prefers_word_boundary_when_balanced\n");
+}
+
+void test_retry_split_does_not_trade_word_boundary_for_balance() {
+    auto pieces = split_text_for_synthesis_retry(
+        "alpha bravo charlie", fake_count, /*min_tokens=*/6,
+        /*max_tokens=*/16);
+    assert(pieces.size() == 2);
+    assert(pieces[0] == "alpha bravo");
+    assert(pieces[1] == "charlie");
+    printf("  PASS: retry_split_does_not_trade_word_boundary_for_balance\n");
+}
+
+void test_retry_split_keeps_punctuation_on_left() {
+    auto pieces = split_text_for_synthesis_retry(
+        "aaaaa. bbbbb", fake_count, /*min_tokens=*/6, /*max_tokens=*/12);
+    assert(pieces.size() == 2);
+    assert(pieces[0] == "aaaaa.");
+    assert(pieces[1] == "bbbbb");
+    printf("  PASS: retry_split_keeps_punctuation_on_left\n");
+}
+
+void test_retry_split_keeps_closing_quote_with_sentence() {
+    auto pieces = split_text_for_synthesis_retry(
+        "aaaaa.\" bbbbb", fake_count, /*min_tokens=*/6, /*max_tokens=*/13);
+    assert(pieces.size() == 2);
+    assert(pieces[0] == "aaaaa.\"");
+    assert(pieces[1] == "bbbbb");
+    printf("  PASS: retry_split_keeps_closing_quote_with_sentence\n");
+}
+
+void test_retry_split_keeps_full_sentence_ender_run() {
+    auto pieces = split_text_for_synthesis_retry(
+        "aaaaa...?!\" bbbbb", fake_count, /*min_tokens=*/6,
+        /*max_tokens=*/18);
+    assert(pieces.size() == 2);
+    assert(pieces[0] == "aaaaa...?!\"");
+    assert(pieces[1] == "bbbbb");
+    printf("  PASS: retry_split_keeps_full_sentence_ender_run\n");
+}
+
+void test_retry_split_impossible_returns_empty() {
+    auto pieces = split_text_for_synthesis_retry(
+        "tiny", fake_count, /*min_tokens=*/6, /*max_tokens=*/6);
+    assert(pieces.empty());
+    printf("  PASS: retry_split_impossible_returns_empty\n");
+}
+
 int main() {
     printf("test_text_chunker:\n");
     test_empty_and_whitespace();
@@ -167,11 +284,20 @@ int main() {
     test_budget_respected();
     test_clause_fallback_for_run_on_sentence();
     test_word_fallback();
+    test_long_sentence_preserves_whole_words();
     test_monster_word_char_split();
     test_utf8_never_split_mid_character();
     test_tiny_tail_merges();
     test_newlines_are_boundaries();
     test_tiny_tail_kept_when_hard_cap_blocks();
+    test_retry_split_progress_for_13_to_42_tokens();
+    test_retry_split_utf8_is_balanced_and_intact();
+    test_retry_split_prefers_word_boundary_when_balanced();
+    test_retry_split_does_not_trade_word_boundary_for_balance();
+    test_retry_split_keeps_punctuation_on_left();
+    test_retry_split_keeps_closing_quote_with_sentence();
+    test_retry_split_keeps_full_sentence_ender_run();
+    test_retry_split_impossible_returns_empty();
     printf("All text_chunker tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

- make the published 3.0-second Kokoro realtime graph select its validated short-turn profile automatically
- split and retry oversized or unstable synthesis at semantic and word boundaries without truncating words or emitting unsafe PCM
- keep Kokoro on four CPU threads with environment overrides, reduce phonemizer memory, and report conventional RTF consistently
- document the shared-weight realtime graph and measured Galaxy S23 Ultra performance

## Validation

- default host suite: 19/19 passed
- ONNX benchmark target builds successfully
- realtime profile integration test passes with the published graph
- Android arm64 build and physical Galaxy S23 Ultra synthesis test passed; measured 0.725-0.877 RTF across thermal states
- long-form playback sample verified after the whole-word fallback fix