### PR TITLE
Fix arm64 release package verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,14 @@ jobs:
       - name: Verify arm64 artefacts (cross — no execution possible)
         if: matrix.arch == 'arm64'
         run: |
-          # The .deb can't be installed on the x86_64 runner; assert the staged
-          # binaries are really aarch64 and carry the packaging RPATH.
-          for exe in build-pkg/examples/linux/speech_transcribe \
-                     build-pkg/examples/linux/speech_synthesize \
-                     build-pkg/examples/linux/speech_phonemize; do
+          # INSTALL_RPATH is applied while CPack installs into the package, so
+          # inspect the extracted .deb rather than the build-tree executables.
+          # The package can't be executed on the x86_64 release runner.
+          mkdir package-root
+          dpkg-deb -x dist/speech_*_arm64.deb package-root
+          for exe in package-root/usr/bin/speech_transcribe \
+                     package-root/usr/bin/speech_synthesize \
+                     package-root/usr/bin/speech_phonemize; do
             file "$exe" | tee /dev/stderr | grep -q "aarch64"
             readelf -d "$exe" | tee /dev/stderr | grep -E "RUNPATH|RPATH" | grep -q '\$ORIGIN/../lib'
           done


### PR DESCRIPTION
## Summary

- extract the generated arm64 Debian package before checking architecture and runtime search paths
- verify the installed executables, where CPack has applied `INSTALL_RPATH`, instead of build-tree binaries that intentionally retain build dependency paths

## Validation

- `actionlint -shellcheck '' .github/workflows/release.yml`
- ran the corrected verification block against `speech_0.0.9_arm64.deb` in an Ubuntu 22.04 amd64 container
- built the exact v0.0.9 arm64 package natively and clean-installed it on Ubuntu 22.04 and 24.04