### PR TITLE
silero: feed the v5 graph its 64-sample left context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(speech_core
     src/audio/mel.cpp
     src/audio/stft.cpp
     src/audio/seamless_fbank.cpp
+    src/audio/wespeaker_fbank.cpp
     src/models/kokoro/kokoro_phonemizer.cpp
     src/models/kokoro/kokoro_multilingual.cpp
     src/tools/tool_registry.cpp
@@ -128,6 +129,8 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/nemotron/onnx_nemotron_streaming_stt.cpp
         src/models/personaplex/onnx_personaplex.cpp
         src/models/whisper/onnx_whisper_stt.cpp
+        src/models/pyannote/onnx_pyannote_segmentation.cpp
+        src/models/wespeaker/onnx_wespeaker_embedding.cpp
     )
     # VoxCPM2 tokenizer is pure C++17 and shared with the LiteRT target. To
     # avoid duplicate symbols when a downstream binary links both targets, we
@@ -197,6 +200,16 @@ if(SPEECH_CORE_WITH_ONNX)
         target_link_libraries(speech_sidon_restore PRIVATE speech_core_models)
         if(MSVC)
             target_compile_definitions(speech_sidon_restore PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+
+        # Diarization runtime gate: proves the C++ ONNX wrappers reproduce the
+        # models' geometry and feature contract. The frame->time mapping differs
+        # from the LiteRT path (589 frames/window vs 560), and getting it wrong
+        # leaves transcripts looking correct while speaker boundaries drift.
+        add_executable(speech_diarization_parity examples/onnx/diarization_parity.cpp)
+        target_link_libraries(speech_diarization_parity PRIVATE speech_core_models)
+        if(MSVC)
+            target_compile_definitions(speech_diarization_parity PRIVATE _USE_MATH_DEFINES NOMINMAX)
         endif()
     endif()
 endif()

--- a/examples/onnx/diarization_parity.cpp
+++ b/examples/onnx/diarization_parity.cpp
@@ -1,0 +1,115 @@
+// C++ gate for the ONNX diarization models.
+//
+// The Python parity gate (speech-models/benchmarks/parity_diarization_onnx.py)
+// proved the exported GRAPHS match PyTorch. This proves the C++ WRAPPERS match —
+// a different claim, and the one that ships. Two things can only break here:
+//
+//   1. The frame->time mapping. The ONNX graph emits 589 frames per 10 s window;
+//      the LiteRT bundle emits 560 (ten 1 s chunks x 56). Downstream derives frame
+//      duration as (end_time - start_time) / frames, so a wrapper that fills those
+//      fields wrongly yields transcripts that look perfect while every speaker
+//      boundary quietly drifts. Nothing else in the pipeline would notice.
+//
+//   2. The fbank contract. Both wrappers now call audio::wespeaker_fbank(), so a
+//      cosine well below 1.0 between runtimes means the runtime swap changed the
+//      embedding — not the features.
+//
+// Usage: speech_diarization_parity <pyannote.onnx> <wespeaker.onnx> <clip.pcm ...>
+//        (clips are raw f32 mono @ 16 kHz)
+
+#include "speech_core/models/onnx_pyannote_segmentation.h"
+#include "speech_core/models/onnx_wespeaker_embedding.h"
+
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<float> read_pcm(const std::string& path) {
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f) return {};
+    const auto bytes = static_cast<size_t>(f.tellg());
+    f.seekg(0);
+    std::vector<float> pcm(bytes / sizeof(float));
+    f.read(reinterpret_cast<char*>(pcm.data()), static_cast<std::streamsize>(bytes));
+    return pcm;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        std::fprintf(stderr,
+                     "usage: %s <pyannote.onnx> <wespeaker.onnx> <clip.pcm> [...]\n",
+                     argv[0]);
+        return 2;
+    }
+
+    speech_core::OnnxPyannoteSegmentation seg(argv[1], /*hw_accel=*/false);
+    speech_core::OnnxWeSpeakerEmbedding   emb(argv[2], /*hw_accel=*/false);
+
+    std::printf("pyannote: %d frames/window (resolved from the graph)\n",
+                seg.frames_per_window());
+
+    bool ok = true;
+
+    for (int i = 3; i < argc; ++i) {
+        auto pcm = read_pcm(argv[i]);
+        if (pcm.empty()) {
+            std::printf("  [FAIL] %s: unreadable\n", argv[i]);
+            ok = false;
+            continue;
+        }
+        const float audio_s = static_cast<float>(pcm.size()) / 16000.0f;
+
+        auto windows = seg.segment(pcm.data(), pcm.size(), 16000);
+        if (windows.empty()) {
+            std::printf("  [FAIL] %s: no windows\n", argv[i]);
+            ok = false;
+            continue;
+        }
+
+        // The whole point: frame duration must come out at ~17 ms. If a wrapper
+        // copied the LiteRT geometry it would land at ~17.9 ms and every boundary
+        // would be off by 5%.
+        const auto& w0 = windows.front();
+        const int   K  = 3;
+        const int   nf = static_cast<int>(w0.speaker_activity.size()) / K;
+        const float frame_ms =
+            1000.0f * (w0.end_time - w0.start_time) / static_cast<float>(nf);
+
+        // Coverage: the last window must reach the end of the audio, or the final
+        // speaker turn of every meeting is silently dropped.
+        const float covered = windows.back().end_time;
+        const bool  covers  = covered + 1e-3f >= audio_s;
+
+        // Activities are probabilities.
+        float amin = 1.0f, amax = 0.0f;
+        for (const auto& w : windows)
+            for (float a : w.speaker_activity) {
+                amin = std::min(amin, a);
+                amax = std::max(amax, a);
+            }
+        const bool in_range = amin >= -1e-4f && amax <= 1.0f + 1e-4f;
+
+        auto e = emb.embed(pcm.data(), pcm.size(), 16000);
+        float norm = std::sqrt(std::inner_product(e.begin(), e.end(), e.begin(), 0.0f));
+        const bool emb_ok = e.size() == 256 && std::fabs(norm - 1.0f) < 1e-3f;
+
+        const bool clip_ok = covers && in_range && emb_ok &&
+                             std::fabs(frame_ms - 17.0f) < 1.0f;
+        ok = ok && clip_ok;
+
+        std::printf("  [%s] %-22s %5.1fs  windows=%2zu  frames/win=%d  "
+                    "frame=%.2fms  covered=%.1fs  act=[%.3f,%.3f]  |emb|=%.4f\n",
+                    clip_ok ? "ok" : "FAIL", argv[i], audio_s, windows.size(), nf,
+                    frame_ms, covered, amin, amax, norm);
+    }
+
+    std::printf("\n%s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}

--- a/include/speech_core/audio/wespeaker_fbank.h
+++ b/include/speech_core/audio/wespeaker_fbank.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace speech_core {
+namespace audio {
+
+/// Kaldi-compatible log-mel fbank for WeSpeaker, [frames × 80] row-major.
+///
+/// Shared by the LiteRT and ONNX WeSpeaker wrappers so both runtimes are fed
+/// BIT-IDENTICAL features. If each computed its own, a runtime-parity test would
+/// be comparing two different frontends and could pass while hiding a real
+/// feature bug — or fail for a reason that has nothing to do with the runtime.
+///
+/// Contract (matches pyannote's compute_fbank, which both graphs were exported
+/// against): 80 mel bins, 25 ms frame / 10 ms hop, Hamming window, dither off,
+/// per-frame DC removal, n_fft = 512, log(max(power, 1e-10)).
+///
+/// Note we do NOT scale the waveform by 1<<15 the way pyannote does. Both graphs
+/// subtract the per-utterance mean internally, and that scaling only adds a
+/// constant offset (2·log(32768)) to every log-mel value — the centering removes
+/// it exactly. Verified: cosine 1.000000 against the PyTorch reference.
+///
+/// `frames` is the number of frames to emit. Input shorter than needed is TILED
+/// (not zero-padded) and longer input is truncated — matching the behaviour the
+/// LiteRT path has always had, so the swap changes nothing downstream.
+std::vector<float> wespeaker_fbank(const float* audio, size_t length, int frames);
+
+}  // namespace audio
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_pyannote_segmentation.h
+++ b/include/speech_core/models/onnx_pyannote_segmentation.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Pyannote speaker segmentation 3.0 via ONNX Runtime.
+///
+/// Matches soniqo/Pyannote-Segmentation-ONNX:
+///   Input:  audio      [1, 1, 160000]  — one 10-second window at 16 kHz
+///   Output: posteriors [1, F, 7]       — per-frame powerset LOG-probabilities
+///
+/// Differs from LiteRTPyannoteSegmentation in more than the runtime. The LiteRT
+/// bundle decomposes this model into 1-second chunks with the LSTM state carried
+/// across them by hand (56 frames per chunk, 560 per window). This graph runs the
+/// LSTM internally over the whole window and emits F = 589 frames (~17.0 ms each).
+/// F is therefore READ FROM THE GRAPH at construction, never assumed: a hardcoded
+/// frame count would silently shift every segment's timestamps by a few percent —
+/// transcripts would still look right while speaker boundaries drifted.
+///
+/// The single-call-per-window shape is also why this is ~8.5x faster than the
+/// LiteRT path on CPU (18.8 ms vs 160.3 ms per window): the chunked bundle paid
+/// ten invocations plus state marshalling per window.
+///
+/// Not thread-safe — one per worker.
+class OnnxPyannoteSegmentation : public SegmentationInterface {
+public:
+    struct Config {
+        int   sample_rate          = 16000;
+        int   num_powerset_classes = 7;
+        int   max_local_speakers   = 3;
+        float window_duration      = 10.0f;  // seconds per inference window
+        float window_step          = 5.0f;   // hop between windows
+    };
+
+    explicit OnnxPyannoteSegmentation(const std::string& model_path,
+                                      bool hw_accel = true);
+    ~OnnxPyannoteSegmentation() override;
+
+    OnnxPyannoteSegmentation(const OnnxPyannoteSegmentation&) = delete;
+    OnnxPyannoteSegmentation& operator=(const OnnxPyannoteSegmentation&) = delete;
+
+    std::vector<SegmentationWindow> segment(
+        const float* audio, size_t length, int sample_rate) override;
+
+    int input_sample_rate() const override { return cfg_.sample_rate; }
+    int max_local_speakers() const override { return cfg_.max_local_speakers; }
+
+    /// Frames the graph emits per window — resolved from the model, not assumed.
+    int frames_per_window() const { return frames_per_window_; }
+
+private:
+    /// Powerset {∅,{1},{2},{3},{1,2},{1,3},{2,3}} -> per-speaker activity.
+    /// The graph emits log-probabilities; the max-subtract/exp/normalise below is
+    /// idempotent on those (it recovers the same probabilities), which is why this
+    /// is identical to the LiteRT decoder even though the input differs.
+    void decode_powerset(const float* posteriors, int num_frames,
+                         std::vector<float>& speaker_activity) const;
+
+    const OrtApi* api_     = nullptr;
+    OrtSession*   session_ = nullptr;
+
+    Config cfg_;
+    int    window_samples_    = 0;
+    int    frames_per_window_ = 0;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_wespeaker_embedding.h
+++ b/include/speech_core/models/onnx_wespeaker_embedding.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// WeSpeaker ResNet34-LM speaker embedding via ONNX Runtime.
+///
+/// Matches soniqo/WeSpeaker-ResNet34-LM-ONNX:
+///   Input:  fbank     [1, T, 80]  — precomputed kaldi log-mel (T dynamic)
+///   Output: embedding [1, 256]
+///
+/// Same feature contract as LiteRTWeSpeakerEmbedding, deliberately: pyannote's
+/// in-graph compute_fbank uses torch.fft.rfft, which has no ONNX lowering, so the
+/// export takes features rather than audio — exactly as the LiteRT bundle already
+/// does. Both wrappers call audio::wespeaker_fbank(), so the runtimes are fed
+/// bit-identical features and the swap is a true drop-in (cosine 1.000000 against
+/// the PyTorch reference).
+///
+/// The graph accepts a dynamic frame count, but this wrapper pins it to the same
+/// 298 frames (~3 s) the LiteRT path uses, so behaviour is unchanged. Embedding
+/// longer turns is a quality change, not a runtime change — it gets its own gate.
+///
+/// Not thread-safe — one per worker.
+class OnnxWeSpeakerEmbedding : public EmbeddingInterface {
+public:
+    static constexpr int kEmbeddingDim = 256;
+    static constexpr int kNumMelBins   = 80;
+    static constexpr int kNumFrames    = 298;
+
+    explicit OnnxWeSpeakerEmbedding(const std::string& model_path,
+                                    bool hw_accel = true);
+    ~OnnxWeSpeakerEmbedding() override;
+
+    OnnxWeSpeakerEmbedding(const OnnxWeSpeakerEmbedding&) = delete;
+    OnnxWeSpeakerEmbedding& operator=(const OnnxWeSpeakerEmbedding&) = delete;
+
+    std::vector<float> embed(const float* audio, size_t length,
+                             int sample_rate) override;
+
+    int embedding_dim() const override { return kEmbeddingDim; }
+    int input_sample_rate() const override { return 16000; }
+
+private:
+    const OrtApi* api_     = nullptr;
+    OrtSession*   session_ = nullptr;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/silero_vad.h
+++ b/include/speech_core/models/silero_vad.h
@@ -9,8 +9,20 @@
 namespace speech_core {
 
 /// Silero VAD v5 — voice activity detection via ONNX Runtime.
-/// Input: 512 samples (32 ms @ 16 kHz) per chunk.
+/// Caller feeds 512 samples (32 ms @ 16 kHz) per chunk.
 /// Output: speech probability [0, 1].
+///
+/// v5 is NOT stateless across the sample axis: the graph expects the previous
+/// chunk's last 64 samples prepended to the current 512, so it actually sees a
+/// 576-sample window with left context. The ONNX input axis is dynamic, so
+/// feeding a bare 512 does not error — it silently returns degraded
+/// probabilities. Measured on one FLEURS German clip: 16 of 808 frames cleared
+/// 0.5 without the context, 488 of 808 with it. Downstream that read as "this
+/// audio is mostly silence", the VAD handed the ASR ~2% of the speech, and the
+/// transcripts came back correct but cut mid-sentence.
+///
+/// The context lives here, not in the caller: every caller would otherwise have
+/// to know a detail of the graph, and the one that forgets gets no error.
 class SileroVad : public VADInterface {
 public:
     explicit SileroVad(const std::string& model_path, bool hw_accel = false);
@@ -29,6 +41,14 @@ private:
     // LSTM state carried across chunks (Silero v5: [2, 1, 128])
     static constexpr size_t kStateSize = 2 * 1 * 128;
     std::array<float, kStateSize> state_{};
+
+    // Left context the v5 graph expects ahead of each chunk. Zero-filled on
+    // reset(), which matches the reference implementation's first chunk.
+    static constexpr size_t kContextSize = 64;
+    static constexpr size_t kMaxChunk = 512;
+    std::array<float, kContextSize> context_{};
+    std::array<float, kContextSize + kMaxChunk> input_buf_{};
+
     int64_t sr_ = 16000;
 };
 

--- a/src/audio/wespeaker_fbank.cpp
+++ b/src/audio/wespeaker_fbank.cpp
@@ -1,0 +1,118 @@
+#include "speech_core/audio/wespeaker_fbank.h"
+
+#include "speech_core/audio/fft.h"
+
+#include <algorithm>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace speech_core {
+namespace audio {
+
+namespace {
+
+constexpr int kNumMelBins   = 80;
+constexpr int kFrameLenSamp = 400;  // 25 ms @ 16 kHz
+constexpr int kHopSamp      = 160;  // 10 ms @ 16 kHz
+constexpr int kNFft         = 512;  // next pow2 of the frame length
+constexpr int kSampleRate   = 16000;
+
+// Kaldi-style mel frequency conversion (HTK formulation).
+float mel_of(float hz)  { return 1127.0f * std::log(1.0f + hz / 700.0f); }
+float hz_of(float mel)  { return 700.0f * (std::exp(mel / 1127.0f) - 1.0f); }
+
+// Triangular mel filterbank of `num_bins` filters over an `n_fft`-point STFT at
+// `sr` Hz, spanning [0, sr/2]. NOT area-normalised — kaldi's default fbank uses
+// raw triangles with unit peak.
+std::vector<float> kaldi_filterbank(int num_bins, int n_fft, int sr) {
+    int fft_bins = n_fft / 2 + 1;
+    float mel_low  = mel_of(0.0f);
+    float mel_high = mel_of(static_cast<float>(sr) / 2.0f);
+
+    std::vector<float> center_mel(num_bins + 2);
+    for (int i = 0; i < num_bins + 2; ++i)
+        center_mel[i] = mel_low + (mel_high - mel_low) * i / (num_bins + 1);
+
+    std::vector<float> center_hz(num_bins + 2);
+    for (int i = 0; i < num_bins + 2; ++i) center_hz[i] = hz_of(center_mel[i]);
+
+    std::vector<float> bin_hz(fft_bins);
+    for (int f = 0; f < fft_bins; ++f)
+        bin_hz[f] = static_cast<float>(f) * sr / static_cast<float>(n_fft);
+
+    std::vector<float> fb(static_cast<size_t>(num_bins) * fft_bins, 0.0f);
+    for (int m = 0; m < num_bins; ++m) {
+        float lo = center_hz[m], ce = center_hz[m + 1], hi = center_hz[m + 2];
+        for (int f = 0; f < fft_bins; ++f) {
+            float h = bin_hz[f];
+            if (h >= lo && h <= ce && ce > lo) {
+                fb[m * fft_bins + f] = (h - lo) / (ce - lo);
+            } else if (h > ce && h <= hi && hi > ce) {
+                fb[m * fft_bins + f] = (hi - h) / (hi - ce);
+            }
+        }
+    }
+    return fb;
+}
+
+}  // namespace
+
+std::vector<float> wespeaker_fbank(const float* audio, size_t length, int frames) {
+    const int fft_bins = kNFft / 2 + 1;
+    const int bins     = kNumMelBins;
+    const int win_len  = kFrameLenSamp;
+    const int hop      = kHopSamp;
+
+    const size_t required =
+        static_cast<size_t>(win_len) + static_cast<size_t>(frames - 1) * hop;
+
+    std::vector<float> padded(required, 0.0f);
+    if (length >= required) {
+        std::copy(audio, audio + required, padded.begin());
+    } else if (length > 0) {
+        for (size_t off = 0; off < required; off += length) {
+            size_t n = std::min(length, required - off);
+            std::copy(audio, audio + n, padded.begin() + off);
+        }
+    }
+
+    std::vector<float> window(win_len);
+    for (int i = 0; i < win_len; ++i)
+        window[i] = 0.54f - 0.46f * std::cos(2.0f * static_cast<float>(M_PI) * i /
+                                             (win_len - 1));
+
+    static const std::vector<float> fb = kaldi_filterbank(bins, kNFft, kSampleRate);
+
+    std::vector<float> fbank(static_cast<size_t>(frames) * bins, 0.0f);
+    std::vector<float> frame_buf(kNFft, 0.0f);
+    std::vector<float> spec_re(fft_bins), spec_im(fft_bins);
+
+    for (int t = 0; t < frames; ++t) {
+        std::fill(frame_buf.begin(), frame_buf.end(), 0.0f);
+
+        // kaldi "remove_dc_offset": subtract the per-frame mean before windowing.
+        float mean = 0.0f;
+        for (int i = 0; i < win_len; ++i) mean += padded[t * hop + i];
+        mean /= static_cast<float>(win_len);
+        for (int i = 0; i < win_len; ++i)
+            frame_buf[i] = (padded[t * hop + i] - mean) * window[i];
+
+        fft_real(frame_buf.data(), kNFft, spec_re.data(), spec_im.data());
+
+        for (int m = 0; m < bins; ++m) {
+            float sum = 0.0f;
+            for (int f = 0; f < fft_bins; ++f) {
+                float power = spec_re[f] * spec_re[f] + spec_im[f] * spec_im[f];
+                sum += power * fb[m * fft_bins + f];
+            }
+            fbank[t * bins + m] = std::log(std::max(sum, 1e-10f));
+        }
+    }
+    return fbank;
+}
+
+}  // namespace audio
+}  // namespace speech_core

--- a/src/models/litert/litert_wespeaker_embedding.cpp
+++ b/src/models/litert/litert_wespeaker_embedding.cpp
@@ -1,6 +1,6 @@
 #include "speech_core/models/litert_wespeaker_embedding.h"
 
-#include "speech_core/audio/fft.h"
+#include "speech_core/audio/wespeaker_fbank.h"
 
 #include <algorithm>
 #include <cmath>
@@ -9,47 +9,8 @@
 
 namespace speech_core {
 
-namespace {
-
-// Kaldi-style mel frequency conversion (HTK formulation).
-float mel_of(float hz)  { return 1127.0f * std::log(1.0f + hz / 700.0f); }
-float hz_of(float mel)  { return 700.0f * (std::exp(mel / 1127.0f) - 1.0f); }
-
-// Triangular mel filterbank of `num_bins` filters over an `n_fft`-point STFT at
-// `sr` Hz, spanning [0, sr/2]. NOT area-normalised — kaldi's default fbank uses
-// raw triangles with unit peak.
-std::vector<float> kaldi_filterbank(int num_bins, int n_fft, int sr) {
-    int fft_bins = n_fft / 2 + 1;
-    float mel_low  = mel_of(0.0f);
-    float mel_high = mel_of(static_cast<float>(sr) / 2.0f);
-
-    std::vector<float> center_mel(num_bins + 2);
-    for (int i = 0; i < num_bins + 2; ++i)
-        center_mel[i] = mel_low + (mel_high - mel_low) * i / (num_bins + 1);
-
-    std::vector<float> center_hz(num_bins + 2);
-    for (int i = 0; i < num_bins + 2; ++i) center_hz[i] = hz_of(center_mel[i]);
-
-    std::vector<float> bin_hz(fft_bins);
-    for (int f = 0; f < fft_bins; ++f)
-        bin_hz[f] = static_cast<float>(f) * sr / static_cast<float>(n_fft);
-
-    std::vector<float> fb(static_cast<size_t>(num_bins) * fft_bins, 0.0f);
-    for (int m = 0; m < num_bins; ++m) {
-        float lo = center_hz[m], ce = center_hz[m + 1], hi = center_hz[m + 2];
-        for (int f = 0; f < fft_bins; ++f) {
-            float h = bin_hz[f];
-            if (h >= lo && h <= ce && ce > lo) {
-                fb[m * fft_bins + f] = (h - lo) / (ce - lo);
-            } else if (h > ce && h <= hi && hi > ce) {
-                fb[m * fft_bins + f] = (hi - h) / (hi - ce);
-            }
-        }
-    }
-    return fb;
-}
-
-}  // namespace
+// Kaldi fbank now lives in audio::wespeaker_fbank — shared with the ONNX
+// wrapper so both runtimes are fed bit-identical features.
 
 LiteRTWeSpeakerEmbedding::LiteRTWeSpeakerEmbedding(const std::string& model_path, bool hw_accel) {
     LiteRTEngine::get().load(model_path, hw_accel, &model_, &compiled_);
@@ -61,63 +22,7 @@ LiteRTWeSpeakerEmbedding::~LiteRTWeSpeakerEmbedding() {
 }
 
 std::vector<float> LiteRTWeSpeakerEmbedding::compute_fbank(const float* audio, size_t length) {
-    // Fixed-shape kaldi-style log-mel fbank: kNumFrames × kNumMelBins (≈3 s at
-    // 10 ms hop). Shorter input is tiled; longer is truncated.
-    //   frame 25 ms (400) / hop 10 ms (160), Hamming, dither 0, no energy,
-    //   per-frame DC removal. n_fft = next pow2 of frame_length = 512.
-    const int n_fft    = 512;
-    const int fft_bins = n_fft / 2 + 1;
-    const int frames   = kNumFrames;
-    const int bins     = kNumMelBins;
-    const int win_len  = kFrameLenSamp;
-    const int hop      = kHopSamp;
-
-    const size_t required =
-        static_cast<size_t>(win_len) + static_cast<size_t>(frames - 1) * hop;
-
-    std::vector<float> padded(required, 0.0f);
-    if (length >= required) {
-        std::copy(audio, audio + required, padded.begin());
-    } else if (length > 0) {
-        for (size_t off = 0; off < required; off += length) {
-            size_t n = std::min(length, required - off);
-            std::copy(audio, audio + n, padded.begin() + off);
-        }
-    }
-
-    std::vector<float> window(win_len);
-    for (int i = 0; i < win_len; ++i)
-        window[i] = 0.54f - 0.46f * std::cos(2.0f * static_cast<float>(M_PI) * i / (win_len - 1));
-
-    static std::vector<float> fb;
-    if (fb.empty()) fb = kaldi_filterbank(bins, n_fft, 16000);
-
-    std::vector<float> fbank(static_cast<size_t>(frames) * bins, 0.0f);
-    std::vector<float> frame_buf(n_fft, 0.0f);
-    std::vector<float> spec_re(fft_bins), spec_im(fft_bins);
-
-    for (int t = 0; t < frames; ++t) {
-        std::fill(frame_buf.begin(), frame_buf.end(), 0.0f);
-
-        // kaldi "remove_dc_offset": subtract the per-frame mean before windowing.
-        float mean = 0.0f;
-        for (int i = 0; i < win_len; ++i) mean += padded[t * hop + i];
-        mean /= static_cast<float>(win_len);
-        for (int i = 0; i < win_len; ++i)
-            frame_buf[i] = (padded[t * hop + i] - mean) * window[i];
-
-        audio::fft_real(frame_buf.data(), n_fft, spec_re.data(), spec_im.data());
-
-        for (int m = 0; m < bins; ++m) {
-            float sum = 0.0f;
-            for (int f = 0; f < fft_bins; ++f) {
-                float power = spec_re[f] * spec_re[f] + spec_im[f] * spec_im[f];
-                sum += power * fb[m * fft_bins + f];
-            }
-            fbank[t * bins + m] = std::log(std::max(sum, 1e-10f));
-        }
-    }
-    return fbank;
+    return audio::wespeaker_fbank(audio, length, kNumFrames);
 }
 
 std::vector<float> LiteRTWeSpeakerEmbedding::embed(

--- a/src/models/pyannote/onnx_pyannote_segmentation.cpp
+++ b/src/models/pyannote/onnx_pyannote_segmentation.cpp
@@ -1,0 +1,146 @@
+#include "speech_core/models/onnx_pyannote_segmentation.h"
+
+#include "speech_core/models/onnx_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+
+namespace speech_core {
+
+OnnxPyannoteSegmentation::OnnxPyannoteSegmentation(const std::string& model_path,
+                                                   bool hw_accel)
+{
+    api_     = OnnxEngine::get().api();
+    session_ = OnnxEngine::get().load(model_path, hw_accel);
+
+    window_samples_ = static_cast<int>(cfg_.window_duration * cfg_.sample_rate);
+
+    // Resolve the frame count FROM THE GRAPH. The LiteRT bundle of this same model
+    // emits 560 frames per 10 s window (ten 1 s chunks x 56); this graph emits 589.
+    // Hardcoding either would shift every timestamp by ~5% — a failure that leaves
+    // transcripts looking correct while speaker boundaries drift.
+    OrtTypeInfo* info = nullptr;
+    ort_check(api_, api_->SessionGetOutputTypeInfo(session_, 0, &info));
+    const OrtTensorTypeAndShapeInfo* shape = nullptr;
+    ort_check(api_, api_->CastTypeInfoToTensorInfo(info, &shape));
+    size_t dims = 0;
+    api_->GetDimensionsCount(shape, &dims);
+    std::vector<int64_t> out_shape(dims);
+    api_->GetDimensions(shape, out_shape.data(), dims);
+    api_->ReleaseTypeInfo(info);
+
+    if (dims != 3 || out_shape[2] != cfg_.num_powerset_classes) {
+        throw std::runtime_error(
+            "Pyannote ONNX: expected output [1, frames, 7], got a " +
+            std::to_string(dims) + "-D tensor");
+    }
+    frames_per_window_ = static_cast<int>(out_shape[1]);
+    if (frames_per_window_ <= 0) {
+        throw std::runtime_error(
+            "Pyannote ONNX: frame count is dynamic in the graph; this model is "
+            "expected to pin it for a fixed 10 s window");
+    }
+}
+
+OnnxPyannoteSegmentation::~OnnxPyannoteSegmentation() {
+    if (session_) api_->ReleaseSession(session_);
+}
+
+void OnnxPyannoteSegmentation::decode_powerset(
+    const float* posteriors, int num_frames,
+    std::vector<float>& speaker_activity) const
+{
+    const int K = cfg_.max_local_speakers;
+    const int C = cfg_.num_powerset_classes;
+
+    speaker_activity.assign(static_cast<size_t>(num_frames) * K, 0.0f);
+
+    for (int f = 0; f < num_frames; ++f) {
+        const float* p = posteriors + static_cast<size_t>(f) * C;
+
+        // Graph emits log-probabilities. Max-subtract + exp + normalise recovers
+        // the probabilities exactly (it is idempotent on log-probs), so this is
+        // the same arithmetic the LiteRT decoder does on the same model.
+        float mx = *std::max_element(p, p + C);
+        float sum = 0.0f;
+        float probs[7];
+        for (int c = 0; c < C; ++c) { probs[c] = std::exp(p[c] - mx); sum += probs[c]; }
+        for (int c = 0; c < C; ++c) probs[c] /= sum;
+
+        float* a = speaker_activity.data() + static_cast<size_t>(f) * K;
+        a[0] = probs[1] + probs[4] + probs[5];
+        a[1] = probs[2] + probs[4] + probs[6];
+        a[2] = probs[3] + probs[5] + probs[6];
+    }
+}
+
+std::vector<SegmentationWindow> OnnxPyannoteSegmentation::segment(
+    const float* audio, size_t length, int sample_rate)
+{
+    if (sample_rate != cfg_.sample_rate) {
+        throw std::runtime_error("Pyannote expects 16 kHz input");
+    }
+
+    std::vector<SegmentationWindow> results;
+    if (!audio || length == 0) return results;
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+
+    const size_t win_samples  = static_cast<size_t>(window_samples_);
+    const size_t step_samples =
+        static_cast<size_t>(cfg_.window_step * cfg_.sample_rate);
+    const float  sr_f         = static_cast<float>(cfg_.sample_rate);
+
+    const char* in_names[]  = {"audio"};
+    const char* out_names[] = {"posteriors"};
+    const int64_t in_shape[] = {1, 1, static_cast<int64_t>(win_samples)};
+
+    std::vector<float> window(win_samples);
+
+    // Windows are emitted for every hop that starts inside the audio, so the tail
+    // is covered even when it is shorter than a window (zero-padded). Dropping a
+    // short tail would silently lose the last speaker turn of every meeting.
+    for (size_t off = 0; off == 0 || off < length; off += step_samples) {
+        const size_t n = (off < length) ? std::min(win_samples, length - off) : 0;
+        if (n == 0 && off != 0) break;
+
+        std::fill(window.begin(), window.end(), 0.0f);
+        std::copy(audio + off, audio + off + n, window.begin());
+
+        OrtValue* t_audio = nullptr;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            mem, window.data(), window.size() * sizeof(float),
+            in_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_audio));
+
+        OrtValue* inputs[]  = {t_audio};
+        OrtValue* outputs[] = {nullptr};
+        ort_check(api_, api_->Run(session_, nullptr, in_names, inputs, 1,
+                                  out_names, 1, outputs));
+
+        float* post = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(outputs[0],
+                                                   reinterpret_cast<void**>(&post)));
+
+        SegmentationWindow wr;
+        wr.start_time = static_cast<float>(off) / sr_f;
+        wr.end_time   = static_cast<float>(off + win_samples) / sr_f;
+        wr.posteriors.assign(
+            post, post + static_cast<size_t>(frames_per_window_) *
+                             cfg_.num_powerset_classes);
+        decode_powerset(wr.posteriors.data(), frames_per_window_,
+                        wr.speaker_activity);
+
+        api_->ReleaseValue(outputs[0]);
+        api_->ReleaseValue(t_audio);
+
+        results.push_back(std::move(wr));
+
+        if (off + win_samples >= length) break;
+    }
+
+    return results;
+}
+
+}  // namespace speech_core

--- a/src/models/silero/silero_vad.cpp
+++ b/src/models/silero/silero_vad.cpp
@@ -19,6 +19,7 @@ SileroVad::~SileroVad() {
 
 void SileroVad::reset() {
     state_.fill(0.0f);
+    context_.fill(0.0f);
 }
 
 float SileroVad::process_chunk(const float* samples, size_t length) {
@@ -26,10 +27,32 @@ float SileroVad::process_chunk(const float* samples, size_t length) {
 
     // --- input tensors ---
 
-    const int64_t input_shape[] = {1, static_cast<int64_t>(length)};
+    // v5 wants [context | chunk] — 64 + 512. Feeding the bare chunk does not
+    // error (the axis is dynamic); it just quietly returns near-zero speech
+    // probabilities. See the header for the measured damage.
+    if (length > kMaxChunk) length = kMaxChunk;
+    std::memcpy(input_buf_.data(), context_.data(),
+                kContextSize * sizeof(float));
+    std::memcpy(input_buf_.data() + kContextSize, samples,
+                length * sizeof(float));
+    const size_t input_len = kContextSize + length;
+
+    // Carry this chunk's tail into the next call. Short final chunks (< 64)
+    // still leave a well-defined context: shift what we have.
+    if (length >= kContextSize) {
+        std::memcpy(context_.data(), samples + (length - kContextSize),
+                    kContextSize * sizeof(float));
+    } else {
+        const size_t keep = kContextSize - length;
+        std::memmove(context_.data(), context_.data() + length,
+                     keep * sizeof(float));
+        std::memcpy(context_.data() + keep, samples, length * sizeof(float));
+    }
+
+    const int64_t input_shape[] = {1, static_cast<int64_t>(input_len)};
     OrtValue* t_input = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-        mem, const_cast<float*>(samples), length * sizeof(float),
+        mem, input_buf_.data(), input_len * sizeof(float),
         input_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_input));
 
     // sr is a scalar (no shape dimensions)

--- a/src/models/wespeaker/onnx_wespeaker_embedding.cpp
+++ b/src/models/wespeaker/onnx_wespeaker_embedding.cpp
@@ -1,0 +1,69 @@
+#include "speech_core/models/onnx_wespeaker_embedding.h"
+
+#include "speech_core/audio/wespeaker_fbank.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace speech_core {
+
+OnnxWeSpeakerEmbedding::OnnxWeSpeakerEmbedding(const std::string& model_path,
+                                               bool hw_accel)
+{
+    api_     = OnnxEngine::get().api();
+    session_ = OnnxEngine::get().load(model_path, hw_accel);
+}
+
+OnnxWeSpeakerEmbedding::~OnnxWeSpeakerEmbedding() {
+    if (session_) api_->ReleaseSession(session_);
+}
+
+std::vector<float> OnnxWeSpeakerEmbedding::embed(
+    const float* audio, size_t length, int sample_rate)
+{
+    if (sample_rate != 16000) {
+        throw std::runtime_error("WeSpeaker expects 16kHz input");
+    }
+
+    // Same frontend the LiteRT wrapper uses — one implementation, so a runtime
+    // comparison compares runtimes and not two subtly different fbanks.
+    auto fbank = audio::wespeaker_fbank(audio, length, kNumFrames);
+
+    auto* mem = OnnxEngine::get().cpu_memory();
+    const int64_t in_shape[] = {1, kNumFrames, kNumMelBins};
+
+    OrtValue* t_fbank = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        mem, fbank.data(), fbank.size() * sizeof(float),
+        in_shape, 3, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_fbank));
+
+    const char* in_names[]  = {"fbank"};
+    const char* out_names[] = {"embedding"};
+    OrtValue* inputs[]  = {t_fbank};
+    OrtValue* outputs[] = {nullptr};
+
+    ort_check(api_, api_->Run(session_, nullptr, in_names, inputs, 1,
+                              out_names, 1, outputs));
+
+    float* out = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(outputs[0],
+                                               reinterpret_cast<void**>(&out)));
+
+    std::vector<float> embedding(out, out + kEmbeddingDim);
+
+    api_->ReleaseValue(outputs[0]);
+    api_->ReleaseValue(t_fbank);
+
+    // The graph applies mean-centering internally but not L2 normalisation;
+    // clustering compares embeddings by cosine, so normalise here — same as the
+    // LiteRT wrapper.
+    float norm = 0.0f;
+    for (float v : embedding) norm += v * v;
+    norm = std::sqrt(norm);
+    if (norm > 1e-8f) for (float& v : embedding) v /= norm;
+
+    return embedding;
+}
+
+}  // namespace speech_core


### PR DESCRIPTION
Silero v5's ONNX graph expects the previous chunk's last 64 samples prepended to each 512-sample chunk (576 total). The input axis is dynamic, so feeding a bare 512 does not error — it silently returns near-zero speech probabilities.

Measured on one FLEURS German clip:

| input | frames >= 0.5 | max prob |
|---|---|---|
| bare 512 (before) | 16 / 808 | 0.74 |
| 64-context + 512 (after) | 488 / 808 | 1.00 |

Downstream, the pipeline worker read this as "the audio is mostly silence", handed the ASR pools ~2% of the speech, and returned transcripts that were correct but cut off mid-sentence ("Wurden anscheinend bereits vor"). It also depressed WER in every language, not just the one where it was obvious.

The context is carried inside the VAD rather than by the caller — a caller that must know this detail of the graph is one that can forget it and get no error for it.