### PR TITLE
Add RNN-T beam search + contextual biasing to the streaming decoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(speech_core
     src/tools/intent_matcher.cpp
     src/tools/tool_executor.cpp
     src/diarization/diarization_pipeline.cpp
+    src/models/context_graph.cpp
     src/speech_core_c.cpp
     src/tts_synthesis_options.cpp
     src/util/text_chunker.cpp

--- a/docs/models.md
+++ b/docs/models.md
@@ -553,6 +553,33 @@ auto final = stt.end_stream();
   `end_of_utterance()`, not written into the transcript) and `<EOB>` as a soft
   boundary. A config without those ids is plain Nemotron and is byte-identical to
   before.
+- **Decoding.** Greedy by default and byte-identical to prior releases. Set
+  `Config.beam_size > 1` for modified RNN-T beam search: N hypotheses, each with
+  its own predictor state and context position, carried across streaming windows.
+  Greedy stays the default; beam is opt-in.
+- **Contextual biasing (shallow fusion).** `set_context_phrases()` biases beam
+  search toward a caller-supplied phrase list — command words, a brand name, the
+  contact / track names currently on the device. It rides on a tokenizer-agnostic
+  character automaton (`ContextGraph`, Aho-Corasick) that matches on the *decoded
+  surface text* of tokens, so it works even though the published EOU bundle ships
+  only a decode vocabulary (no encoder tokenizer). Matches are anchored to word
+  starts and a broken partial match refunds its bonus via the fail arc, so
+  unrelated speech nets ~zero. Rebuild the phrase list per utterance to inject
+  live entities; no effect unless `beam_size > 1`, and an empty list is a no-op.
+  Tuning note: keep the beam moderate (≈4) and the bonus modest — an over-wide
+  beam or over-strong bonus lets a long phrase dominate acoustically weak audio.
+
+```cpp
+speech_core::OnnxNemotronStreamingStt::Config cfg;
+cfg.beam_size = 4;                        // opt into beam search
+speech_core::OnnxNemotronStreamingStt stt(
+    "/models/parakeet-eou-encoder.onnx", "/models/parakeet-eou-decoder.onnx",
+    "/models/parakeet-eou-joint.onnx",   "/models/vocab.json", cfg);
+// Per-utterance: the fixed command grammar + whatever is on the device now.
+stt.set_context_phrases({"Soniqo", "set volume", "play music", "stop playing",
+                         /* live contact + track names */});
+```
+
 - Encoder INT8, decoder + joint FP32; 320 ms streaming chunks.
 - Model files: [soniqo/Parakeet-EOU-120M-ONNX-INT8](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) — `parakeet-eou-{encoder,decoder,joint}.onnx`, `vocab.json`, `config.json`
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -566,8 +566,14 @@ auto final = stt.end_stream();
   starts and a broken partial match refunds its bonus via the fail arc, so
   unrelated speech nets ~zero. Rebuild the phrase list per utterance to inject
   live entities; no effect unless `beam_size > 1`, and an empty list is a no-op.
-  Tuning note: keep the beam moderate (≈4) and the bonus modest — an over-wide
-  beam or over-strong bonus lets a long phrase dominate acoustically weak audio.
+- **Over-biasing guardrail (optional).** Uncapped, longer phrases accumulate a
+  larger boost — the same behavior as sherpa-onnx / k2, where the score is tuned
+  by hand and an over-wide beam or long list can let a phrase override clear
+  audio (e.g. every segment collapsing to "what can you do"). Pass a positive
+  `max_bonus` to `set_context_phrases()` to cap each phrase's per-character
+  boost: sufficiently long phrases then all reach the same ceiling, so no single
+  phrase dominates. Default 0 keeps the uncapped, tune-by-hand behavior. With a
+  cap set, a wider beam and a longer bias list stay safe.
 
 ```cpp
 speech_core::OnnxNemotronStreamingStt::Config cfg;
@@ -576,8 +582,11 @@ speech_core::OnnxNemotronStreamingStt stt(
     "/models/parakeet-eou-encoder.onnx", "/models/parakeet-eou-decoder.onnx",
     "/models/parakeet-eou-joint.onnx",   "/models/vocab.json", cfg);
 // Per-utterance: the fixed command grammar + whatever is on the device now.
+// The trailing max_bonus (6.0) caps each phrase's boost so a wide beam / long
+// list can't override clear audio; pass 0 (default) for the uncapped behavior.
 stt.set_context_phrases({"Soniqo", "set volume", "play music", "stop playing",
-                         /* live contact + track names */});
+                         /* live contact + track names */},
+                        /*per_char=*/1.5f, /*completion=*/3.0f, /*max_bonus=*/6.0f);
 ```
 
 - Encoder INT8, decoder + joint FP32; 320 ms streaming chunks.

--- a/include/speech_core/models/context_graph.h
+++ b/include/speech_core/models/context_graph.h
@@ -32,9 +32,19 @@ public:
     /// @param phrases    surface phrases to bias toward (case-insensitive).
     /// @param per_char   log-domain bonus per matched character inside a phrase.
     /// @param completion extra bonus applied when a whole phrase completes.
+    /// @param max_bonus  ceiling on the per-character accumulation a single
+    ///                   phrase match can reach (completion is added on top).
+    ///                   0 = uncapped (default) — the same behavior as
+    ///                   sherpa-onnx / k2, where longer phrases accumulate a
+    ///                   larger boost and the score must be tuned by hand. A
+    ///                   positive cap bounds each phrase's contribution, so an
+    ///                   over-wide beam or long bias list can't let a long
+    ///                   phrase override clear audio; set it low enough and
+    ///                   sufficiently long phrases all reach the same ceiling.
     explicit ContextGraph(const std::vector<std::string>& phrases,
                           float per_char = 1.5f,
-                          float completion = 3.0f);
+                          float completion = 3.0f,
+                          float max_bonus = 0.0f);
 
     /// True when no phrase produced any matchable content (biasing is a no-op).
     bool empty() const { return nodes_.size() <= 1; }

--- a/include/speech_core/models/context_graph.h
+++ b/include/speech_core/models/context_graph.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace speech_core {
+
+/// Aho-Corasick character automaton for shallow-fusion ASR context biasing.
+///
+/// Built from a list of surface phrases (command words, a brand name, live
+/// contact/track names). During beam search each hypothesis carries an opaque
+/// [State]; [advance] appends the decoded surface text of one emitted token and
+/// returns a log-domain score bonus that nudges the beam toward hypotheses that
+/// spell out a phrase.
+///
+/// Matching is on decoded text, not token ids, so it is tokenizer-agnostic — it
+/// works even when the model's exact sub-word segmentation is unknown (our
+/// Parakeet-EOU export ships only a decode vocabulary, no encoder tokenizer).
+/// Phrases are anchored to word starts (the SentencePiece word marker U+2581
+/// normalizes to a leading space), so "son" biases the word "Soniqo" but not
+/// the "son" inside "person".
+///
+/// The per-character score telescopes: matching root->...->node accrues
+/// `per_char` per depth, and a broken partial match follows a fail arc back
+/// toward the root, refunding the bonus it earned. Only sustained matches keep
+/// their boost; unrelated text nets ~0.
+class ContextGraph {
+public:
+    ContextGraph() = default;
+
+    /// @param phrases    surface phrases to bias toward (case-insensitive).
+    /// @param per_char   log-domain bonus per matched character inside a phrase.
+    /// @param completion extra bonus applied when a whole phrase completes.
+    explicit ContextGraph(const std::vector<std::string>& phrases,
+                          float per_char = 1.5f,
+                          float completion = 3.0f);
+
+    /// True when no phrase produced any matchable content (biasing is a no-op).
+    bool empty() const { return nodes_.size() <= 1; }
+
+    /// Opaque per-hypothesis match state — an automaton node index. 0 = root.
+    using State = int;
+    State start() const { return 0; }
+
+    struct Step {
+        float bonus;
+        State state;
+    };
+    /// Append one emitted token's surface text (as it appears in the vocab,
+    /// including any U+2581 markers); returns the bonus and the next state.
+    Step advance(State s, const std::string& token_text) const;
+
+    /// Normalize a piece/phrase to the matching alphabet: U+2581 -> space,
+    /// ASCII upper -> lower, keep [a-z0-9 ], drop the rest. Exposed for tests.
+    static std::string normalize(const std::string& text);
+
+private:
+    struct Node {
+        std::unordered_map<char, int> children;
+        int   fail  = 0;
+        int   depth = 0;
+        bool  end   = false;   // a phrase terminates here
+        bool  output = false;  // this node, or one on its fail chain, is an end
+    };
+
+    int  go(int node, char c) const;  // Aho-Corasick goto via fail links
+
+    std::vector<Node>  nodes_{Node{}};  // nodes_[0] == root
+    std::vector<float> score_{0.0f};    // per_char * depth, indexed by node
+    float per_char_   = 1.5f;
+    float completion_ = 3.0f;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_nemotron_streaming_stt.h
+++ b/include/speech_core/models/onnx_nemotron_streaming_stt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "speech_core/interfaces.h"
+#include "speech_core/models/context_graph.h"
 
 #include <onnxruntime_c_api.h>
 
@@ -64,6 +65,10 @@ public:
         // frontend (NeMo `preemph`, read from config.json's preEmphasis).
         // 0 = disabled, keeping the plain-Nemotron path unchanged.
         float preemph         = 0.0f;
+        // RNN-T decoding: <=1 keeps the original greedy path (byte-identical);
+        // >1 enables modified beam search, which is what contextual biasing
+        // (set_context_phrases) rides on. Greedy stays the default.
+        int   beam_size       = 0;
     };
 
     OnnxNemotronStreamingStt(const std::string& encoder_path,
@@ -88,6 +93,13 @@ public:
     // stream itself. Reset by begin_stream() / cancel_stream().
     bool end_of_utterance() const { return eou_detected_; }
 
+    // Contextual biasing (shallow fusion). Nudges beam search toward the given
+    // surface phrases — command words, a brand name, live contact/track names.
+    // No effect unless Config.beam_size > 1. Rebuild per utterance to inject the
+    // entities currently on the device. Empty list clears biasing.
+    void set_context_phrases(const std::vector<std::string>& phrases,
+                             float per_char = 1.5f, float completion = 3.0f);
+
     // --- STTInterface (streaming — the real path) ---
     bool supports_streaming() const override { return true; }
     void begin_stream(int sample_rate) override;
@@ -100,8 +112,32 @@ private:
     bool load_vocab(const std::string& path);
     void reset_stream_state();
     void run_decoder_step(int64_t token_id);
+    // Pure predictor (decoder LSTM) step: reads (token, h_in, c_in), writes the
+    // fresh joint-input hidden + next LSTM state. No shared-state side effects,
+    // so beam hypotheses each carry their own predictor state. run_decoder_step
+    // is this applied to the greedy path's shared members.
+    void decoder_step(int64_t token_id,
+                      const std::vector<float>& h_in, const std::vector<float>& c_in,
+                      std::vector<float>& hidden_out,
+                      std::vector<float>& h_out, std::vector<float>& c_out);
+    // Run the joint network for one encoder frame + predictor hidden -> logits.
+    void joint_logits(const float* enc_frame, const std::vector<float>& dec_hidden,
+                      std::vector<float>& logits);
     std::string run_window();
+    std::string decode_greedy(const std::vector<float>& encoded);
+    std::string decode_beam(const std::vector<float>& encoded);
     std::string token_to_text(int id) const;
+
+    // One beam-search hypothesis: emitted text, running log-prob score, its own
+    // predictor state, and its position in the context-biasing automaton.
+    struct BeamHyp {
+        std::string        text;
+        double             score = 0.0;
+        std::vector<float> dec_h, dec_c, dec_hidden;
+        ContextGraph::State ctx = 0;
+        bool               eou = false;
+    };
+    const BeamHyp* best_beam() const;
     // Mel window fed to the encoder, in samples. EOU streams melFrames*hop
     // windows advanced by a smaller shift (see run_window); Nemotron uses the
     // original (melFrames-1)*hop stride where window == shift.
@@ -149,12 +185,16 @@ private:
     std::vector<float> cache_last_channel_;  // [L, 1, attn, H]
     std::vector<float> cache_last_time_;     // [L, 1, H, conv]
     int64_t            cache_last_channel_len_ = 0;
-    std::vector<float> dec_h_, dec_c_;       // [L, 1, Hd]
-    std::vector<float> dec_hidden_;          // [Hd] — joint input
+    std::vector<float> dec_h_, dec_c_;       // [L, 1, Hd]  (greedy path)
+    std::vector<float> dec_hidden_;          // [Hd] — joint input (greedy path)
     std::string        accumulated_text_;
     bool               stream_init_ = false;
     bool               eou_detected_ = false;  // Parakeet-EOU: <EOU> seen this stream
     float              preemph_prev_ = 0.0f;   // last raw sample, for cross-window pre-emphasis
+
+    // ---- beam-search state (Config.beam_size > 1) ----
+    std::vector<BeamHyp> beams_;   // carried across windows, like the greedy predictor state
+    ContextGraph         ctx_;     // contextual-biasing automaton (empty = no biasing)
 };
 
 }  // namespace speech_core

--- a/include/speech_core/models/onnx_nemotron_streaming_stt.h
+++ b/include/speech_core/models/onnx_nemotron_streaming_stt.h
@@ -96,9 +96,13 @@ public:
     // Contextual biasing (shallow fusion). Nudges beam search toward the given
     // surface phrases — command words, a brand name, live contact/track names.
     // No effect unless Config.beam_size > 1. Rebuild per utterance to inject the
-    // entities currently on the device. Empty list clears biasing.
+    // entities currently on the device. Empty list clears biasing. `max_bonus`
+    // optionally caps each phrase's per-character boost (0 = uncapped, matching
+    // sherpa-onnx/k2); a positive cap keeps a long phrase from overriding clear
+    // audio at wider beams. See ContextGraph.
     void set_context_phrases(const std::vector<std::string>& phrases,
-                             float per_char = 1.5f, float completion = 3.0f);
+                             float per_char = 1.5f, float completion = 3.0f,
+                             float max_bonus = 0.0f);
 
     // --- STTInterface (streaming — the real path) ---
     bool supports_streaming() const override { return true; }

--- a/src/models/context_graph.cpp
+++ b/src/models/context_graph.cpp
@@ -1,5 +1,6 @@
 #include "speech_core/models/context_graph.h"
 
+#include <algorithm>
 #include <cctype>
 #include <deque>
 
@@ -38,7 +39,7 @@ std::string ContextGraph::normalize(const std::string& text) {
 }
 
 ContextGraph::ContextGraph(const std::vector<std::string>& phrases,
-                           float per_char, float completion)
+                           float per_char, float completion, float max_bonus)
     : per_char_(per_char), completion_(completion) {
     // Build the trie. Each phrase is anchored with a leading space so it only
     // matches at a word boundary (the emitted text has a space from U+2581 at
@@ -88,9 +89,16 @@ ContextGraph::ContextGraph(const std::vector<std::string>& phrases,
         }
     }
 
+    // Node score = per_char * depth, optionally capped. The cap flattens the
+    // deep region of every phrase, so no single match can accumulate an
+    // unbounded per-character boost (telescoping bonuses derive from these
+    // scores, so the cap needs no special-casing in advance()). Fail-arc
+    // refunds still work: a shallower fail target always has a lower score.
     score_.assign(nodes_.size(), 0.0f);
     for (size_t n = 0; n < nodes_.size(); ++n) {
-        score_[n] = per_char_ * static_cast<float>(nodes_[n].depth);
+        float s = per_char_ * static_cast<float>(nodes_[n].depth);
+        if (max_bonus > 0.0f) s = std::min(s, max_bonus);
+        score_[n] = s;
     }
 }
 

--- a/src/models/context_graph.cpp
+++ b/src/models/context_graph.cpp
@@ -1,0 +1,121 @@
+#include "speech_core/models/context_graph.h"
+
+#include <cctype>
+#include <deque>
+
+namespace speech_core {
+
+std::string ContextGraph::normalize(const std::string& text) {
+    std::string out;
+    out.reserve(text.size());
+    size_t i = 0;
+    while (i < text.size()) {
+        const unsigned char b = static_cast<unsigned char>(text[i]);
+        // SentencePiece word marker U+2581 (E2 96 81) -> word-boundary space.
+        if (b == 0xE2 && i + 2 < text.size() &&
+            static_cast<unsigned char>(text[i + 1]) == 0x96 &&
+            static_cast<unsigned char>(text[i + 2]) == 0x81) {
+            out.push_back(' ');
+            i += 3;
+            continue;
+        }
+        if (b < 0x80) {
+            const char c = static_cast<char>(b);
+            if (c >= 'A' && c <= 'Z') {
+                out.push_back(static_cast<char>(c - 'A' + 'a'));
+            } else if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == ' ') {
+                out.push_back(c);
+            }
+            // else: punctuation — dropped
+            i += 1;
+        } else {
+            // Other multi-byte UTF-8 (accented Latin, etc.): skip the lead byte;
+            // continuation bytes fall through and are dropped as >= 0x80.
+            i += 1;
+        }
+    }
+    return out;
+}
+
+ContextGraph::ContextGraph(const std::vector<std::string>& phrases,
+                           float per_char, float completion)
+    : per_char_(per_char), completion_(completion) {
+    // Build the trie. Each phrase is anchored with a leading space so it only
+    // matches at a word boundary (the emitted text has a space from U+2581 at
+    // every word start, including the first).
+    for (const auto& raw : phrases) {
+        const std::string norm = normalize(" " + raw);
+        if (norm.size() <= 1) continue;  // empty or just the anchor space
+        int node = 0;
+        for (char c : norm) {
+            auto it = nodes_[node].children.find(c);
+            if (it != nodes_[node].children.end()) {
+                node = it->second;
+            } else {
+                const int child = static_cast<int>(nodes_.size());
+                nodes_.push_back(Node{});
+                nodes_.back().depth = nodes_[node].depth + 1;
+                nodes_[node].children[c] = child;
+                node = child;
+            }
+        }
+        nodes_[node].end = true;
+    }
+
+    // Aho-Corasick fail links + output flags via BFS over trie depth.
+    std::deque<int> queue;
+    for (auto& [c, child] : nodes_[0].children) {
+        nodes_[child].fail = 0;
+        queue.push_back(child);
+    }
+    while (!queue.empty()) {
+        const int u = queue.front();
+        queue.pop_front();
+        nodes_[u].output = nodes_[u].end || nodes_[nodes_[u].fail].output;
+        // Snapshot children keys/values: building fail links reads other nodes.
+        std::vector<std::pair<char, int>> kids(nodes_[u].children.begin(),
+                                               nodes_[u].children.end());
+        for (auto& [c, v] : kids) {
+            int f = nodes_[u].fail;
+            while (f != 0 && nodes_[f].children.find(c) == nodes_[f].children.end()) {
+                f = nodes_[f].fail;
+            }
+            auto it = nodes_[f].children.find(c);
+            nodes_[v].fail = (it != nodes_[f].children.end() && it->second != v)
+                                 ? it->second
+                                 : 0;
+            queue.push_back(v);
+        }
+    }
+
+    score_.assign(nodes_.size(), 0.0f);
+    for (size_t n = 0; n < nodes_.size(); ++n) {
+        score_[n] = per_char_ * static_cast<float>(nodes_[n].depth);
+    }
+}
+
+int ContextGraph::go(int node, char c) const {
+    while (node != 0 && nodes_[node].children.find(c) == nodes_[node].children.end()) {
+        node = nodes_[node].fail;
+    }
+    auto it = nodes_[node].children.find(c);
+    return it != nodes_[node].children.end() ? it->second : 0;
+}
+
+ContextGraph::Step ContextGraph::advance(State s, const std::string& token_text) const {
+    if (empty()) return {0.0f, 0};
+    const std::string norm = normalize(token_text);
+    float bonus = 0.0f;
+    int n = s;
+    for (char c : norm) {
+        const int d = go(n, c);
+        // Telescoping: forward arcs add per_char; fail arcs (broken match)
+        // land on a shallower node and refund the difference.
+        bonus += score_[d] - score_[n];
+        if (nodes_[d].output) bonus += completion_;
+        n = d;
+    }
+    return {bonus, n};
+}
+
+}  // namespace speech_core

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -628,8 +628,9 @@ OnnxNemotronStreamingStt::best_beam() const {
 }
 
 void OnnxNemotronStreamingStt::set_context_phrases(
-    const std::vector<std::string>& phrases, float per_char, float completion) {
-    ctx_ = ContextGraph(phrases, per_char, completion);
+    const std::vector<std::string>& phrases, float per_char, float completion,
+    float max_bonus) {
+    ctx_ = ContextGraph(phrases, per_char, completion, max_bonus);
 }
 
 // Modified RNN-T beam search over the committed frames, with optional

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -8,6 +8,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
+#include <utility>
 
 namespace speech_core {
 
@@ -327,9 +329,25 @@ void OnnxNemotronStreamingStt::reset_stream_state() {
     // Prime the decoder LSTM with the blank token so the first joint() call
     // sees a meaningful hidden state (matches the LiteRT impl).
     run_decoder_step(cfg_.blank_id);
+
+    // Beam search seeds one hypothesis from that same primed predictor state.
+    beams_.clear();
+    if (cfg_.beam_size > 1) {
+        BeamHyp seed;
+        seed.dec_h      = dec_h_;
+        seed.dec_c      = dec_c_;
+        seed.dec_hidden = dec_hidden_;
+        seed.ctx        = ctx_.start();
+        beams_.push_back(std::move(seed));
+    }
 }
 
-void OnnxNemotronStreamingStt::run_decoder_step(int64_t token_id) {
+void OnnxNemotronStreamingStt::decoder_step(
+    int64_t token_id,
+    const std::vector<float>& h_in, const std::vector<float>& c_in,
+    std::vector<float>& hidden_out,
+    std::vector<float>& h_out, std::vector<float>& c_out)
+{
     auto* mem = OnnxEngine::get().cpu_memory();
 
     const int64_t s_tok[2]   = {1, 1};
@@ -343,10 +361,10 @@ void OnnxNemotronStreamingStt::run_decoder_step(int64_t token_id) {
         mem, &tok, sizeof(int64_t), s_tok, 2,
         ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &t_tok));
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-        mem, dec_h_.data(), dec_h_.size() * sizeof(float), s_state, 3,
+        mem, const_cast<float*>(h_in.data()), h_in.size() * sizeof(float), s_state, 3,
         ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_h));
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-        mem, dec_c_.data(), dec_c_.size() * sizeof(float), s_state, 3,
+        mem, const_cast<float*>(c_in.data()), c_in.size() * sizeof(float), s_state, 3,
         ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_c));
 
     OrtValue* in[3]  = {t_tok, t_h, t_c};
@@ -356,19 +374,67 @@ void OnnxNemotronStreamingStt::run_decoder_step(int64_t token_id) {
         dec_io_.in_names.data(),  in,  dec_io_.in_names.size(),
         dec_io_.out_names.data(), dec_io_.out_names.size(), out));
 
+    // Size the destinations (no-op when already sized) before copying. Safe
+    // when the out vectors alias the in vectors — Run has finished reading the
+    // inputs, and same-size resize keeps the wrapped pointers valid.
+    hidden_out.resize(static_cast<size_t>(cfg_.decoder_hidden));
+    h_out.resize(static_cast<size_t>(cfg_.decoder_layers) * cfg_.decoder_hidden);
+    c_out.resize(h_out.size());
+
     auto copy_out = [&](OrtValue* v, void* dst, size_t bytes) {
         void* p = nullptr;
         ort_check(api_, api_->GetTensorMutableData(v, &p));
         std::memcpy(dst, p, bytes);
     };
-    copy_out(out[0], dec_hidden_.data(), dec_hidden_.size() * sizeof(float));
-    copy_out(out[1], dec_h_.data(),      dec_h_.size()      * sizeof(float));
-    copy_out(out[2], dec_c_.data(),      dec_c_.size()      * sizeof(float));
+    copy_out(out[0], hidden_out.data(), hidden_out.size() * sizeof(float));
+    copy_out(out[1], h_out.data(),      h_out.size()      * sizeof(float));
+    copy_out(out[2], c_out.data(),      c_out.size()      * sizeof(float));
 
     for (int i = 2; i >= 0; --i) api_->ReleaseValue(out[i]);
     api_->ReleaseValue(t_c);
     api_->ReleaseValue(t_h);
     api_->ReleaseValue(t_tok);
+}
+
+void OnnxNemotronStreamingStt::run_decoder_step(int64_t token_id) {
+    decoder_step(token_id, dec_h_, dec_c_, dec_hidden_, dec_h_, dec_c_);
+}
+
+void OnnxNemotronStreamingStt::joint_logits(
+    const float* enc_frame, const std::vector<float>& dec_hidden,
+    std::vector<float>& logits)
+{
+    auto* mem = OnnxEngine::get().cpu_memory();
+    const int64_t s_encf  [3] = {1, 1, cfg_.encoder_hidden};
+    const int64_t s_dechid[3] = {1, 1, cfg_.decoder_hidden};
+    const size_t  n_logits    = static_cast<size_t>(cfg_.vocab_size) + 1;
+    logits.resize(n_logits);
+
+    OrtValue* t_encf   = nullptr;
+    OrtValue* t_dechid = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, const_cast<float*>(enc_frame),
+        static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
+        s_encf, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_encf));
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, const_cast<float*>(dec_hidden.data()),
+        dec_hidden.size() * sizeof(float),
+        s_dechid, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_dechid));
+
+    OrtValue* jin[2]  = {t_encf, t_dechid};
+    OrtValue* jout[1] = {nullptr};
+    ort_check(api_, api_->Run(
+        jnt_, nullptr,
+        jnt_io_.in_names.data(),  jin,  jnt_io_.in_names.size(),
+        jnt_io_.out_names.data(), jnt_io_.out_names.size(), jout));
+
+    void* p = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(jout[0], &p));
+    std::memcpy(logits.data(), p, n_logits * sizeof(float));
+
+    api_->ReleaseValue(jout[0]);
+    api_->ReleaseValue(t_dechid);
+    api_->ReleaseValue(t_encf);
 }
 
 // Drain one window from pending_, run mel -> encoder (cache-aware) -> greedy
@@ -510,45 +576,21 @@ std::string OnnxNemotronStreamingStt::run_window() {
     api_->ReleaseValue(t_mlen);
     api_->ReleaseValue(t_mel);
 
-    // Greedy RNN-T over the COMMITTED encoder frames (frames 0..output_frames_-1).
-    // The remaining T_out - output_frames_ frames are right-context lookahead,
-    // re-settled on the next window — feeding them duplicates output. For
-    // 80 ms chunks (output_frames_=1) we decode only frame 0, same as before.
-    // For 160/560/1120 ms (output_frames_=2/7/14) we now decode multiple
-    // frames per window — this is what closes the streaming-quality gap.
-    const int64_t s_encf  [3] = {1, 1, cfg_.encoder_hidden};
-    const int64_t s_dechid[3] = {1, 1, cfg_.decoder_hidden};
-    const size_t  n_logits     = static_cast<size_t>(cfg_.vocab_size) + 1;
+    // Decode the committed frames (0..output_frames_-1). The remaining
+    // T_out - output_frames_ frames are right-context lookahead, re-settled on
+    // the next window. Greedy is the default and byte-identical to before;
+    // beam search (Config.beam_size > 1) carries the alternative hypotheses.
+    return (cfg_.beam_size > 1) ? decode_beam(encoded) : decode_greedy(encoded);
+}
 
+std::string OnnxNemotronStreamingStt::decode_greedy(const std::vector<float>& encoded) {
+    const size_t n_logits = static_cast<size_t>(cfg_.vocab_size) + 1;
+    std::vector<float> logits;
     std::string emitted;
     for (int frame = 0; frame < output_frames_; ++frame) {
-        // Offset into encoded[]: frame 0 starts at index 0, frame 1 at
-        // encoder_hidden, etc. The joint sees one encoder_hidden vector.
         const size_t frame_off = static_cast<size_t>(frame) * cfg_.encoder_hidden;
         for (int expand = 0; expand < cfg_.max_symbols; ++expand) {
-            OrtValue* t_encf   = nullptr;
-            OrtValue* t_dechid = nullptr;
-            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-                mem, encoded.data() + frame_off,
-                static_cast<size_t>(cfg_.encoder_hidden) * sizeof(float),
-                s_encf, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_encf));
-            ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-                mem, dec_hidden_.data(), dec_hidden_.size() * sizeof(float),
-                s_dechid, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_dechid));
-
-            OrtValue* jin[2]  = {t_encf, t_dechid};
-            OrtValue* jout[1] = {nullptr};
-            ort_check(api_, api_->Run(
-                jnt_, nullptr,
-                jnt_io_.in_names.data(),  jin,  jnt_io_.in_names.size(),
-                jnt_io_.out_names.data(), jnt_io_.out_names.size(), jout));
-
-            std::vector<float> logits(n_logits);
-            copy_out(jout[0], logits.data(), n_logits * sizeof(float));
-
-            api_->ReleaseValue(jout[0]);
-            api_->ReleaseValue(t_dechid);
-            api_->ReleaseValue(t_encf);
+            joint_logits(encoded.data() + frame_off, dec_hidden_, logits);
 
             int   best   = 0;
             float best_v = logits[0];
@@ -576,6 +618,143 @@ std::string OnnxNemotronStreamingStt::run_window() {
     return emitted;
 }
 
+const OnnxNemotronStreamingStt::BeamHyp*
+OnnxNemotronStreamingStt::best_beam() const {
+    const BeamHyp* best = nullptr;
+    for (const auto& h : beams_) {
+        if (!best || h.score > best->score) best = &h;
+    }
+    return best;
+}
+
+void OnnxNemotronStreamingStt::set_context_phrases(
+    const std::vector<std::string>& phrases, float per_char, float completion) {
+    ctx_ = ContextGraph(phrases, per_char, completion);
+}
+
+// Modified RNN-T beam search over the committed frames, with optional
+// contextual biasing. Frame-synchronous: within a frame each hypothesis may
+// emit up to max_symbols tokens (blank ends its emission for that frame). The
+// context graph adds a log-domain bonus that steers the beam toward hypotheses
+// spelling out a bias phrase. State (beams_) carries across windows exactly
+// like the greedy predictor state does.
+std::string OnnxNemotronStreamingStt::decode_beam(const std::vector<float>& encoded) {
+    const int    n_logits = cfg_.vocab_size + 1;
+    const int    beam     = std::max(2, cfg_.beam_size);
+    const size_t enc_h    = static_cast<size_t>(cfg_.encoder_hidden);
+    const bool   biasing  = !ctx_.empty();
+
+    struct Cand {
+        int    base;    // index into `active`
+        int    token;   // emitted token (blank_id = advance frame)
+        double score;   // base.score + logP(token) [+ context bonus]
+    };
+
+    std::vector<float> logits;
+    std::vector<std::pair<float, int>> ranked;  // (logit, token) for non-blank top-k
+
+    for (int frame = 0; frame < output_frames_; ++frame) {
+        const float* enc = encoded.data() + static_cast<size_t>(frame) * enc_h;
+
+        // Terminal (EOU) hypotheses are carried forward untouched; only live
+        // ones expand at this frame.
+        std::vector<BeamHyp> active;
+        std::vector<BeamHyp> frozen;
+        for (auto& h : beams_) {
+            (h.eou ? frozen : active).push_back(std::move(h));
+        }
+        beams_.clear();
+
+        for (int step = 0; step < cfg_.max_symbols && !active.empty(); ++step) {
+            std::vector<Cand> cands;
+            cands.reserve(active.size() * (static_cast<size_t>(beam) + 1));
+
+            for (size_t i = 0; i < active.size(); ++i) {
+                joint_logits(enc, active[i].dec_hidden, logits);
+
+                float mx = logits[0];
+                for (int t = 1; t < n_logits; ++t) mx = std::max(mx, logits[t]);
+                double sum = 0.0;
+                for (int t = 0; t < n_logits; ++t) sum += std::exp(logits[t] - mx);
+                const double lse = static_cast<double>(mx) + std::log(sum);
+
+                // Blank: hypothesis advances a frame, predictor unchanged.
+                cands.push_back({static_cast<int>(i), cfg_.blank_id,
+                                 active[i].score + (logits[cfg_.blank_id] - lse)});
+
+                // Top-`beam` non-blank tokens (ranking by logit is monotone in logP).
+                ranked.clear();
+                for (int t = 0; t < n_logits; ++t) {
+                    if (t != cfg_.blank_id) ranked.emplace_back(logits[t], t);
+                }
+                const size_t keep = std::min(static_cast<size_t>(beam), ranked.size());
+                std::partial_sort(ranked.begin(), ranked.begin() + keep, ranked.end(),
+                                  [](const auto& a, const auto& b) { return a.first > b.first; });
+                for (size_t k = 0; k < keep; ++k) {
+                    const int t = ranked[k].second;
+                    double sc = active[i].score + (logits[t] - lse);
+                    if (biasing && t != cfg_.eou_token_id && t != cfg_.eob_token_id) {
+                        sc += ctx_.advance(active[i].ctx, token_to_text(t)).bonus;
+                    }
+                    cands.push_back({static_cast<int>(i), t, sc});
+                }
+            }
+
+            // Keep the best `beam` candidates across all active hypotheses.
+            const size_t keepc = std::min(static_cast<size_t>(beam), cands.size());
+            std::partial_sort(cands.begin(), cands.begin() + keepc, cands.end(),
+                              [](const Cand& a, const Cand& b) { return a.score > b.score; });
+            cands.resize(keepc);
+
+            std::vector<BeamHyp> next_active;
+            for (const Cand& cd : cands) {
+                BeamHyp h = active[cd.base];  // copy: several cands can share a base
+                h.score = cd.score;
+
+                if (cd.token == cfg_.blank_id) {
+                    frozen.push_back(std::move(h));           // frame done for this hyp
+                    continue;
+                }
+                if (cd.token == cfg_.eou_token_id) {
+                    h.eou = true;
+                    decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
+                                 h.dec_hidden, h.dec_h, h.dec_c);
+                    frozen.push_back(std::move(h));           // terminal
+                    continue;
+                }
+                if (cd.token == cfg_.eob_token_id) {
+                    decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
+                                 h.dec_hidden, h.dec_h, h.dec_c);
+                    next_active.push_back(std::move(h));      // soft boundary, no text
+                    continue;
+                }
+                if (biasing) h.ctx = ctx_.advance(active[cd.base].ctx, token_to_text(cd.token)).state;
+                h.text += token_to_text(cd.token);
+                decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
+                             h.dec_hidden, h.dec_h, h.dec_c);
+                next_active.push_back(std::move(h));
+            }
+            active = std::move(next_active);
+        }
+
+        // Carry survivors (blanked = frozen; still-active hit the max_symbols cap)
+        // to the next frame, pruned to the beam width.
+        beams_ = std::move(frozen);
+        for (auto& h : active) beams_.push_back(std::move(h));
+        if (static_cast<int>(beams_.size()) > beam) {
+            std::partial_sort(beams_.begin(), beams_.begin() + beam, beams_.end(),
+                              [](const BeamHyp& a, const BeamHyp& b) { return a.score > b.score; });
+            beams_.resize(beam);
+        }
+    }
+
+    const BeamHyp* best = best_beam();
+    if (best && best->eou) eou_detected_ = true;
+    // Beam mode reports the full best transcript from end_stream(), not an
+    // incremental per-window delta, so return nothing here.
+    return {};
+}
+
 // ---------------------------------------------------------------------------
 // Streaming API
 // ---------------------------------------------------------------------------
@@ -594,10 +773,18 @@ PartialResult OnnxNemotronStreamingStt::push_chunk(const float* audio, size_t le
     while (static_cast<int>(pending_.size()) >= chunk_samples()) {
         text += run_window();
     }
-    accumulated_text_ += text;
 
     PartialResult out;
-    out.text = std::move(text);
+    if (cfg_.beam_size > 1) {
+        // Beam mode: run_window() emits no incremental delta; the transcript
+        // lives in the hypotheses. Report the current best as a full partial
+        // (replace semantics — the best path can change as more audio arrives).
+        const BeamHyp* best = best_beam();
+        out.text = best ? best->text : std::string{};
+    } else {
+        accumulated_text_ += text;
+        out.text = std::move(text);
+    }
     return out;
 }
 
@@ -623,7 +810,12 @@ void OnnxNemotronStreamingStt::flush_stream() {
 TranscriptionResult OnnxNemotronStreamingStt::end_stream() {
     flush_stream();
     TranscriptionResult out;
-    out.text = accumulated_text_;
+    if (cfg_.beam_size > 1) {
+        const BeamHyp* best = best_beam();
+        out.text = best ? best->text : std::string{};
+    } else {
+        out.text = accumulated_text_;
+    }
     stream_init_ = false;
     return out;
 }

--- a/tests/test_context_graph.cpp
+++ b/tests/test_context_graph.cpp
@@ -84,6 +84,25 @@ void test_word_boundary_anchor() {
                 inside, atword);
 }
 
+void test_bonus_cap_bounds_long_phrases() {
+    // Uncapped: a long phrase accumulates far more than a short one.
+    ContextGraph uncapped({"what can you do", "stop"}, 1.5f, 3.0f, /*max_bonus=*/0.0f);
+    const float long_unc  = run(uncapped, {w("what"), w("can"), w("you"), w("do")});
+    const float short_unc = run(uncapped, {w("stop")});
+    assert(long_unc > short_unc + 5.0f);  // long dominates when uncapped
+
+    // Capped: the long phrase's per-char accumulation is bounded, so it no
+    // longer runs away past the short one (both reach the ceiling + completion).
+    ContextGraph capped({"what can you do", "stop"}, 1.5f, 3.0f, /*max_bonus=*/6.0f);
+    const float long_cap  = run(capped, {w("what"), w("can"), w("you"), w("do")});
+    const float short_cap = run(capped, {w("stop")});
+    assert(long_cap <= long_unc);                 // capped is not larger
+    assert(long_cap <= short_cap + 0.01f);         // long no longer dominates
+    std::printf("  PASS: bonus_cap_bounds_long_phrases "
+                "(long unc=%.1f cap=%.1f | short unc=%.1f cap=%.1f)\n",
+                long_unc, long_cap, short_unc, short_cap);
+}
+
 void test_multiple_phrases() {
     ContextGraph g({"soniqo", "set volume", "play"}, 1.5f, 3.0f);
     assert(run(g, {w("play")}) > 5.0f);
@@ -101,6 +120,7 @@ int main() {
     test_partial_prefix_does_not_beat_full_match();
     test_multiword_phrase();
     test_word_boundary_anchor();
+    test_bonus_cap_bounds_long_phrases();
     test_multiple_phrases();
     std::printf("All context graph tests passed.\n");
     return 0;

--- a/tests/test_context_graph.cpp
+++ b/tests/test_context_graph.cpp
@@ -1,0 +1,107 @@
+#include "speech_core/models/context_graph.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace speech_core;
+
+// Feed a sequence of token surface strings through the graph, summing bonuses.
+static float run(const ContextGraph& g, const std::vector<std::string>& tokens) {
+    float total = 0.0f;
+    ContextGraph::State s = g.start();
+    for (const auto& t : tokens) {
+        auto step = g.advance(s, t);
+        total += step.bonus;
+        s = step.state;
+    }
+    return total;
+}
+
+static const char* SP = "\xE2\x96\x81";  // U+2581 word marker
+static std::string w(const std::string& s) { return std::string(SP) + s; }
+
+void test_normalize() {
+    assert(ContextGraph::normalize(w("Set")) == " set");
+    assert(ContextGraph::normalize("Qo!") == "qo");
+    assert(ContextGraph::normalize(w("8")) == " 8");
+    std::printf("  PASS: normalize\n");
+}
+
+void test_empty_graph_is_noop() {
+    ContextGraph g;
+    assert(g.empty());
+    assert(run(g, {w("anything"), "goes"}) == 0.0f);
+    std::printf("  PASS: empty_graph_is_noop\n");
+}
+
+void test_completed_phrase_scores_positive() {
+    ContextGraph g({"soniqo"}, /*per_char=*/1.5f, /*completion=*/3.0f);
+    // Tokens that spell "soniqo" at a word boundary.
+    const float hit = run(g, {w("so"), "ni", "qo"});
+    // 6 matched chars after the anchor space (" soniqo") + one completion.
+    // Space(+1.5) s o n i q o = 7 forward chars * 1.5 + 3.0 completion.
+    assert(hit > 10.0f);
+    std::printf("  PASS: completed_phrase_scores_positive (bonus=%.2f)\n", hit);
+}
+
+void test_unrelated_text_nets_near_zero() {
+    ContextGraph g({"soniqo"}, 1.5f, 3.0f);
+    // "so" starts matching " so" then "up" breaks it — the fail arc refunds.
+    const float miss = run(g, {w("so"), "up"});
+    assert(std::fabs(miss) < 1e-3f);
+    std::printf("  PASS: unrelated_text_nets_near_zero (net=%.4f)\n", miss);
+}
+
+void test_partial_prefix_does_not_beat_full_match() {
+    ContextGraph g({"soniqo"}, 1.5f, 3.0f);
+    const float full    = run(g, {w("soniqo")});
+    const float partial = run(g, {w("son"), "der"});  // "sonder" breaks the match
+    assert(full > partial);
+    assert(partial < 1.0f);  // refunded to ~0 once the match breaks
+    std::printf("  PASS: partial_prefix_does_not_beat_full_match (full=%.2f partial=%.2f)\n",
+                full, partial);
+}
+
+void test_multiword_phrase() {
+    ContextGraph g({"set volume"}, 1.5f, 3.0f);
+    const float hit  = run(g, {w("set"), w("volume")});
+    const float near = run(g, {w("said"), w("william")});
+    assert(hit > 10.0f);
+    assert(hit > near);
+    std::printf("  PASS: multiword_phrase (hit=%.2f near=%.2f)\n", hit, near);
+}
+
+void test_word_boundary_anchor() {
+    // "son" must not match inside "person" (no word boundary before "son").
+    ContextGraph g({"son"}, 1.5f, 3.0f);
+    const float inside = run(g, {w("person")});
+    const float atword = run(g, {w("son")});
+    assert(atword > inside);
+    std::printf("  PASS: word_boundary_anchor (inside=%.2f atword=%.2f)\n",
+                inside, atword);
+}
+
+void test_multiple_phrases() {
+    ContextGraph g({"soniqo", "set volume", "play"}, 1.5f, 3.0f);
+    assert(run(g, {w("play")}) > 5.0f);
+    assert(run(g, {w("soniqo")}) > 5.0f);
+    assert(std::fabs(run(g, {w("random"), "junk"})) < 1e-3f);
+    std::printf("  PASS: multiple_phrases\n");
+}
+
+int main() {
+    std::printf("test_context_graph:\n");
+    test_normalize();
+    test_empty_graph_is_noop();
+    test_completed_phrase_scores_positive();
+    test_unrelated_text_nets_near_zero();
+    test_partial_prefix_does_not_beat_full_match();
+    test_multiword_phrase();
+    test_word_boundary_anchor();
+    test_multiple_phrases();
+    std::printf("All context graph tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds opt-in **modified RNN-T beam search** and **tokenizer-agnostic contextual biasing** to the Parakeet-EOU / Nemotron streaming decoder, with an optional **over-biasing guardrail**. Greedy stays the default and is byte-identical to prior releases — beam is only active when `Config.beam_size > 1`.

Motivation: the streaming decoder was greedy-only, so there was no way to bias transcription toward a known vocabulary (command words, a brand name, the contact/track names on the device). This is the standard fix for custom-vocabulary ASR (NeMo, sherpa-onnx), and the only decode-time lever the transducer architecture exposes.

## What changed

- **`ContextGraph` (new, pure C++, in the core lib).** An Aho-Corasick character automaton that scores bias matches on the *decoded surface text* of tokens rather than token ids — so it works even though the published EOU bundle ships only a decode vocabulary (no encoder tokenizer). Matches are anchored to word starts, and a broken partial match refunds its accumulated bonus via the fail arc (same cancellation sherpa-onnx/k2 do), so unrelated speech nets ~zero. Unit-tested (`test_context_graph`, 9 cases).
- **Over-biasing guardrail (optional).** Uncapped, longer phrases accumulate a larger boost (as in sherpa-onnx / k2, where you tune the score by hand). A positive `max_bonus` caps each phrase's per-character boost so a wide beam or long list can't let a phrase override clear audio; `0` (default) keeps the uncapped behavior.
- **`OnnxNemotronStreamingStt`.** Factored pure `decoder_step()` / `joint_logits()` helpers out of the greedy loop; added `Config.beam_size`, `decode_beam()` (N hypotheses carried across streaming windows, each with its own predictor state + context position), and `set_context_phrases()` to install the biasing automaton. `beam_size <= 1` runs the original greedy path.
- **`docs/models.md`.** Documents beam search, contextual biasing, and the guardrail with a usage snippet.

## Test plan

- `cmake -B build && ctest` (default, no ONNX): **20/20 pass** (includes `test_context_graph`).
- `cmake -B build -DSPEECH_CORE_WITH_ONNX=ON && ctest`: **19/19 pass**.
- Greedy path verified byte-identical: host greedy output matches the shipped phone transcripts on a real recording.
- On that recording, `beam_size=4` + the command grammar biased recovers **"set volume eight"** from a greedy **"said william eight"** (the failure that had set the volume to the wrong level).
- Guardrail verified: at `beam_size=8` without a cap, biasing collapses (every segment → "what can you do"); with `max_bonus=6` the segments recover their correct transcripts while "set volume eight" stays fixed.

## Notes

- Public API and the default decode path are unchanged; consumers opt in via `beam_size` + `set_context_phrases()`.
- Not in this PR: the SDK/JNI plumbing so an app can pass `beam_size` and a per-utterance phrase list (a speech-android + control change).
