### PR TITLE
Extract RNN-T beam search into a tested, generic algorithm (+ emit-reward knob)

### DIFF
--- a/include/speech_core/models/onnx_nemotron_streaming_stt.h
+++ b/include/speech_core/models/onnx_nemotron_streaming_stt.h
@@ -2,6 +2,7 @@
 
 #include "speech_core/interfaces.h"
 #include "speech_core/models/context_graph.h"
+#include "speech_core/models/transducer_beam.h"
 
 #include <onnxruntime_c_api.h>
 
@@ -69,6 +70,14 @@ public:
         // >1 enables modified beam search, which is what contextual biasing
         // (set_context_phrases) rides on. Greedy stays the default.
         int   beam_size       = 0;
+        // Per-emitted-token reward for beam search — a shallow-fusion blank
+        // penalty for models whose beam under-emits (blank-heavy hypotheses
+        // win and truncate). Default 0: the published Parakeet-EOU export does
+        // NOT under-emit at beam width 4 (measured — its acoustics are
+        // confident enough that the correct tokens win), and a positive reward
+        // there causes over-emission/hallucination. Raise only for a model
+        // measured to truncate. See transducer_beam.h.
+        float beam_emit_bonus = 0.0f;
     };
 
     OnnxNemotronStreamingStt(const std::string& encoder_path,
@@ -132,16 +141,14 @@ private:
     std::string decode_beam(const std::vector<float>& encoded);
     std::string token_to_text(int id) const;
 
-    // One beam-search hypothesis: emitted text, running log-prob score, its own
-    // predictor state, and its position in the context-biasing automaton.
-    struct BeamHyp {
-        std::string        text;
-        double             score = 0.0;
-        std::vector<float> dec_h, dec_c, dec_hidden;
-        ContextGraph::State ctx = 0;
-        bool               eou = false;
+    // Predictor (decoder LSTM) state carried per beam hypothesis. The generic
+    // beam (transducer_beam.h) treats it as an opaque, copyable State.
+    struct PredState {
+        std::vector<float> h, c, hidden;
     };
-    const BeamHyp* best_beam() const;
+    using Beam = transducer::BeamHyp<PredState, ContextGraph::State>;
+    const Beam* best_beam() const;
+    std::string beam_text(const Beam& b) const;  // token ids -> transcript
     // Mel window fed to the encoder, in samples. EOU streams melFrames*hop
     // windows advanced by a smaller shift (see run_window); Nemotron uses the
     // original (melFrames-1)*hop stride where window == shift.
@@ -197,8 +204,8 @@ private:
     float              preemph_prev_ = 0.0f;   // last raw sample, for cross-window pre-emphasis
 
     // ---- beam-search state (Config.beam_size > 1) ----
-    std::vector<BeamHyp> beams_;   // carried across windows, like the greedy predictor state
-    ContextGraph         ctx_;     // contextual-biasing automaton (empty = no biasing)
+    std::vector<Beam> beams_;   // carried across windows, like the greedy predictor state
+    ContextGraph      ctx_;     // contextual-biasing automaton (empty = no biasing)
 };
 
 }  // namespace speech_core

--- a/include/speech_core/models/transducer_beam.h
+++ b/include/speech_core/models/transducer_beam.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace speech_core::transducer {
+
+/// Modified RNN-T beam search, extracted from any specific model so the
+/// algorithm can be unit-tested with a toy transducer (no ML runtime).
+///
+/// Frame-synchronous: within one committed encoder frame each hypothesis may
+/// emit up to `max_symbols` tokens; a blank ends its emission for that frame
+/// and advances it. Streaming callers keep the `beams` vector across windows,
+/// exactly like the greedy predictor state.
+///
+/// **Blank-bias correction.** Plain RNN-T beam search under-emits: blank is
+/// usually high-probability, so a short, blank-heavy hypothesis out-scores the
+/// complete one and the transcript gets truncated. `emit_bonus` adds a fixed
+/// reward per emitted text token (a shallow-fusion blank penalty), which
+/// counteracts the bias. It is the simplest of the standard fixes (the others
+/// being hypothesis recombination and length normalization).
+
+struct BeamParams {
+    int   beam_size   = 4;
+    int   max_symbols = 8;
+    int   blank_id    = 0;
+    int   eou_id      = -1;   ///< terminal token (ends the hypothesis); -1 = none
+    int   eob_id      = -1;   ///< soft boundary: advances predictor, emits no text
+    float emit_bonus  = 0.0f; ///< per-emitted-text-token reward; corrects blank bias
+};
+
+template <class State, class Aux>
+struct BeamHyp {
+    std::vector<int> tokens;      ///< emitted text token ids (no blank/eou/eob)
+    double           score = 0.0;
+    State            state;       ///< predictor state
+    Aux              aux;         ///< biasing state (e.g. ContextGraph::State)
+    bool             terminal = false;
+};
+
+namespace detail {
+inline void log_softmax(const std::vector<float>& logits, std::vector<float>& out) {
+    out.resize(logits.size());
+    float mx = logits.empty() ? 0.0f : logits[0];
+    for (float v : logits) mx = std::max(mx, v);
+    double sum = 0.0;
+    for (float v : logits) sum += std::exp(static_cast<double>(v) - mx);
+    const double lse = static_cast<double>(mx) + std::log(sum);
+    for (size_t i = 0; i < logits.size(); ++i) {
+        out[i] = static_cast<float>(static_cast<double>(logits[i]) - lse);
+    }
+}
+}  // namespace detail
+
+/// Advance `beams` (in/out, persistent across streaming windows) over
+/// `frame_count` committed frames starting at window-local index `frame_begin`.
+///
+///   joint(int frame, const State&) -> const std::vector<float>&   (logits)
+///   predict(int token, const State&) -> State                     (advance predictor)
+///   bonus(int token, const Aux&) -> std::pair<float, Aux>         (biasing delta + next aux)
+///
+/// `joint` must return a reference valid until the next `joint` call (a reused
+/// buffer is fine — the result is consumed immediately).
+template <class State, class Aux, class Joint, class Predict, class Bonus>
+void beam_decode_frames(std::vector<BeamHyp<State, Aux>>& beams,
+                        int frame_begin, int frame_count,
+                        const BeamParams& p,
+                        Joint joint, Predict predict, Bonus bonus) {
+    using Hyp = BeamHyp<State, Aux>;
+    const int beam_size = std::max(1, p.beam_size);
+
+    struct Cand {
+        int    base;    // index into `active`
+        int    token;
+        double score;
+        Aux    aux;     // resulting biasing state for a text token
+    };
+
+    std::vector<float> lp;
+    std::vector<std::pair<float, int>> ranked;
+
+    for (int f = 0; f < frame_count; ++f) {
+        const int frame = frame_begin + f;
+
+        std::vector<Hyp> active, frozen;
+        for (auto& h : beams) (h.terminal ? frozen : active).push_back(std::move(h));
+        beams.clear();
+
+        for (int step = 0; step < p.max_symbols && !active.empty(); ++step) {
+            std::vector<Cand> cands;
+            cands.reserve(active.size() * (static_cast<size_t>(beam_size) + 1));
+
+            for (size_t i = 0; i < active.size(); ++i) {
+                const std::vector<float>& logits = joint(frame, active[i].state);
+                detail::log_softmax(logits, lp);
+                const int n = static_cast<int>(lp.size());
+
+                // Blank: advance a frame, predictor + aux unchanged.
+                cands.push_back({static_cast<int>(i), p.blank_id,
+                                 active[i].score + lp[p.blank_id], active[i].aux});
+
+                // Top `beam_size` non-blank tokens (logit rank == logprob rank).
+                ranked.clear();
+                for (int t = 0; t < n; ++t) if (t != p.blank_id) ranked.emplace_back(lp[t], t);
+                const size_t keep = std::min(static_cast<size_t>(beam_size), ranked.size());
+                std::partial_sort(ranked.begin(), ranked.begin() + keep, ranked.end(),
+                                  [](const auto& a, const auto& b) { return a.first > b.first; });
+                for (size_t k = 0; k < keep; ++k) {
+                    const int t = ranked[k].second;
+                    double sc = active[i].score + lp[t];
+                    Aux    na = active[i].aux;
+                    if (t != p.eou_id && t != p.eob_id) {
+                        auto pr = bonus(t, active[i].aux);  // {delta, next aux}
+                        sc += pr.first + p.emit_bonus;      // reward emitting text
+                        na = std::move(pr.second);
+                    }
+                    cands.push_back({static_cast<int>(i), t, sc, std::move(na)});
+                }
+            }
+
+            const size_t keepc = std::min(static_cast<size_t>(beam_size), cands.size());
+            std::partial_sort(cands.begin(), cands.begin() + keepc, cands.end(),
+                              [](const Cand& a, const Cand& b) { return a.score > b.score; });
+            cands.resize(keepc);
+
+            std::vector<Hyp> next_active;
+            for (auto& c : cands) {
+                Hyp h = active[c.base];  // copy: several cands can share a base
+                h.score = c.score;
+                if (c.token == p.blank_id) {
+                    frozen.push_back(std::move(h));
+                } else if (c.token == p.eou_id) {
+                    h.state = predict(c.token, active[c.base].state);
+                    h.terminal = true;
+                    frozen.push_back(std::move(h));
+                } else if (c.token == p.eob_id) {
+                    h.state = predict(c.token, active[c.base].state);
+                    next_active.push_back(std::move(h));
+                } else {
+                    h.tokens.push_back(c.token);
+                    h.aux   = std::move(c.aux);
+                    h.state = predict(c.token, active[c.base].state);
+                    next_active.push_back(std::move(h));
+                }
+            }
+            active = std::move(next_active);
+        }
+
+        beams = std::move(frozen);
+        for (auto& h : active) beams.push_back(std::move(h));
+        if (static_cast<int>(beams.size()) > beam_size) {
+            std::partial_sort(beams.begin(), beams.begin() + beam_size, beams.end(),
+                              [](const Hyp& a, const Hyp& b) { return a.score > b.score; });
+            beams.resize(beam_size);
+        }
+    }
+}
+
+template <class State, class Aux>
+const BeamHyp<State, Aux>* best_hyp(const std::vector<BeamHyp<State, Aux>>& beams) {
+    const BeamHyp<State, Aux>* best = nullptr;
+    for (const auto& h : beams) if (!best || h.score > best->score) best = &h;
+    return best;
+}
+
+}  // namespace speech_core::transducer

--- a/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+++ b/src/models/nemotron/onnx_nemotron_streaming_stt.cpp
@@ -333,11 +333,9 @@ void OnnxNemotronStreamingStt::reset_stream_state() {
     // Beam search seeds one hypothesis from that same primed predictor state.
     beams_.clear();
     if (cfg_.beam_size > 1) {
-        BeamHyp seed;
-        seed.dec_h      = dec_h_;
-        seed.dec_c      = dec_c_;
-        seed.dec_hidden = dec_hidden_;
-        seed.ctx        = ctx_.start();
+        Beam seed;
+        seed.state = PredState{dec_h_, dec_c_, dec_hidden_};
+        seed.aux   = ctx_.start();
         beams_.push_back(std::move(seed));
     }
 }
@@ -618,13 +616,15 @@ std::string OnnxNemotronStreamingStt::decode_greedy(const std::vector<float>& en
     return emitted;
 }
 
-const OnnxNemotronStreamingStt::BeamHyp*
+const OnnxNemotronStreamingStt::Beam*
 OnnxNemotronStreamingStt::best_beam() const {
-    const BeamHyp* best = nullptr;
-    for (const auto& h : beams_) {
-        if (!best || h.score > best->score) best = &h;
-    }
-    return best;
+    return transducer::best_hyp(beams_);
+}
+
+std::string OnnxNemotronStreamingStt::beam_text(const Beam& b) const {
+    std::string text;
+    for (int id : b.tokens) text += token_to_text(id);
+    return text;
 }
 
 void OnnxNemotronStreamingStt::set_context_phrases(
@@ -633,124 +633,46 @@ void OnnxNemotronStreamingStt::set_context_phrases(
     ctx_ = ContextGraph(phrases, per_char, completion, max_bonus);
 }
 
-// Modified RNN-T beam search over the committed frames, with optional
-// contextual biasing. Frame-synchronous: within a frame each hypothesis may
-// emit up to max_symbols tokens (blank ends its emission for that frame). The
-// context graph adds a log-domain bonus that steers the beam toward hypotheses
-// spelling out a bias phrase. State (beams_) carries across windows exactly
-// like the greedy predictor state does.
+// Modified RNN-T beam search over the committed frames via the generic,
+// unit-tested transducer::beam_decode_frames (see transducer_beam.h). The
+// per-token emit reward corrects the blank bias that otherwise truncates the
+// transcript; contextual biasing rides on the same scoring. beams_ carries
+// across windows exactly like the greedy predictor state does.
 std::string OnnxNemotronStreamingStt::decode_beam(const std::vector<float>& encoded) {
-    const int    n_logits = cfg_.vocab_size + 1;
-    const int    beam     = std::max(2, cfg_.beam_size);
-    const size_t enc_h    = static_cast<size_t>(cfg_.encoder_hidden);
-    const bool   biasing  = !ctx_.empty();
+    const size_t enc_h   = static_cast<size_t>(cfg_.encoder_hidden);
+    const bool   biasing = !ctx_.empty();
 
-    struct Cand {
-        int    base;    // index into `active`
-        int    token;   // emitted token (blank_id = advance frame)
-        double score;   // base.score + logP(token) [+ context bonus]
+    transducer::BeamParams p;
+    p.beam_size   = std::max(2, cfg_.beam_size);
+    p.max_symbols = cfg_.max_symbols;
+    p.blank_id    = cfg_.blank_id;
+    p.eou_id      = cfg_.eou_token_id;
+    p.eob_id      = cfg_.eob_token_id;
+    p.emit_bonus  = cfg_.beam_emit_bonus;
+
+    std::vector<float> logits;  // reused joint-output buffer (valid per joint() call)
+
+    auto joint = [&](int frame, const PredState& s) -> const std::vector<float>& {
+        joint_logits(encoded.data() + static_cast<size_t>(frame) * enc_h, s.hidden, logits);
+        return logits;
+    };
+    auto predict = [&](int token, const PredState& s) -> PredState {
+        PredState out;
+        decoder_step(token, s.h, s.c, out.hidden, out.h, out.c);
+        return out;
+    };
+    auto bonus = [&](int token, const ContextGraph::State& aux)
+        -> std::pair<float, ContextGraph::State> {
+        if (!biasing) return {0.0f, aux};
+        auto step = ctx_.advance(aux, token_to_text(token));
+        return {step.bonus, step.state};
     };
 
-    std::vector<float> logits;
-    std::vector<std::pair<float, int>> ranked;  // (logit, token) for non-blank top-k
+    transducer::beam_decode_frames(beams_, /*frame_begin=*/0, output_frames_, p,
+                                   joint, predict, bonus);
 
-    for (int frame = 0; frame < output_frames_; ++frame) {
-        const float* enc = encoded.data() + static_cast<size_t>(frame) * enc_h;
-
-        // Terminal (EOU) hypotheses are carried forward untouched; only live
-        // ones expand at this frame.
-        std::vector<BeamHyp> active;
-        std::vector<BeamHyp> frozen;
-        for (auto& h : beams_) {
-            (h.eou ? frozen : active).push_back(std::move(h));
-        }
-        beams_.clear();
-
-        for (int step = 0; step < cfg_.max_symbols && !active.empty(); ++step) {
-            std::vector<Cand> cands;
-            cands.reserve(active.size() * (static_cast<size_t>(beam) + 1));
-
-            for (size_t i = 0; i < active.size(); ++i) {
-                joint_logits(enc, active[i].dec_hidden, logits);
-
-                float mx = logits[0];
-                for (int t = 1; t < n_logits; ++t) mx = std::max(mx, logits[t]);
-                double sum = 0.0;
-                for (int t = 0; t < n_logits; ++t) sum += std::exp(logits[t] - mx);
-                const double lse = static_cast<double>(mx) + std::log(sum);
-
-                // Blank: hypothesis advances a frame, predictor unchanged.
-                cands.push_back({static_cast<int>(i), cfg_.blank_id,
-                                 active[i].score + (logits[cfg_.blank_id] - lse)});
-
-                // Top-`beam` non-blank tokens (ranking by logit is monotone in logP).
-                ranked.clear();
-                for (int t = 0; t < n_logits; ++t) {
-                    if (t != cfg_.blank_id) ranked.emplace_back(logits[t], t);
-                }
-                const size_t keep = std::min(static_cast<size_t>(beam), ranked.size());
-                std::partial_sort(ranked.begin(), ranked.begin() + keep, ranked.end(),
-                                  [](const auto& a, const auto& b) { return a.first > b.first; });
-                for (size_t k = 0; k < keep; ++k) {
-                    const int t = ranked[k].second;
-                    double sc = active[i].score + (logits[t] - lse);
-                    if (biasing && t != cfg_.eou_token_id && t != cfg_.eob_token_id) {
-                        sc += ctx_.advance(active[i].ctx, token_to_text(t)).bonus;
-                    }
-                    cands.push_back({static_cast<int>(i), t, sc});
-                }
-            }
-
-            // Keep the best `beam` candidates across all active hypotheses.
-            const size_t keepc = std::min(static_cast<size_t>(beam), cands.size());
-            std::partial_sort(cands.begin(), cands.begin() + keepc, cands.end(),
-                              [](const Cand& a, const Cand& b) { return a.score > b.score; });
-            cands.resize(keepc);
-
-            std::vector<BeamHyp> next_active;
-            for (const Cand& cd : cands) {
-                BeamHyp h = active[cd.base];  // copy: several cands can share a base
-                h.score = cd.score;
-
-                if (cd.token == cfg_.blank_id) {
-                    frozen.push_back(std::move(h));           // frame done for this hyp
-                    continue;
-                }
-                if (cd.token == cfg_.eou_token_id) {
-                    h.eou = true;
-                    decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
-                                 h.dec_hidden, h.dec_h, h.dec_c);
-                    frozen.push_back(std::move(h));           // terminal
-                    continue;
-                }
-                if (cd.token == cfg_.eob_token_id) {
-                    decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
-                                 h.dec_hidden, h.dec_h, h.dec_c);
-                    next_active.push_back(std::move(h));      // soft boundary, no text
-                    continue;
-                }
-                if (biasing) h.ctx = ctx_.advance(active[cd.base].ctx, token_to_text(cd.token)).state;
-                h.text += token_to_text(cd.token);
-                decoder_step(cd.token, active[cd.base].dec_h, active[cd.base].dec_c,
-                             h.dec_hidden, h.dec_h, h.dec_c);
-                next_active.push_back(std::move(h));
-            }
-            active = std::move(next_active);
-        }
-
-        // Carry survivors (blanked = frozen; still-active hit the max_symbols cap)
-        // to the next frame, pruned to the beam width.
-        beams_ = std::move(frozen);
-        for (auto& h : active) beams_.push_back(std::move(h));
-        if (static_cast<int>(beams_.size()) > beam) {
-            std::partial_sort(beams_.begin(), beams_.begin() + beam, beams_.end(),
-                              [](const BeamHyp& a, const BeamHyp& b) { return a.score > b.score; });
-            beams_.resize(beam);
-        }
-    }
-
-    const BeamHyp* best = best_beam();
-    if (best && best->eou) eou_detected_ = true;
+    const Beam* best = best_beam();
+    if (best && best->terminal) eou_detected_ = true;
     // Beam mode reports the full best transcript from end_stream(), not an
     // incremental per-window delta, so return nothing here.
     return {};
@@ -780,8 +702,8 @@ PartialResult OnnxNemotronStreamingStt::push_chunk(const float* audio, size_t le
         // Beam mode: run_window() emits no incremental delta; the transcript
         // lives in the hypotheses. Report the current best as a full partial
         // (replace semantics — the best path can change as more audio arrives).
-        const BeamHyp* best = best_beam();
-        out.text = best ? best->text : std::string{};
+        const Beam* best = best_beam();
+        out.text = best ? beam_text(*best) : std::string{};
     } else {
         accumulated_text_ += text;
         out.text = std::move(text);
@@ -812,8 +734,8 @@ TranscriptionResult OnnxNemotronStreamingStt::end_stream() {
     flush_stream();
     TranscriptionResult out;
     if (cfg_.beam_size > 1) {
-        const BeamHyp* best = best_beam();
-        out.text = best ? best->text : std::string{};
+        const Beam* best = best_beam();
+        out.text = best ? beam_text(*best) : std::string{};
     } else {
         out.text = accumulated_text_;
     }

--- a/tests/test_transducer_beam.cpp
+++ b/tests/test_transducer_beam.cpp
@@ -1,0 +1,154 @@
+#include "speech_core/models/transducer_beam.h"
+
+#include <cassert>
+#include <cstdio>
+#include <utility>
+#include <vector>
+
+using namespace speech_core::transducer;
+
+// State = number of text tokens emitted so far. Aux = unused (int).
+using Hyp = BeamHyp<int, int>;
+
+// No-op biasing.
+static std::pair<float, int> no_bonus(int /*token*/, int aux) { return {0.0f, aux}; }
+
+// ---------------------------------------------------------------------------
+// Toy transducer: emit tokens [1..target] one per state step. Blank is more
+// probable than the correct token (blank_logit > token_logit), which is what
+// makes plain RNN-T beam under-emit — the exact bug we are fixing. vocab:
+// 0 = blank, 1..3 = text tokens.
+// ---------------------------------------------------------------------------
+struct EmitToy {
+    int   target;
+    float token_logit;
+    float blank_logit;
+    std::vector<float> buf;
+    const std::vector<float>& joint(int /*frame*/, int count) {
+        buf.assign(4, -10.0f);
+        buf[0] = blank_logit;
+        if (count < target) buf[count + 1] = token_logit;
+        else buf[0] = 10.0f;  // done — blank dominates so it just advances
+        return buf;
+    }
+    static int predict(int /*token*/, int count) { return count + 1; }
+};
+
+static std::vector<int> run_emit(float emit_bonus) {
+    EmitToy toy{/*target=*/3, /*token_logit=*/1.0f, /*blank_logit=*/2.0f, {}};
+    BeamParams p;
+    p.beam_size = 4;
+    p.max_symbols = 8;
+    p.blank_id = 0;
+    p.emit_bonus = emit_bonus;
+
+    std::vector<Hyp> beams;
+    beams.push_back(Hyp{{}, 0.0, /*state=*/0, /*aux=*/0, false});
+    beam_decode_frames(beams, /*frame_begin=*/0, /*frame_count=*/3, p,
+                       [&](int f, int s) -> const std::vector<float>& { return toy.joint(f, s); },
+                       EmitToy::predict, no_bonus);
+    const Hyp* best = best_hyp(beams);
+    return best ? best->tokens : std::vector<int>{};
+}
+
+void test_blank_bias_under_emits_without_reward() {
+    // Blank is preferred, so with no emission reward the beam emits (almost)
+    // nothing — the truncation bug.
+    const auto out = run_emit(/*emit_bonus=*/0.0f);
+    assert(out.size() < 3);
+    std::printf("  PASS: blank_bias_under_emits_without_reward (emitted %zu of 3)\n", out.size());
+}
+
+void test_emit_reward_recovers_full_sequence() {
+    const auto out = run_emit(/*emit_bonus=*/3.0f);
+    assert((out == std::vector<int>{1, 2, 3}));
+    std::printf("  PASS: emit_reward_recovers_full_sequence\n");
+}
+
+void test_reward_threshold_is_monotone() {
+    // More reward never emits fewer tokens.
+    const size_t a = run_emit(0.0f).size();
+    const size_t b = run_emit(1.5f).size();
+    const size_t c = run_emit(3.0f).size();
+    assert(a <= b && b <= c);
+    std::printf("  PASS: reward_threshold_is_monotone (%zu <= %zu <= %zu)\n", a, b, c);
+}
+
+// ---------------------------------------------------------------------------
+// Toy for contextual biasing: two text tokens (1, 2) with equal acoustics at
+// the first step. The bonus callback boosts token 2, so the beam should emit 2.
+// ---------------------------------------------------------------------------
+struct ChoiceToy {
+    std::vector<float> buf;
+    const std::vector<float>& joint(int /*frame*/, int count) {
+        buf.assign(3, -10.0f);
+        buf[0] = 0.5f;  // blank
+        if (count == 0) { buf[1] = 1.0f; buf[2] = 1.0f; }  // tokens 1, 2 tie
+        else buf[0] = 10.0f;
+        return buf;
+    }
+    static int predict(int /*token*/, int count) { return count + 1; }
+};
+
+void test_bias_breaks_ties() {
+    ChoiceToy toy;
+    BeamParams p;
+    p.beam_size = 4; p.max_symbols = 4; p.blank_id = 0; p.emit_bonus = 2.0f;
+
+    auto boost_two = [](int token, int aux) -> std::pair<float, int> {
+        return {token == 2 ? 5.0f : 0.0f, aux};
+    };
+
+    std::vector<Hyp> beams;
+    beams.push_back(Hyp{{}, 0.0, 0, 0, false});
+    beam_decode_frames(beams, 0, 2, p,
+                       [&](int f, int s) -> const std::vector<float>& { return toy.joint(f, s); },
+                       ChoiceToy::predict, boost_two);
+    const Hyp* best = best_hyp(beams);
+    assert(best && best->tokens == std::vector<int>{2});
+    std::printf("  PASS: bias_breaks_ties (chose token 2)\n");
+}
+
+// ---------------------------------------------------------------------------
+// EOU: emitting the terminal token ends the hypothesis and is not written into
+// the token output. vocab: 0 = blank, 1 = text, 2 = eou.
+// ---------------------------------------------------------------------------
+struct EouToy {
+    std::vector<float> buf;
+    const std::vector<float>& joint(int /*frame*/, int count) {
+        buf.assign(3, -10.0f);
+        buf[0] = 0.5f;
+        if (count == 0) buf[1] = 5.0f;        // emit text
+        else if (count == 1) buf[2] = 5.0f;   // then EOU
+        else buf[0] = 10.0f;
+        return buf;
+    }
+    static int predict(int /*token*/, int count) { return count + 1; }
+};
+
+void test_eou_terminates_and_is_not_emitted() {
+    EouToy toy;
+    BeamParams p;
+    p.beam_size = 4; p.max_symbols = 4; p.blank_id = 0; p.eou_id = 2; p.emit_bonus = 2.0f;
+
+    std::vector<Hyp> beams;
+    beams.push_back(Hyp{{}, 0.0, 0, 0, false});
+    beam_decode_frames(beams, 0, 3, p,
+                       [&](int f, int s) -> const std::vector<float>& { return toy.joint(f, s); },
+                       EouToy::predict, no_bonus);
+    const Hyp* best = best_hyp(beams);
+    assert(best && best->terminal);
+    assert(best->tokens == std::vector<int>{1});  // EOU (2) not in the transcript
+    std::printf("  PASS: eou_terminates_and_is_not_emitted\n");
+}
+
+int main() {
+    std::printf("test_transducer_beam:\n");
+    test_blank_bias_under_emits_without_reward();
+    test_emit_reward_recovers_full_sequence();
+    test_reward_threshold_is_monotone();
+    test_bias_breaks_ties();
+    test_eou_terminates_and_is_not_emitted();
+    std::printf("All transducer beam tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Refactors the RNN-T beam search (added in #106) into a **generic, unit-tested algorithm**, and adds an optional **emit-reward** knob for the blank-bias / under-emission problem. No behavior change on the shipped Parakeet-EOU model.

## Motivation

The #106 beam was hand-rolled inside `OnnxNemotronStreamingStt` and untestable without the ONNX model. Live on-device testing raised a truncation concern; investigating it required being able to test the beam algorithm in isolation.

## What changed

- **`transducer_beam.h` (new).** `transducer::beam_decode_frames` — a generic, header-only modified RNN-T beam search parameterized on the predictor `State` and a biasing `Aux`, driven by `joint` / `predict` / `bonus` callables. Streaming callers keep the beam vector across windows.
- **`test_transducer_beam` (new, 5 cases).** A toy transducer that reproduces the blank bias with no ML runtime, proving: without the reward the beam emits nothing (the truncation failure mode), with the reward it recovers the full sequence; the reward is monotone; biasing breaks ties; EOU terminates a hypothesis without emitting the token.
- **`Config.beam_emit_bonus` (default 0).** The standard shallow-fusion blank penalty. Default 0 because it was **measured** that the published Parakeet-EOU export does not under-emit at beam width 4 — its beam output is byte-identical to greedy on real recordings — and a positive reward there causes over-emission/hallucination. The knob is there, tested, for a future model that does under-emit.
- **`OnnxNemotronStreamingStt::decode_beam`** now runs the generic algorithm; the hand-rolled loop is removed.

## Test plan

- `ctest` (default + ONNX): **20/20 pass**, including `test_transducer_beam` and `test_context_graph`.
- Beam vs greedy on real quiet-mic recordings: byte-identical at `emit_bonus=0` (confirms no behavior change on this model).

## Note

Finding worth recording: the on-device truncation seen during live testing was **not** the beam scoring (host beam == greedy, complete) — it tracked the replay-bench input cadence, not the decoder. This PR makes the beam testable and adds the reward knob for models that genuinely under-emit; it does not change the EOU model's output.
