### PR TITLE
feat: add streaming Pocket TTS ONNX backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/parakeet/parakeet_stt.cpp
         src/models/nemotron/nemotron_multilingual_stt.cpp
         src/models/kokoro/kokoro_tts.cpp
+        src/models/pocket/onnx_pocket_tts.cpp
+        src/models/pocket/pocket_tts_tokenizer.cpp
         src/models/deepfilter/deepfilter.cpp
         src/models/sidon/onnx_sidon_restorer.cpp
         src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
@@ -149,6 +151,7 @@ if(SPEECH_CORE_WITH_ONNX)
             $<INSTALL_INTERFACE:include>
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party
     )
 
     if(MSVC)
@@ -165,6 +168,26 @@ if(SPEECH_CORE_WITH_ONNX)
     set_target_properties(speech_core_models PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
     target_link_libraries(speech_core_models PUBLIC speech_core onnxruntime)
+
+    # Device-friendly Pocket TTS benchmark. Unlike the other ONNX CLIs this
+    # target is also built for Android so it can be pushed and run through adb.
+    add_executable(speech_pocket_tts_bench EXCLUDE_FROM_ALL
+        examples/onnx/pocket_tts_bench.cpp)
+    target_link_libraries(speech_pocket_tts_bench PRIVATE speech_core_models)
+
+    # Device-native intelligibility gate: Pocket TTS -> 24/16 kHz resample ->
+    # the deployed streaming Parakeet/Nemotron STT graphs, with WER/CER output.
+    add_executable(speech_pocket_tts_roundtrip EXCLUDE_FROM_ALL
+        examples/onnx/pocket_tts_roundtrip.cpp)
+    target_link_libraries(speech_pocket_tts_roundtrip PRIVATE speech_core_models)
+    if(ANDROID)
+        target_link_libraries(speech_pocket_tts_bench PRIVATE log)
+        target_link_libraries(speech_pocket_tts_roundtrip PRIVATE log)
+    endif()
+    if(MSVC)
+        target_compile_definitions(speech_pocket_tts_bench PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        target_compile_definitions(speech_pocket_tts_roundtrip PRIVATE NOMINMAX)
+    endif()
 
     # VoxCPM2 ONNX voice-cloning CLI — the in-repo runner for the ONNX path:
     # the full 4-graph AR loop through OnnxVoxCPM2Tts, on CPU or CUDA/TensorRT
@@ -577,6 +600,8 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_indic_mio_istft"
            OR TEST_NAME STREQUAL "test_indic_mio_tokenizer"
            OR TEST_NAME STREQUAL "test_litert_indic_mio"
+           OR TEST_NAME STREQUAL "test_pocket_tts"
+           OR TEST_NAME STREQUAL "test_pocket_tts_tokenizer"
            OR TEST_NAME STREQUAL "test_litert_functiongemma_llm"
            OR TEST_NAME STREQUAL "test_ollama_llm"
            OR TEST_NAME STREQUAL "test_pipeline_ollama_e2e"
@@ -637,7 +662,25 @@ if(SPEECH_CORE_BUILD_TESTS)
             endif()
             target_compile_definitions(bench_ort_models PRIVATE
                 SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+            if(MSVC)
+                target_compile_definitions(bench_ort_models PRIVATE NOMINMAX)
+            endif()
         endif()
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pocket_tts_tokenizer.cpp)
+        add_executable(test_pocket_tts_tokenizer
+            tests/test_pocket_tts_tokenizer.cpp)
+        target_link_libraries(test_pocket_tts_tokenizer PRIVATE speech_core_models)
+        add_test(NAME test_pocket_tts_tokenizer COMMAND test_pocket_tts_tokenizer)
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pocket_tts.cpp)
+        add_executable(test_pocket_tts tests/test_pocket_tts.cpp)
+        target_link_libraries(test_pocket_tts PRIVATE speech_core_models)
+        add_test(NAME test_pocket_tts COMMAND test_pocket_tts)
     endif()
 
     # LiteRT model integration tests — require SPEECH_CORE_WITH_LITERT=ON.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -47,6 +47,16 @@ for the complete texts.
 
 ## Vendored source (source tree)
 
+### sherpa-onnx SentencePiece tokenizer algorithm
+
+- **Files:** `src/models/pocket/pocket_tts_tokenizer.cpp`
+- **Source:** adapted from `sherpa-onnx/csrc/sentence-piece-tokenizer.cc`
+  in https://github.com/k2-fsa/sherpa-onnx
+- **License:** Apache License 2.0
+- Copyright 2026 Xiaomi Corporation.
+- **Used by:** the Pocket TTS ONNX backend. No sherpa-onnx runtime code or
+  library is linked into speech-core.
+
 ### Ooura FFT
 
 - **Files:** `third_party/fftooura/`
@@ -64,3 +74,8 @@ are downloaded separately by the user at runtime (see
 `scripts/download_models.sh`, `scripts/download_models_litert.sh`, and
 `docs/models.md`) and are governed by their own licenses as published on
 their respective HuggingFace repositories.
+
+The optional Pocket TTS bundle is published separately at
+https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8 under CC BY 4.0. Its
+fixed voice was performed by Alba MacKenna; retain that attribution when the
+bundle is redistributed or used in product notices.

--- a/docs/models.md
+++ b/docs/models.md
@@ -10,6 +10,7 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 | `ParakeetStt` | `STTInterface` | `speech_core/models/parakeet_stt.h` | full |
 | `OnnxWhisperStt` | `STTInterface` | `speech_core/models/onnx_whisper_stt.h` | full |
 | `KokoroTts` | `TTSInterface` | `speech_core/models/kokoro_tts.h` | full |
+| `OnnxPocketTts` | `TTSInterface` | `speech_core/models/onnx_pocket_tts.h` | full (80 ms frame streaming, fixed Alba voice) |
 | `DeepFilterEnhancer` | `EnhancerInterface` | `speech_core/models/deepfilter.h` | full |
 | `OnnxSidonRestorer` | (own API; `EnhancerInterface` adapter) | `speech_core/models/onnx_sidon_restorer.h` | full — see [OnnxSidonRestorer](#onnxsidonrestorer) |
 | `OnnxCosyVoice3Tts` | `TTSInterface` | `speech_core/models/onnx_cosyvoice3_tts.h` | staged — ONNX runtime + cached conditioning |
@@ -315,6 +316,83 @@ tts.synthesize("Hello world.", "en",
 - The physical-device GPU audit was rejected; this wrapper is CPU/XNNPACK-only.
 - Use the staged bundle when `.tflite` format compatibility is required; the ONNX backend has separate full-graph and guarded short-turn profiles documented below.
 - Model files: [soniqo/Kokoro-82M-LiteRT](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) — the three graphs, `vocab_index.json`, `us_gold.json`, `us_silver.json`, and `voices/af_heart.bin`.
+
+## OnnxPocketTts
+
+Download and verify the public `v1.0.0` bundle (120.3 MiB):
+
+```bash
+bash scripts/download_pocket_tts_onnx.sh /models/pocket-tts-onnx
+```
+
+```cpp
+#include <speech_core/models/onnx_pocket_tts.h>
+
+speech_core::PocketTtsConfig config;
+config.intra_threads = 2;
+config.flow_steps = 4;
+
+speech_core::OnnxPocketTts tts("/models/pocket-tts-onnx", config);
+tts.synthesize("Hello world.", "en",
+    [](const float* samples, size_t length, bool is_final) {
+        // Each non-final callback is 1,920 Float32 samples: 80 ms at 24 kHz.
+    });
+```
+
+- Model files: [soniqo/Pocket-TTS-100M-ONNX-INT8](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8),
+  pinned by the downloader to tag `v1.0.0` (release commit
+  `ad5d3fae3fb2f10024583708597afca8337c094c`).
+- The bundle contains `lm_main.int8.onnx`, `lm_flow.int8.onnx`,
+  `decoder.int8.onnx`, `encoder.onnx`, `text_conditioner.onnx`, `vocab.json`,
+  and `token_scores.json`.
+- This public-checkpoint export is English-only and bakes in Kyutai's Alba
+  preset. It does not provide arbitrary voice cloning. The model and voice are
+  CC BY 4.0; retain the Alba MacKenna attribution from the bundle manifest.
+- Inference is genuinely interleaved: one autoregressive latent frame is
+  decoded and emitted before the next frame is generated. `last_metrics()`
+  reports conditioning, first-audio and total latency, frame/sample counts,
+  EOS state, cancellation and the effective random seed.
+- On a Galaxy S23 Ultra (`SM-S918B`, Android 16, ONNX Runtime 1.27, two
+  threads), ten warmed runs measured 130/136 ms p50/p95 TTFA for `Hello
+  world.` and 147/151 ms for `I can call your contacts,`. Peak RSS was about
+  376.5 MiB and median RTF remained below 0.46. These are direct CLI
+  measurements, not UI/pipeline timings.
+- A post-publication rerun from an anonymous `v1.0.0` download measured
+  127.7/133.7 ms p50/p95 TTFA, 467.5/485.3 ms total latency, 0.4495 median RTF
+  and 373.7 MiB peak RSS for `Hello world.`. The complete 46-phrase seed-42
+  TTS-to-ASR gate reproduced 8.00% WER / 3.47% CER with no empty output,
+  empty transcript, or EOS failure.
+- Build the device benchmark explicitly with
+  `cmake --build <build-dir> --target speech_pocket_tts_bench`. Run it as
+  `speech_pocket_tts_bench BUNDLE [TEXT] [THREADS] [STEPS] [WARMUP] [RUNS]
+  [OUTPUT_WAV]`.
+- Build the device-native intelligibility gate with
+  `cmake --build <build-dir> --target speech_pocket_tts_roundtrip`. It runs the
+  editable `examples/onnx/pocket_tts_roundtrip.tsv` corpus through Pocket TTS,
+  the 24-to-16 kHz production resampler, and the deployed Parakeet-EOU
+  streaming recognizer. The JSON report contains per-phrase transcripts,
+  WER/CER, audio duration, TTFA, synthesis/recognition latency, EOS status,
+  peak and RMS. The predeclared gate is corpus WER <=10%, CER <=5%, and no
+  empty audio, empty transcript, or EOS failure.
+- Three complete Galaxy S23 Ultra runs with different Pocket seeds passed.
+  Across 138 syntheses (46 phrases x three seeds), the deployed Parakeet-EOU
+  recognizer measured 6.79% micro WER and 2.91% CER, 103/138 transcripts were
+  exact, and every synthesis produced audio and stopped on EOS. The
+  assistant-response subset measured 1.96% WER and 0.06% CER.
+- As an independent check, locally cached Faster-Whisper Large-v3 scored all 46
+  untouched seed-123 device WAVs at 1.43% WER and 0.40% CER after its standard
+  English normalization, with 42/46 exact. Numbers and technical replies were
+  exact. Three of the four residual word errors were equivalent time formats
+  (`seven thirty` vs `7:30`); the sole lexical miss was `Play` vs `Plain` in a
+  short name command. Round-trip ASR measures intelligibility, not naturalness
+  or listener preference, so it complements rather than replaces listening
+  tests.
+- Set `SPEECH_POCKET_TTS_BUNDLE` to the bundle directory to enable the
+  tokenizer golden test and end-to-end streaming/cancellation test.
+- The published `manifest.json` records the exact source-checkpoint and ONNX
+  exporter revisions. Export source:
+  [csukuangfj/pocket-tts-onnx-export](https://github.com/csukuangfj/pocket-tts-onnx-export).
+  Public checkpoint: [kyutai/pocket-tts-without-voice-cloning](https://huggingface.co/kyutai/pocket-tts-without-voice-cloning).
 
 ## OnnxVoxCPMTts
 

--- a/examples/onnx/pocket_tts_bench.cpp
+++ b/examples/onnx/pocket_tts_bench.cpp
@@ -1,0 +1,205 @@
+#include "speech_core/models/onnx_pocket_tts.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+double milliseconds(Clock::time_point start, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+double percentile(std::vector<double> values, double fraction) {
+    std::sort(values.begin(), values.end());
+    const double position = (values.size() - 1) * fraction;
+    const auto lower = static_cast<std::size_t>(position);
+    const auto upper = std::min(lower + 1, values.size() - 1);
+    const double weight = position - static_cast<double>(lower);
+    return values[lower] * (1.0 - weight) + values[upper] * weight;
+}
+
+long read_status_kib(const char* key) {
+    std::FILE* stream = std::fopen("/proc/self/status", "r");
+    if (!stream) return -1;
+    char line[256];
+    long value = -1;
+    while (std::fgets(line, sizeof(line), stream)) {
+        if (std::strncmp(line, key, std::strlen(key)) == 0) {
+            if (std::sscanf(line + std::strlen(key), "%ld", &value) != 1) value = -1;
+            break;
+        }
+    }
+    std::fclose(stream);
+    return value;
+}
+
+struct Run {
+    speech_core::PocketTtsMetrics metrics;
+    std::uint64_t hash = UINT64_C(14695981039346656037);
+    int chunks = 0;
+    double sum_squares = 0.0;
+    float peak = 0.0f;
+};
+
+Run generate(speech_core::OnnxPocketTts& tts,
+             const std::string& text,
+             std::vector<float>* captured_audio = nullptr) {
+    Run result;
+    tts.synthesize(text, "en", [&](const float* samples, std::size_t count, bool final) {
+        if (!final && samples && count > 0) {
+            ++result.chunks;
+            if (captured_audio) {
+                captured_audio->insert(captured_audio->end(), samples, samples + count);
+            }
+            for (std::size_t index = 0; index < count; ++index) {
+                result.sum_squares += static_cast<double>(samples[index]) * samples[index];
+                result.peak = std::max(result.peak, std::abs(samples[index]));
+            }
+            const auto* bytes = reinterpret_cast<const unsigned char*>(samples);
+            for (std::size_t index = 0; index < count * sizeof(float); ++index) {
+                result.hash ^= bytes[index];
+                result.hash *= UINT64_C(1099511628211);
+            }
+        }
+    });
+    result.metrics = tts.last_metrics();
+    return result;
+}
+
+void write_u16(std::FILE* stream, std::uint16_t value) {
+    const unsigned char bytes[] = {
+        static_cast<unsigned char>(value & 0xff),
+        static_cast<unsigned char>((value >> 8) & 0xff)};
+    std::fwrite(bytes, 1, sizeof(bytes), stream);
+}
+
+void write_u32(std::FILE* stream, std::uint32_t value) {
+    const unsigned char bytes[] = {
+        static_cast<unsigned char>(value & 0xff),
+        static_cast<unsigned char>((value >> 8) & 0xff),
+        static_cast<unsigned char>((value >> 16) & 0xff),
+        static_cast<unsigned char>((value >> 24) & 0xff)};
+    std::fwrite(bytes, 1, sizeof(bytes), stream);
+}
+
+void write_wav(const std::string& path, const std::vector<float>& samples) {
+    std::FILE* stream = std::fopen(path.c_str(), "wb");
+    if (!stream) throw std::runtime_error("Cannot open WAV output: " + path);
+    const auto data_bytes = static_cast<std::uint32_t>(samples.size() * sizeof(std::int16_t));
+    std::fwrite("RIFF", 1, 4, stream);
+    write_u32(stream, 36 + data_bytes);
+    std::fwrite("WAVEfmt ", 1, 8, stream);
+    write_u32(stream, 16);
+    write_u16(stream, 1);
+    write_u16(stream, 1);
+    write_u32(stream, 24000);
+    write_u32(stream, 24000 * sizeof(std::int16_t));
+    write_u16(stream, sizeof(std::int16_t));
+    write_u16(stream, 16);
+    std::fwrite("data", 1, 4, stream);
+    write_u32(stream, data_bytes);
+    for (const float value : samples) {
+        const float clipped = std::max(-1.0f, std::min(1.0f, value));
+        const auto pcm = static_cast<std::int16_t>(std::lrint(clipped * 32767.0f));
+        write_u16(stream, static_cast<std::uint16_t>(pcm));
+    }
+    std::fclose(stream);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr,
+            "Usage: %s BUNDLE [TEXT] [THREADS] [STEPS] [WARMUP] [RUNS] [OUTPUT_WAV]\n",
+            argv[0]);
+        return 2;
+    }
+
+    const std::string bundle = argv[1];
+    const std::string text = argc > 2 ? argv[2] : "Hello world.";
+    const int threads = argc > 3 ? std::atoi(argv[3]) : 2;
+    const int steps = argc > 4 ? std::atoi(argv[4]) : 4;
+    const int warmup = argc > 5 ? std::atoi(argv[5]) : 1;
+    const int run_count = argc > 6 ? std::atoi(argv[6]) : 10;
+    const std::string output_wav = argc > 7 ? argv[7] : "";
+    if (threads < 1 || steps < 1 || warmup < 0 || run_count < 1) return 2;
+
+    try {
+        speech_core::PocketTtsConfig config;
+        config.intra_threads = threads;
+        config.flow_steps = steps;
+        config.max_frames = 100;
+        config.seed = 42;
+
+        const auto load_started = Clock::now();
+        speech_core::OnnxPocketTts tts(bundle, config);
+        const double load_ms = milliseconds(load_started, Clock::now());
+
+        for (int index = 0; index < warmup; ++index) generate(tts, text);
+
+        std::vector<Run> runs;
+        std::vector<double> first_audio;
+        std::vector<double> total;
+        std::vector<double> rtf;
+        std::vector<float> captured_audio;
+        runs.reserve(static_cast<std::size_t>(run_count));
+        for (int index = 0; index < run_count; ++index) {
+            auto* capture = !output_wav.empty() && index == run_count - 1
+                ? &captured_audio : nullptr;
+            runs.push_back(generate(tts, text, capture));
+            const auto& metrics = runs.back().metrics;
+            first_audio.push_back(metrics.first_audio_ms);
+            total.push_back(metrics.total_ms);
+            const double audio_seconds = metrics.output_samples / 24000.0;
+            rtf.push_back(metrics.total_ms / 1000.0 / audio_seconds);
+        }
+
+        const auto& last = runs.back();
+        const long rss_kib = read_status_kib("VmRSS:");
+        const long peak_kib = read_status_kib("VmHWM:");
+        if (!output_wav.empty()) write_wav(output_wav, captured_audio);
+        std::printf("Pocket TTS speech-core interleaved benchmark\n");
+        std::printf("text=\"%s\" threads=%d steps=%d warmup=%d runs=%d\n",
+                    text.c_str(), threads, steps, warmup, run_count);
+        std::printf("load_ms=%.3f conditioning_ms=%.3f\n",
+                    load_ms, last.metrics.conditioning_ms);
+        std::printf("ttfa_p50_ms=%.3f ttfa_p90_ms=%.3f ttfa_p95_ms=%.3f\n",
+                    percentile(first_audio, 0.50), percentile(first_audio, 0.90),
+                    percentile(first_audio, 0.95));
+        std::printf("total_p50_ms=%.3f total_p90_ms=%.3f total_p95_ms=%.3f\n",
+                    percentile(total, 0.50), percentile(total, 0.90),
+                    percentile(total, 0.95));
+        std::printf(
+            "rtf_p50=%.4f audio_seconds=%.3f chunks=%d rss_mib=%.1f "
+            "peak_rss_mib=%.1f peak=%.4f rms=%.4f hash=%016llx\n",
+            percentile(rtf, 0.50), last.metrics.output_samples / 24000.0,
+            last.chunks, rss_kib / 1024.0, peak_kib / 1024.0,
+            last.peak,
+            std::sqrt(last.sum_squares / last.metrics.output_samples),
+            static_cast<unsigned long long>(last.hash));
+        std::printf("run,conditioning_ms,ttfa_ms,total_ms,rtf,frames,output_samples,eos\n");
+        for (std::size_t index = 0; index < runs.size(); ++index) {
+            const auto& metrics = runs[index].metrics;
+            std::printf("%zu,%.3f,%.3f,%.3f,%.4f,%d,%d,%d\n", index + 1,
+                        metrics.conditioning_ms, metrics.first_audio_ms,
+                        metrics.total_ms, rtf[index], metrics.frames_generated,
+                        metrics.output_samples, metrics.stopped_on_eos ? 1 : 0);
+        }
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "Pocket TTS benchmark failed: %s\n", error.what());
+        return 3;
+    }
+    return 0;
+}

--- a/examples/onnx/pocket_tts_roundtrip.cpp
+++ b/examples/onnx/pocket_tts_roundtrip.cpp
@@ -1,0 +1,515 @@
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_nemotron_streaming_stt.h"
+#include "speech_core/models/onnx_pocket_tts.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr double kMaxAcceptedWer = 0.10;
+constexpr double kMaxAcceptedCer = 0.05;
+
+struct TestCase {
+    std::string category;
+    std::string text;
+    std::vector<std::string> references;
+};
+
+struct Result {
+    TestCase test;
+    std::string chosen_reference;
+    std::string transcript;
+    int word_errors = 0;
+    int reference_words = 0;
+    int character_errors = 0;
+    int reference_characters = 0;
+    double wer = 0.0;
+    double cer = 0.0;
+    double stt_ms = 0.0;
+    double audio_seconds = 0.0;
+    float peak = 0.0f;
+    float rms = 0.0f;
+    speech_core::PocketTtsMetrics tts;
+};
+
+struct Aggregate {
+    int cases = 0;
+    int exact = 0;
+    int word_errors = 0;
+    int reference_words = 0;
+    int character_errors = 0;
+    int reference_characters = 0;
+};
+
+double milliseconds(Clock::time_point start, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+std::vector<std::string> split(const std::string& text, char delimiter) {
+    std::vector<std::string> values;
+    std::size_t start = 0;
+    while (true) {
+        const auto end = text.find(delimiter, start);
+        values.push_back(text.substr(start, end - start));
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return values;
+}
+
+std::vector<TestCase> read_corpus(const std::string& path) {
+    std::ifstream stream(path);
+    if (!stream) throw std::runtime_error("Cannot open round-trip corpus: " + path);
+
+    std::vector<TestCase> cases;
+    std::string line;
+    int line_number = 0;
+    while (std::getline(stream, line)) {
+        ++line_number;
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        if (line.empty() || line[0] == '#') continue;
+        const auto fields = split(line, '\t');
+        if (fields.size() != 3 || fields[0].empty() || fields[1].empty() ||
+            fields[2].empty()) {
+            throw std::runtime_error(
+                "Invalid round-trip corpus line " + std::to_string(line_number));
+        }
+        auto references = split(fields[2], '|');
+        for (const auto& reference : references) {
+            if (reference.empty()) {
+                throw std::runtime_error(
+                    "Empty round-trip reference on line " +
+                    std::to_string(line_number));
+            }
+        }
+        cases.push_back({fields[0], fields[1], std::move(references)});
+    }
+    if (cases.empty()) throw std::runtime_error("Round-trip corpus is empty");
+    return cases;
+}
+
+std::string normalize(const std::string& input) {
+    std::string output;
+    output.reserve(input.size());
+    bool pending_space = false;
+    for (const unsigned char byte : input) {
+        if (byte >= 128) {
+            if (pending_space && !output.empty()) output.push_back(' ');
+            pending_space = false;
+            output.push_back(static_cast<char>(byte));
+        } else if ((byte >= 'a' && byte <= 'z') ||
+                   (byte >= '0' && byte <= '9')) {
+            if (pending_space && !output.empty()) output.push_back(' ');
+            pending_space = false;
+            output.push_back(static_cast<char>(byte));
+        } else if (byte >= 'A' && byte <= 'Z') {
+            if (pending_space && !output.empty()) output.push_back(' ');
+            pending_space = false;
+            output.push_back(static_cast<char>(byte - 'A' + 'a'));
+        } else if (byte == '\'' || byte == '`') {
+            // Join apostrophe contractions so punctuation style is not scored.
+        } else if (byte == '&') {
+            if (!output.empty() && output.back() != ' ') output.push_back(' ');
+            output.append("and");
+            pending_space = true;
+        } else {
+            pending_space = true;
+        }
+    }
+    return output;
+}
+
+std::vector<std::string> words(const std::string& normalized) {
+    std::istringstream stream(normalized);
+    std::vector<std::string> result;
+    std::string word;
+    while (stream >> word) result.push_back(word);
+    return result;
+}
+
+std::vector<unsigned char> characters(const std::string& normalized) {
+    std::vector<unsigned char> result;
+    for (const unsigned char byte : normalized) {
+        if (byte != ' ') result.push_back(byte);
+    }
+    return result;
+}
+
+template <typename T>
+int edit_distance(const std::vector<T>& reference,
+                  const std::vector<T>& hypothesis) {
+    std::vector<int> previous(hypothesis.size() + 1);
+    std::vector<int> current(hypothesis.size() + 1);
+    for (std::size_t index = 0; index <= hypothesis.size(); ++index) {
+        previous[index] = static_cast<int>(index);
+    }
+    for (std::size_t row = 1; row <= reference.size(); ++row) {
+        current[0] = static_cast<int>(row);
+        for (std::size_t column = 1; column <= hypothesis.size(); ++column) {
+            const int substitution = previous[column - 1] +
+                (reference[row - 1] == hypothesis[column - 1] ? 0 : 1);
+            current[column] = std::min({
+                previous[column] + 1, current[column - 1] + 1, substitution});
+        }
+        previous.swap(current);
+    }
+    return previous.back();
+}
+
+Result score(TestCase test,
+             std::string transcript,
+             const speech_core::PocketTtsMetrics& tts_metrics,
+             double stt_ms,
+             const std::vector<float>& audio) {
+    Result result;
+    result.test = std::move(test);
+    result.transcript = std::move(transcript);
+    result.tts = tts_metrics;
+    result.stt_ms = stt_ms;
+    result.audio_seconds = audio.size() / 24000.0;
+
+    double sum_squares = 0.0;
+    for (const float sample : audio) {
+        result.peak = std::max(result.peak, std::abs(sample));
+        sum_squares += static_cast<double>(sample) * sample;
+    }
+    result.rms = audio.empty()
+        ? 0.0f
+        : static_cast<float>(std::sqrt(sum_squares / audio.size()));
+
+    const auto hypothesis_words = words(normalize(result.transcript));
+    const auto hypothesis_characters = characters(normalize(result.transcript));
+    double best_wer = std::numeric_limits<double>::infinity();
+    double best_cer = std::numeric_limits<double>::infinity();
+    for (const auto& reference : result.test.references) {
+        const auto normalized_reference = normalize(reference);
+        const auto reference_words = words(normalized_reference);
+        const auto reference_characters = characters(normalized_reference);
+        const int word_errors = edit_distance(reference_words, hypothesis_words);
+        const int character_errors = edit_distance(
+            reference_characters, hypothesis_characters);
+        const double wer = reference_words.empty()
+            ? 0.0
+            : static_cast<double>(word_errors) / reference_words.size();
+        const double cer = reference_characters.empty()
+            ? 0.0
+            : static_cast<double>(character_errors) / reference_characters.size();
+        if (wer < best_wer || (wer == best_wer && cer < best_cer)) {
+            best_wer = wer;
+            best_cer = cer;
+            result.chosen_reference = reference;
+            result.word_errors = word_errors;
+            result.reference_words = static_cast<int>(reference_words.size());
+            result.character_errors = character_errors;
+            result.reference_characters =
+                static_cast<int>(reference_characters.size());
+        }
+    }
+    result.wer = best_wer;
+    result.cer = best_cer;
+    return result;
+}
+
+void write_u16(std::FILE* stream, std::uint16_t value) {
+    const unsigned char bytes[] = {
+        static_cast<unsigned char>(value & 0xff),
+        static_cast<unsigned char>((value >> 8) & 0xff)};
+    std::fwrite(bytes, 1, sizeof(bytes), stream);
+}
+
+void write_u32(std::FILE* stream, std::uint32_t value) {
+    const unsigned char bytes[] = {
+        static_cast<unsigned char>(value & 0xff),
+        static_cast<unsigned char>((value >> 8) & 0xff),
+        static_cast<unsigned char>((value >> 16) & 0xff),
+        static_cast<unsigned char>((value >> 24) & 0xff)};
+    std::fwrite(bytes, 1, sizeof(bytes), stream);
+}
+
+void write_wav(const std::filesystem::path& path,
+               const std::vector<float>& samples) {
+    std::FILE* stream = std::fopen(path.string().c_str(), "wb");
+    if (!stream) throw std::runtime_error("Cannot write WAV: " + path.string());
+    const auto bytes = static_cast<std::uint32_t>(samples.size() * sizeof(std::int16_t));
+    std::fwrite("RIFF", 1, 4, stream);
+    write_u32(stream, 36 + bytes);
+    std::fwrite("WAVEfmt ", 1, 8, stream);
+    write_u32(stream, 16);
+    write_u16(stream, 1);
+    write_u16(stream, 1);
+    write_u32(stream, 24000);
+    write_u32(stream, 48000);
+    write_u16(stream, 2);
+    write_u16(stream, 16);
+    std::fwrite("data", 1, 4, stream);
+    write_u32(stream, bytes);
+    for (const float sample : samples) {
+        const float clipped = std::max(-1.0f, std::min(1.0f, sample));
+        const auto value = static_cast<std::int16_t>(std::lrint(clipped * 32767.0f));
+        write_u16(stream, static_cast<std::uint16_t>(value));
+    }
+    std::fclose(stream);
+}
+
+std::string json_escape(const std::string& value) {
+    std::string result;
+    for (const unsigned char byte : value) {
+        switch (byte) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default:
+                if (byte < 0x20) {
+                    char escaped[7];
+                    std::snprintf(escaped, sizeof(escaped), "\\u%04x", byte);
+                    result += escaped;
+                } else {
+                    result.push_back(static_cast<char>(byte));
+                }
+        }
+    }
+    return result;
+}
+
+double ratio(int errors, int reference_units) {
+    return reference_units == 0
+        ? 0.0
+        : static_cast<double>(errors) / reference_units;
+}
+
+void add(Aggregate& aggregate, const Result& result) {
+    ++aggregate.cases;
+    if (result.word_errors == 0) ++aggregate.exact;
+    aggregate.word_errors += result.word_errors;
+    aggregate.reference_words += result.reference_words;
+    aggregate.character_errors += result.character_errors;
+    aggregate.reference_characters += result.reference_characters;
+}
+
+void write_report(const std::string& path,
+                  const std::vector<Result>& results,
+                  const Aggregate& aggregate,
+                  double tts_load_ms,
+                  double stt_load_ms,
+                  bool passed) {
+    if (path.empty()) return;
+    std::ofstream stream(path);
+    if (!stream) throw std::runtime_error("Cannot write JSON report: " + path);
+    stream << std::fixed << std::setprecision(6);
+    stream << "{\n  \"format_version\": 1,\n"
+           << "  \"tts_load_ms\": " << tts_load_ms << ",\n"
+           << "  \"stt_load_ms\": " << stt_load_ms << ",\n"
+           << "  \"thresholds\": {\"max_wer\": " << kMaxAcceptedWer
+           << ", \"max_cer\": " << kMaxAcceptedCer << "},\n"
+           << "  \"summary\": {\"cases\": " << aggregate.cases
+           << ", \"exact\": " << aggregate.exact
+           << ", \"word_errors\": " << aggregate.word_errors
+           << ", \"reference_words\": " << aggregate.reference_words
+           << ", \"wer\": "
+           << ratio(aggregate.word_errors, aggregate.reference_words)
+           << ", \"character_errors\": " << aggregate.character_errors
+           << ", \"reference_characters\": "
+           << aggregate.reference_characters << ", \"cer\": "
+           << ratio(aggregate.character_errors, aggregate.reference_characters)
+           << ", \"passed\": " << (passed ? "true" : "false") << "},\n"
+           << "  \"cases\": [\n";
+    for (std::size_t index = 0; index < results.size(); ++index) {
+        const auto& result = results[index];
+        stream << "    {\"index\": " << index + 1
+               << ", \"category\": \"" << json_escape(result.test.category)
+               << "\", \"text\": \"" << json_escape(result.test.text)
+               << "\", \"reference\": \""
+               << json_escape(result.chosen_reference)
+               << "\", \"transcript\": \"" << json_escape(result.transcript)
+               << "\", \"word_errors\": " << result.word_errors
+               << ", \"reference_words\": " << result.reference_words
+               << ", \"wer\": " << result.wer
+               << ", \"character_errors\": " << result.character_errors
+               << ", \"reference_characters\": "
+               << result.reference_characters << ", \"cer\": " << result.cer
+               << ", \"audio_seconds\": " << result.audio_seconds
+               << ", \"tts_ttfa_ms\": " << result.tts.first_audio_ms
+               << ", \"tts_total_ms\": " << result.tts.total_ms
+               << ", \"stt_ms\": " << result.stt_ms
+               << ", \"frames\": " << result.tts.frames_generated
+               << ", \"eos\": "
+               << (result.tts.stopped_on_eos ? "true" : "false")
+               << ", \"peak\": " << result.peak << ", \"rms\": "
+               << result.rms << "}";
+        if (index + 1 != results.size()) stream << ',';
+        stream << '\n';
+    }
+    stream << "  ]\n}\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        std::fprintf(stderr,
+            "Usage: %s POCKET_BUNDLE STT_BUNDLE CORPUS_TSV [THREADS] [STEPS] "
+            "[SEED] [REPORT_JSON] [FAILED_WAV_DIR]\n",
+            argv[0]);
+        return 2;
+    }
+
+    const std::string pocket_bundle = argv[1];
+    const std::string stt_bundle = argv[2];
+    const std::string corpus_path = argv[3];
+    const int threads = argc > 4 ? std::atoi(argv[4]) : 2;
+    const int steps = argc > 5 ? std::atoi(argv[5]) : 4;
+    const int seed = argc > 6 ? std::atoi(argv[6]) : 42;
+    const std::string report_path = argc > 7 ? argv[7] : "";
+    const std::string failed_wav_dir = argc > 8 ? argv[8] : "";
+    const char* write_all_value =
+        std::getenv("SPEECH_POCKET_TTS_ROUNDTRIP_WRITE_ALL");
+    const bool write_all_wavs =
+        write_all_value && std::string(write_all_value) == "1";
+    if (threads < 1 || steps < 1 || seed < 0) return 2;
+
+    try {
+        const auto cases = read_corpus(corpus_path);
+        speech_core::PocketTtsConfig tts_config;
+        tts_config.intra_threads = threads;
+        tts_config.flow_steps = steps;
+        tts_config.seed = seed;
+        tts_config.max_frames = 200;
+
+        auto started = Clock::now();
+        speech_core::OnnxPocketTts tts(pocket_bundle, tts_config);
+        const double tts_load_ms = milliseconds(started, Clock::now());
+
+        started = Clock::now();
+        speech_core::OnnxNemotronStreamingStt stt(
+            stt_bundle + "/parakeet-eou-encoder.onnx",
+            stt_bundle + "/parakeet-eou-decoder.onnx",
+            stt_bundle + "/parakeet-eou-joint.onnx",
+            stt_bundle + "/vocab.json",
+            /*hw_accel=*/false);
+        const double stt_load_ms = milliseconds(started, Clock::now());
+
+        if (!failed_wav_dir.empty()) {
+            std::filesystem::create_directories(failed_wav_dir);
+        }
+
+        std::printf("Pocket TTS -> Parakeet EOU round-trip intelligibility\n");
+        std::printf("cases=%zu threads=%d steps=%d seed=%d "
+                    "tts_load_ms=%.3f stt_load_ms=%.3f\n",
+                    cases.size(), threads, steps, seed, tts_load_ms, stt_load_ms);
+
+        std::vector<Result> results;
+        results.reserve(cases.size());
+        Aggregate aggregate;
+        std::unordered_map<std::string, Aggregate> categories;
+        int empty_audio = 0;
+        int empty_transcript = 0;
+        int eos_failures = 0;
+
+        for (std::size_t index = 0; index < cases.size(); ++index) {
+            std::vector<float> audio_24k;
+            tts.synthesize(cases[index].text, "en",
+                [&](const float* samples, std::size_t count, bool final) {
+                    if (!final && samples && count) {
+                        audio_24k.insert(audio_24k.end(), samples, samples + count);
+                    }
+                });
+            const auto tts_metrics = tts.last_metrics();
+            if (audio_24k.empty()) ++empty_audio;
+            if (!tts_metrics.stopped_on_eos) ++eos_failures;
+
+            auto speech_16k = speech_core::Resampler::resample(
+                audio_24k.data(), audio_24k.size(), 24000, 16000);
+            // Give the streaming recognizer stable boundaries without altering
+            // the synthesized speech itself: 150 ms before and 300 ms after.
+            std::vector<float> stt_audio(2400, 0.0f);
+            stt_audio.insert(stt_audio.end(), speech_16k.begin(), speech_16k.end());
+            stt_audio.insert(stt_audio.end(), 4800, 0.0f);
+
+            const auto stt_started = Clock::now();
+            const auto transcription = stt.transcribe(
+                stt_audio.data(), stt_audio.size(), 16000);
+            const double stt_ms = milliseconds(stt_started, Clock::now());
+            if (normalize(transcription.text).empty()) ++empty_transcript;
+
+            auto result = score(
+                cases[index], transcription.text, tts_metrics, stt_ms, audio_24k);
+            add(aggregate, result);
+            add(categories[result.test.category], result);
+            std::printf(
+                "CASE %02zu [%s] WER=%5.1f%% CER=%5.1f%% audio=%.2fs "
+                "TTFA=%.1fms STT=%.1fms eos=%d\n  REF: %s\n  HYP: %s\n",
+                index + 1, result.test.category.c_str(), result.wer * 100.0,
+                result.cer * 100.0, result.audio_seconds,
+                result.tts.first_audio_ms, result.stt_ms,
+                result.tts.stopped_on_eos ? 1 : 0,
+                result.chosen_reference.c_str(), result.transcript.c_str());
+
+            if (!failed_wav_dir.empty() &&
+                (write_all_wavs || result.word_errors != 0 ||
+                 !result.tts.stopped_on_eos ||
+                 normalize(result.transcript).empty())) {
+                char name[64];
+                std::snprintf(name, sizeof(name), "case_%02zu.wav", index + 1);
+                write_wav(std::filesystem::path(failed_wav_dir) / name, audio_24k);
+            }
+            results.push_back(std::move(result));
+            std::fflush(stdout);
+        }
+
+        std::printf("\nCATEGORY SUMMARY\n");
+        std::vector<std::string> category_names;
+        category_names.reserve(categories.size());
+        for (const auto& entry : categories) category_names.push_back(entry.first);
+        std::sort(category_names.begin(), category_names.end());
+        for (const auto& name : category_names) {
+            const auto& category = categories.at(name);
+            std::printf("%s cases=%d exact=%d WER=%.2f%% CER=%.2f%%\n",
+                name.c_str(), category.cases, category.exact,
+                ratio(category.word_errors, category.reference_words) * 100.0,
+                ratio(category.character_errors,
+                      category.reference_characters) * 100.0);
+        }
+
+        const double corpus_wer = ratio(aggregate.word_errors, aggregate.reference_words);
+        const double corpus_cer = ratio(
+            aggregate.character_errors, aggregate.reference_characters);
+        const bool passed = empty_audio == 0 && empty_transcript == 0 &&
+            eos_failures == 0 && corpus_wer <= kMaxAcceptedWer &&
+            corpus_cer <= kMaxAcceptedCer;
+        std::printf(
+            "\nSUMMARY cases=%d exact=%d exact_rate=%.2f%% word_errors=%d/%d "
+            "WER=%.2f%% char_errors=%d/%d CER=%.2f%% empty_audio=%d "
+            "empty_transcript=%d eos_failures=%d gate=%s\n",
+            aggregate.cases, aggregate.exact,
+            aggregate.cases ? aggregate.exact * 100.0 / aggregate.cases : 0.0,
+            aggregate.word_errors, aggregate.reference_words, corpus_wer * 100.0,
+            aggregate.character_errors, aggregate.reference_characters,
+            corpus_cer * 100.0, empty_audio, empty_transcript, eos_failures,
+            passed ? "PASS" : "FAIL");
+
+        write_report(report_path, results, aggregate, tts_load_ms, stt_load_ms, passed);
+        return passed ? 0 : 4;
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "Pocket TTS round-trip failed: %s\n", error.what());
+        return 3;
+    }
+}

--- a/examples/onnx/pocket_tts_roundtrip.tsv
+++ b/examples/onnx/pocket_tts_roundtrip.tsv
@@ -1,0 +1,47 @@
+# category<TAB>synthesis text<TAB>acceptable transcription reference(s), separated by |
+assistant	Hello world.	Hello world.
+assistant	What can you do?	What can you do?
+assistant	I can call your contacts.	I can call your contacts.
+assistant	I can play music from your library.	I can play music from your library.
+assistant	Your volume is set to five.	Your volume is set to five.
+assistant	The music has been paused.	The music has been paused.
+assistant	I could not find Nina Simone on this phone.	I could not find Nina Simone on this phone.
+assistant	Opening the dialer for Alex.	Opening the dialer for Alex.
+assistant	Your timer is set for ten minutes.	Your timer is set for ten minutes.
+assistant	The alarm is set for seven thirty tomorrow morning.	The alarm is set for seven thirty tomorrow morning.
+assistant	Bluetooth is currently disconnected.	Bluetooth is currently disconnected.
+assistant	Please connect to a Wi-Fi network.	Please connect to a Wi-Fi network.|Please connect to a wifi network.
+assistant	The battery level is eighty three percent.	The battery level is eighty three percent.
+assistant	I did not understand that request.	I did not understand that request.
+assistant	Try saying play some jazz.	Try saying play some jazz.
+assistant	There are no new notifications.	There are no new notifications.
+assistant	Microphone permission is required.	Microphone permission is required.
+assistant	Speech recognition is working offline.	Speech recognition is working offline.
+assistant	Would you like me to call Sarah Johnson?	Would you like me to call Sarah Johnson?
+assistant	Send a message saying I will arrive in twenty minutes.	Send a message saying I will arrive in twenty minutes.
+general	The quick brown fox jumps over the lazy dog.	The quick brown fox jumps over the lazy dog.
+general	Pack my box with five dozen liquor jugs.	Pack my box with five dozen liquor jugs.
+general	She sells seashells by the seashore.	She sells seashells by the seashore.
+general	Peter Piper picked a peck of pickled peppers.	Peter Piper picked a peck of pickled peppers.
+general	Turn left at the next traffic light.	Turn left at the next traffic light.
+general	The meeting starts on Thursday at nine fifteen.	The meeting starts on Thursday at nine fifteen.
+general	The temperature is twenty one degrees Celsius.	The temperature is twenty one degrees Celsius.
+general	The weather will be cloudy with light rain.	The weather will be cloudy with light rain.
+numbers	Your confirmation code is four eight two six.	Your confirmation code is four eight two six.
+numbers	Navigate to one hundred twenty five Market Street.	Navigate to one hundred twenty five Market Street.
+numbers	I found twelve songs by David Bowie.	I found twelve songs by David Bowie.
+numbers	The train departs from platform seventeen.	The train departs from platform seventeen.
+numbers	The total is nineteen dollars and ninety five cents.	The total is nineteen dollars and ninety five cents.
+names	Play Nina Simone.	Play Nina Simone.
+names	Play Beyoncé and stop after this song.	Play Beyoncé and stop after this song.|Play Beyonce and stop after this song.
+names	Search for Sigur Ros in the music library.	Search for Sigur Ros in the music library.
+names	Call Doctor Muller.	Call Doctor Muller.|Call Doctor Mueller.
+names	Play Miles Davis and John Coltrane.	Play Miles Davis and John Coltrane.
+technical	The USB cable is not connected.	The USB cable is not connected.|The U S B cable is not connected.
+technical	The API returned an unexpected response.	The API returned an unexpected response.|The A P I returned an unexpected response.
+technical	Restart the application to apply the update.	Restart the application to apply the update.
+technical	Audio playback will resume automatically.	Audio playback will resume automatically.
+technical	The model is running entirely on device.	The model is running entirely on device.
+formatting	The meeting starts at 6:45 p.m.	The meeting starts at six forty five p m.|The meeting starts at 6 45 p m.|The meeting starts at six forty five pm.
+formatting	Your appointment is on July 14, 2026.	Your appointment is on July fourteenth twenty twenty six.|Your appointment is on July fourteen twenty twenty six.|Your appointment is on July 14 2026.
+formatting	Set the volume to 75%.	Set the volume to seventy five percent.|Set the volume to seventy five.|Set the volume to 75.

--- a/include/speech_core/models/onnx_pocket_tts.h
+++ b/include/speech_core/models/onnx_pocket_tts.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace speech_core {
+
+/// Runtime controls for the public, fixed-voice Pocket TTS ONNX bundle.
+struct PocketTtsConfig {
+    /// Euler flow-matching evaluations per generated 80 ms audio frame.
+    int flow_steps = 4;
+    /// Hard upper bound for generated frames (500 frames = 40 seconds).
+    int max_frames = 500;
+    /// Frames retained after the EOS score first crosses eos_threshold.
+    int frames_after_eos = 3;
+    float eos_threshold = -4.0f;
+    float temperature = 0.7f;
+    /// -1 selects a fresh random seed for each synthesis call.
+    std::int32_t seed = -1;
+    /// Per-session ONNX Runtime intra-op thread count.
+    int intra_threads = 2;
+    /// The exported recurrent graphs are CPU-oriented. Hardware execution is
+    /// opt-in because Android NNAPI support varies by device and ORT build.
+    bool hardware_acceleration = false;
+};
+
+/// Measurements from the most recent synthesis call.
+struct PocketTtsMetrics {
+    double conditioning_ms = 0.0;
+    double first_audio_ms = 0.0;
+    double total_ms = 0.0;
+    int frames_generated = 0;
+    int output_samples = 0;
+    std::uint32_t seed_used = 0;
+    bool stopped_on_eos = false;
+    bool cancelled = false;
+};
+
+/// Pocket TTS streaming ONNX backend.
+///
+/// Published bundle: https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8
+/// (pin revision `v1.0.0`).
+///
+/// The bundle contains five graphs (`lm_main.int8.onnx`,
+/// `lm_flow.int8.onnx`, `decoder.int8.onnx`, `encoder.onnx`, and
+/// `text_conditioner.onnx`) plus `vocab.json` and `token_scores.json`.
+/// The public export bakes in Kyutai's `alba` voice preset and is English-only.
+///
+/// Unlike the sherpa-onnx compatibility runtime, this implementation
+/// interleaves one autoregressive latent with one Mimi decoder invocation and
+/// emits each 1,920-sample (80 ms at 24 kHz) frame immediately. TTFA therefore
+/// does not include generation of the remainder of the utterance.
+class OnnxPocketTts final : public TTSInterface {
+public:
+    explicit OnnxPocketTts(const std::string& bundle_directory,
+                           PocketTtsConfig config = {});
+    ~OnnxPocketTts() override;
+
+    OnnxPocketTts(const OnnxPocketTts&) = delete;
+    OnnxPocketTts& operator=(const OnnxPocketTts&) = delete;
+
+    void synthesize(const std::string& text,
+                    const std::string& language,
+                    TTSChunkCallback on_chunk) override;
+    int output_sample_rate() const override { return 24000; }
+    void cancel() override;
+
+    PocketTtsMetrics last_metrics() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/pocket_tts_tokenizer.h
+++ b/include/speech_core/models/pocket_tts_tokenizer.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Minimal SentencePiece-compatible tokenizer used by the Pocket TTS ONNX
+/// bundle. The export stores its vocabulary and unigram scores as JSON so the
+/// Android runtime does not need to link libsentencepiece.
+class PocketTtsTokenizer {
+public:
+    PocketTtsTokenizer(const std::string& vocab_json,
+                       const std::string& token_scores_json);
+    ~PocketTtsTokenizer();
+
+    PocketTtsTokenizer(PocketTtsTokenizer&&) noexcept;
+    PocketTtsTokenizer& operator=(PocketTtsTokenizer&&) noexcept;
+
+    PocketTtsTokenizer(const PocketTtsTokenizer&) = delete;
+    PocketTtsTokenizer& operator=(const PocketTtsTokenizer&) = delete;
+
+    std::vector<std::int32_t> encode_ids(const std::string& text) const;
+    std::vector<std::string> encode_tokens(const std::string& text) const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace speech_core

--- a/scripts/download_pocket_tts_onnx.sh
+++ b/scripts/download_pocket_tts_onnx.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Download the fixed-Alba Pocket TTS bundle consumed by OnnxPocketTts.
+# Usage: bash scripts/download_pocket_tts_onnx.sh [output_dir]
+
+set -euo pipefail
+
+REPO="${POCKET_TTS_HF_REPO:-soniqo/Pocket-TTS-100M-ONNX-INT8}"
+REVISION="${POCKET_TTS_REVISION:-v1.0.0}"
+DEST="${1:-scripts/models/pocket-tts-onnx}"
+BASE_URL="https://huggingface.co/${REPO}/resolve/${REVISION}"
+
+FILES=(
+    LICENSE
+    README.md
+    decoder.int8.onnx
+    encoder.onnx
+    lm_flow.int8.onnx
+    lm_main.int8.onnx
+    manifest.json
+    text_conditioner.onnx
+    token_scores.json
+    tokenizer.model
+    vocab.json
+)
+
+mkdir -p "$DEST"
+
+for name in "${FILES[@]}"; do
+    output="$DEST/$name"
+    if [ -s "$output" ]; then
+        echo "[skip] $name"
+        continue
+    fi
+    echo "[fetch] ${REPO}@${REVISION}/$name"
+    curl -fL --retry 3 --retry-all-errors \
+        -o "$output.part" "$BASE_URL/$name"
+    mv "$output.part" "$output"
+done
+
+if command -v sha256sum >/dev/null 2>&1; then
+    hash_file() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    hash_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+    echo "error: sha256sum or shasum is required to verify the release" >&2
+    exit 1
+fi
+
+verify() {
+    expected="$1"
+    name="$2"
+    actual="$(hash_file "$DEST/$name")"
+    if [ "$actual" != "$expected" ]; then
+        echo "error: SHA-256 mismatch for $name" >&2
+        exit 1
+    fi
+    echo "[verified] $name"
+}
+
+verify 9ba9550ad48438d0836ddab3da480b3b69ffa0aac7b7878b5a0039e7ab429411 LICENSE
+verify 8f5b926dcf7bf1940796af9ac9be0239fea65ee22bf1a0e0a3ddae542990cacb README.md
+verify ed8d050fc5da275cfca88224b7d2cc29fde7c23e133618f346e98ac505b3d862 decoder.int8.onnx
+verify 2194513df47271ece9f8d2d571facd57b24d96a1d912fdc13bf0e10c69318e85 encoder.onnx
+verify 8d627d235c44a597da908e1085ebe241cbbe358964c502c5a5063d18851a5529 lm_flow.int8.onnx
+verify bfc0c7e7e3d72864fa3bb2ee499f62f21ddc1474b885f5f3ca570f8be73e787e lm_main.int8.onnx
+verify 5eeff5278cfb1e9b627d972512ddf1e2dfacf61827103d9fb9c53707b38d0968 manifest.json
+verify 5217b8474621af91127cfef891714337ae8cba106710ce04a426ec4bd56bbd1e text_conditioner.onnx
+verify 3baa6ef7d57bac245271e33f96161f3ac60038d753f13f3fdbe24a7d2422ad6b token_scores.json
+verify d461765ae179566678c93091c5fa6f2984c31bbe990bf1aa62d92c64d91bc3f6 tokenizer.model
+verify a2673c232cf49dd6eb1ad850e7c7682f6443c2ab64040d1150e9d8f2a7e3587b vocab.json
+
+echo
+echo "Pocket TTS ONNX bundle ready: $DEST"
+echo "Run tests with:"
+echo "  SPEECH_POCKET_TTS_BUNDLE=$DEST ctest --test-dir build --output-on-failure"

--- a/src/models/pocket/onnx_pocket_tts.cpp
+++ b/src/models/pocket/onnx_pocket_tts.cpp
@@ -1,0 +1,649 @@
+#include "speech_core/models/onnx_pocket_tts.h"
+
+#include "speech_core/models/onnx_engine.h"
+#include "speech_core/models/pocket_tts_tokenizer.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace speech_core {
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+double elapsed_ms(Clock::time_point start, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+std::string path_join(const std::string& directory, const char* filename) {
+    if (directory.empty()) return filename;
+    const char tail = directory.back();
+    if (tail == '/' || tail == '\\') return directory + filename;
+#ifdef _WIN32
+    return directory + "\\" + filename;
+#else
+    return directory + "/" + filename;
+#endif
+}
+
+bool is_file(const std::string& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return stream.good();
+}
+
+std::size_t element_size(ONNXTensorElementDataType type) {
+    switch (type) {
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL: return sizeof(bool);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT: return sizeof(float);
+        case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64: return sizeof(std::int64_t);
+        default:
+            throw std::runtime_error("Pocket TTS encountered an unsupported ONNX tensor type");
+    }
+}
+
+std::size_t shape_element_count(const std::vector<std::int64_t>& shape) {
+    std::size_t count = 1;
+    for (const auto dimension : shape) {
+        if (dimension < 0) {
+            throw std::runtime_error("Pocket TTS encountered an unresolved tensor dimension");
+        }
+        if (dimension == 0) return 0;
+        count *= static_cast<std::size_t>(dimension);
+    }
+    return count;
+}
+
+struct ValueDeleter {
+    const OrtApi* api = nullptr;
+    void operator()(OrtValue* value) const {
+        if (api && value) api->ReleaseValue(value);
+    }
+};
+using ValuePtr = std::unique_ptr<OrtValue, ValueDeleter>;
+
+struct SessionDeleter {
+    const OrtApi* api = nullptr;
+    void operator()(OrtSession* session) const {
+        if (api && session) api->ReleaseSession(session);
+    }
+};
+using SessionPtr = std::unique_ptr<OrtSession, SessionDeleter>;
+
+struct OrtStringHandle {
+    const OrtApi* api = nullptr;
+    OrtAllocator* allocator = nullptr;
+    char* value = nullptr;
+    ~OrtStringHandle() {
+        if (api && allocator && value) {
+            OrtStatus* status = api->AllocatorFree(allocator, value);
+            if (status) api->ReleaseStatus(status);
+        }
+    }
+};
+
+}  // namespace
+
+class OnnxPocketTts::Impl {
+public:
+    Impl(const std::string& bundle_directory, PocketTtsConfig config)
+        : config_(config) {
+        validate_config();
+
+        const auto lm_main_path = required_path(bundle_directory, "lm_main.int8.onnx");
+        const auto lm_flow_path = required_path(bundle_directory, "lm_flow.int8.onnx");
+        const auto decoder_path = required_path(bundle_directory, "decoder.int8.onnx");
+        const auto encoder_path = required_path(bundle_directory, "encoder.onnx");
+        const auto conditioner_path = required_path(bundle_directory, "text_conditioner.onnx");
+        const auto vocabulary_path = required_path(bundle_directory, "vocab.json");
+        const auto scores_path = required_path(bundle_directory, "token_scores.json");
+
+        auto& engine = OnnxEngine::get();
+        api_ = engine.api();
+        memory_ = engine.cpu_memory();
+        ort_check(api_, api_->GetAllocatorWithDefaultOptions(&allocator_));
+
+        lm_main_ = load_session(engine, lm_main_path, true);
+        lm_flow_ = load_session(engine, lm_flow_path, true);
+        decoder_ = load_session(engine, decoder_path, true);
+        conditioner_ = load_session(engine, conditioner_path, false);
+        encoder_ = load_session(engine, encoder_path, false);
+
+        lm_main_io_ = query_io(lm_main_.get());
+        lm_flow_io_ = query_io(lm_flow_.get());
+        decoder_io_ = query_io(decoder_.get());
+        conditioner_io_ = query_io(conditioner_.get());
+        encoder_io_ = query_io(encoder_.get());
+        validate_model_contract();
+
+        tokenizer_ = std::make_unique<PocketTtsTokenizer>(vocabulary_path, scores_path);
+        lm_cache_length_ = query_lm_cache_length();
+        voice_embedding_ = create_voice_embedding();
+        const auto voice_shape = tensor_shape(voice_embedding_.get());
+        if (voice_shape.size() != 3 || voice_shape[0] != 1 || voice_shape[2] != 1024) {
+            throw std::runtime_error("Pocket TTS fixed voice embedding has an unexpected shape");
+        }
+        voice_tokens_ = static_cast<int>(voice_shape[1]);
+
+        // The public encoder is a tiny fixed-voice adapter. Its output owns
+        // the cached Alba prompt, so the session itself is no longer needed.
+        encoder_.reset();
+    }
+
+    void synthesize(const std::string& text,
+                    const std::string& language,
+                    TTSChunkCallback on_chunk) {
+        static_cast<void>(language);  // The public bundle is English-only.
+        std::lock_guard<std::mutex> synthesis_lock(synthesis_mutex_);
+        cancelled_.store(false);
+
+        PocketTtsMetrics metrics;
+        const auto started = Clock::now();
+
+        if (!on_chunk) {
+            throw std::invalid_argument("Pocket TTS requires a chunk callback");
+        }
+        if (text.empty()) {
+            on_chunk(nullptr, 0, true);
+            metrics.total_ms = elapsed_ms(started, Clock::now());
+            publish_metrics(metrics);
+            return;
+        }
+
+        const auto ids32 = tokenizer_->encode_ids(text);
+        if (ids32.empty()) {
+            on_chunk(nullptr, 0, true);
+            metrics.total_ms = elapsed_ms(started, Clock::now());
+            publish_metrics(metrics);
+            return;
+        }
+
+        const int remaining_cache =
+            lm_cache_length_ - voice_tokens_ - static_cast<int>(ids32.size());
+        if (remaining_cache <= 0) {
+            throw std::length_error(
+                "Pocket TTS text and voice conditioning exceed the 1000-token LM cache");
+        }
+        const int frame_limit = std::min(config_.max_frames, remaining_cache);
+
+        std::vector<std::int64_t> ids(ids32.begin(), ids32.end());
+        const std::vector<std::int64_t> token_shape = {
+            1, static_cast<std::int64_t>(ids.size())};
+        auto token_tensor = tensor_view(ids.data(), ids.size(), token_shape,
+                                        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+        const std::vector<const OrtValue*> conditioner_inputs = {token_tensor.get()};
+        auto conditioner_outputs = run(conditioner_.get(), conditioner_io_, conditioner_inputs);
+        auto text_embedding = std::move(conditioner_outputs[0]);
+
+        State lm_state = initial_state(lm_main_.get(), 2);
+        auto empty_sequence = owned_tensor(
+            {1, 0, 32}, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, true);
+
+        run_lm(empty_sequence.get(), voice_embedding_.get(), lm_state);
+        run_lm(empty_sequence.get(), text_embedding.get(), lm_state);
+        text_embedding.reset();
+
+        metrics.conditioning_ms = elapsed_ms(started, Clock::now());
+        State decoder_state = initial_state(decoder_.get(), 1);
+        auto empty_text = owned_tensor(
+            {1, 0, 1024}, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, true);
+
+        std::vector<float> current(32, std::numeric_limits<float>::quiet_NaN());
+        std::vector<float> noise(32, 0.0f);
+        const auto seed = resolve_seed();
+        metrics.seed_used = seed;
+        std::mt19937 rng(seed);
+        const float noise_stddev = std::sqrt(config_.temperature);
+
+        int eos_frame = -1;
+        bool first_audio = true;
+        for (int frame = 0; frame < frame_limit; ++frame) {
+            if (cancelled_.load()) break;
+
+            auto sequence = tensor_view(
+                current.data(), current.size(), {1, 1, 32},
+                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+            auto lm_result = run_lm(sequence.get(), empty_text.get(), lm_state);
+            auto conditioning = std::move(lm_result.first);
+            auto eos_logit = std::move(lm_result.second);
+
+            const float eos_score = first_float(eos_logit.get());
+            if (eos_frame < 0 && eos_score > config_.eos_threshold) {
+                eos_frame = frame;
+            }
+            if (eos_frame >= 0 && frame >= eos_frame + config_.frames_after_eos) {
+                metrics.stopped_on_eos = true;
+                break;
+            }
+
+            // Recreate the distribution on every frame to match sherpa-onnx's
+            // deterministic seeded reference implementation.
+            std::normal_distribution<float> distribution(0.0f, noise_stddev);
+            for (float& value : noise) value = distribution(rng);
+
+            current = run_flow(conditioning.get(), noise);
+            auto latent = tensor_view(
+                current.data(), current.size(), {1, 1, 32},
+                ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+            auto audio = run_decoder(latent.get(), decoder_state);
+            const std::size_t sample_count = tensor_element_count(audio.get());
+            if (sample_count != 1920) {
+                throw std::runtime_error(
+                    "Pocket TTS Mimi decoder did not return one 1,920-sample frame");
+            }
+            float* samples = nullptr;
+            ort_check(api_, api_->GetTensorMutableData(audio.get(),
+                                                       reinterpret_cast<void**>(&samples)));
+
+            if (first_audio) {
+                metrics.first_audio_ms = elapsed_ms(started, Clock::now());
+                first_audio = false;
+            }
+            on_chunk(samples, sample_count, false);
+            ++metrics.frames_generated;
+            metrics.output_samples += static_cast<int>(sample_count);
+        }
+
+        metrics.cancelled = cancelled_.load();
+        on_chunk(nullptr, 0, true);
+        metrics.total_ms = elapsed_ms(started, Clock::now());
+        publish_metrics(metrics);
+    }
+
+    void cancel() { cancelled_.store(true); }
+
+    PocketTtsMetrics last_metrics() const {
+        std::lock_guard<std::mutex> lock(metrics_mutex_);
+        return last_metrics_;
+    }
+
+private:
+    struct IoNames {
+        std::vector<std::string> input_strings;
+        std::vector<std::string> output_strings;
+        std::vector<const char*> inputs;
+        std::vector<const char*> outputs;
+    };
+
+    struct State {
+        std::vector<ValuePtr> values;
+    };
+
+    void validate_config() const {
+        if (config_.flow_steps < 1 || config_.flow_steps > 32) {
+            throw std::invalid_argument("Pocket TTS flow_steps must be in [1, 32]");
+        }
+        if (config_.max_frames < 1 || config_.max_frames > 1000) {
+            throw std::invalid_argument("Pocket TTS max_frames must be in [1, 1000]");
+        }
+        if (config_.frames_after_eos < 0 || config_.frames_after_eos > 50) {
+            throw std::invalid_argument("Pocket TTS frames_after_eos must be in [0, 50]");
+        }
+        if (!std::isfinite(config_.temperature) || config_.temperature < 0.0f ||
+            config_.temperature > 10.0f) {
+            throw std::invalid_argument("Pocket TTS temperature must be finite and in [0, 10]");
+        }
+        if (!std::isfinite(config_.eos_threshold)) {
+            throw std::invalid_argument("Pocket TTS eos_threshold must be finite");
+        }
+        if (config_.intra_threads < 1 || config_.intra_threads > 64) {
+            throw std::invalid_argument("Pocket TTS intra_threads must be in [1, 64]");
+        }
+    }
+
+    std::string required_path(const std::string& directory, const char* filename) const {
+        const auto path = path_join(directory, filename);
+        if (!is_file(path)) {
+            throw std::runtime_error("Missing Pocket TTS bundle file: " + path);
+        }
+        return path;
+    }
+
+    SessionPtr load_session(OnnxEngine& engine,
+                            const std::string& path,
+                            bool capture_hint) const {
+        OrtSession* raw = engine.load(
+            path, config_.hardware_acceleration, capture_hint, config_.intra_threads);
+        return SessionPtr(raw, SessionDeleter{api_});
+    }
+
+    ValuePtr adopt(OrtValue* value) const {
+        return ValuePtr(value, ValueDeleter{api_});
+    }
+
+    IoNames query_io(OrtSession* session) const {
+        IoNames names;
+        size_t count = 0;
+        ort_check(api_, api_->SessionGetInputCount(session, &count));
+        names.input_strings.reserve(count);
+        for (size_t index = 0; index < count; ++index) {
+            OrtStringHandle handle{api_, allocator_, nullptr};
+            ort_check(api_, api_->SessionGetInputName(
+                session, index, allocator_, &handle.value));
+            names.input_strings.emplace_back(handle.value);
+        }
+
+        ort_check(api_, api_->SessionGetOutputCount(session, &count));
+        names.output_strings.reserve(count);
+        for (size_t index = 0; index < count; ++index) {
+            OrtStringHandle handle{api_, allocator_, nullptr};
+            ort_check(api_, api_->SessionGetOutputName(
+                session, index, allocator_, &handle.value));
+            names.output_strings.emplace_back(handle.value);
+        }
+
+        names.inputs.reserve(names.input_strings.size());
+        for (const auto& name : names.input_strings) names.inputs.push_back(name.c_str());
+        names.outputs.reserve(names.output_strings.size());
+        for (const auto& name : names.output_strings) names.outputs.push_back(name.c_str());
+        return names;
+    }
+
+    void validate_model_contract() const {
+        require_io(encoder_io_, 1, 1, "audio", "latents", "encoder");
+        require_io(conditioner_io_, 1, 1, "token_ids", "embeddings", "text conditioner");
+        require_io(lm_flow_io_, 4, 1, "c", "flow_dir", "flow model");
+        require_io(lm_main_io_, 20, 20, "sequence", "conditioning", "LM main");
+        require_io(decoder_io_, 57, 57, "latent", "audio_frame", "Mimi decoder");
+    }
+
+    static void require_io(const IoNames& names,
+                           std::size_t inputs,
+                           std::size_t outputs,
+                           const char* first_input,
+                           const char* first_output,
+                           const char* label) {
+        if (names.input_strings.size() != inputs ||
+            names.output_strings.size() != outputs ||
+            names.input_strings.empty() || names.output_strings.empty() ||
+            names.input_strings.front() != first_input ||
+            names.output_strings.front() != first_output) {
+            throw std::runtime_error(
+                std::string("Pocket TTS ") + label + " graph has an incompatible I/O contract");
+        }
+    }
+
+    std::pair<std::vector<std::int64_t>, ONNXTensorElementDataType>
+    input_shape_and_type(OrtSession* session, std::size_t input_index) const {
+        OrtTypeInfo* type_info = nullptr;
+        ort_check(api_, api_->SessionGetInputTypeInfo(session, input_index, &type_info));
+        const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+        OrtStatus* cast_status = api_->CastTypeInfoToTensorInfo(type_info, &tensor_info);
+        if (cast_status != nullptr || tensor_info == nullptr) {
+            if (cast_status) api_->ReleaseStatus(cast_status);
+            api_->ReleaseTypeInfo(type_info);
+            throw std::runtime_error("Pocket TTS model input is not a tensor");
+        }
+
+        ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+        size_t rank = 0;
+        ort_check(api_, api_->GetTensorElementType(tensor_info, &type));
+        ort_check(api_, api_->GetDimensionsCount(tensor_info, &rank));
+        std::vector<std::int64_t> shape(rank);
+        ort_check(api_, api_->GetDimensions(tensor_info, shape.data(), rank));
+        api_->ReleaseTypeInfo(type_info);
+        return {std::move(shape), type};
+    }
+
+    int query_lm_cache_length() const {
+        auto shape_and_type = input_shape_and_type(lm_main_.get(), 2);
+        const auto& shape = shape_and_type.first;
+        if (shape.size() != 5 || shape[2] <= 0) {
+            throw std::runtime_error("Pocket TTS LM cache input has an unexpected shape");
+        }
+        return static_cast<int>(shape[2]);
+    }
+
+    State initial_state(OrtSession* session, std::size_t first_state_input) const {
+        size_t input_count = 0;
+        ort_check(api_, api_->SessionGetInputCount(session, &input_count));
+        State state;
+        state.values.reserve(input_count - first_state_input);
+        for (std::size_t index = first_state_input; index < input_count; ++index) {
+            auto shape_and_type = input_shape_and_type(session, index);
+            for (auto& dimension : shape_and_type.first) {
+                if (dimension < 0) dimension = 1;
+            }
+            state.values.push_back(owned_tensor(
+                shape_and_type.first, shape_and_type.second, true));
+        }
+        return state;
+    }
+
+    ValuePtr owned_tensor(const std::vector<std::int64_t>& shape,
+                          ONNXTensorElementDataType type,
+                          bool zero) const {
+        OrtValue* raw = nullptr;
+        ort_check(api_, api_->CreateTensorAsOrtValue(
+            allocator_, shape.data(), shape.size(), type, &raw));
+        auto value = adopt(raw);
+        if (zero) {
+            const auto count = shape_element_count(shape);
+            if (count > 0) {
+                void* data = nullptr;
+                ort_check(api_, api_->GetTensorMutableData(value.get(), &data));
+                std::memset(data, 0, count * element_size(type));
+            }
+        }
+        return value;
+    }
+
+    template <typename T>
+    ValuePtr tensor_view(T* data,
+                         std::size_t count,
+                         const std::vector<std::int64_t>& shape,
+                         ONNXTensorElementDataType type) const {
+        static T empty_value{};
+        OrtValue* raw = nullptr;
+        T* pointer = count == 0 ? &empty_value : data;
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            memory_, pointer, count * sizeof(T), shape.data(), shape.size(), type, &raw));
+        return adopt(raw);
+    }
+
+    std::vector<ValuePtr> run(OrtSession* session,
+                              const IoNames& names,
+                              const std::vector<const OrtValue*>& inputs) const {
+        if (inputs.size() != names.inputs.size()) {
+            throw std::runtime_error("Pocket TTS internal input count mismatch");
+        }
+        std::vector<OrtValue*> raw_outputs(names.outputs.size(), nullptr);
+        OrtStatus* status = api_->Run(
+            session, nullptr, names.inputs.data(), inputs.data(), inputs.size(),
+            names.outputs.data(), names.outputs.size(), raw_outputs.data());
+        if (status != nullptr) {
+            for (auto* output : raw_outputs) {
+                if (output) api_->ReleaseValue(output);
+            }
+            ort_check(api_, status);
+        }
+
+        std::vector<ValuePtr> outputs;
+        outputs.reserve(raw_outputs.size());
+        for (auto* output : raw_outputs) outputs.push_back(adopt(output));
+        return outputs;
+    }
+
+    std::pair<ValuePtr, ValuePtr> run_lm(const OrtValue* sequence,
+                                         const OrtValue* embedding,
+                                         State& state) const {
+        std::vector<const OrtValue*> inputs;
+        inputs.reserve(2 + state.values.size());
+        inputs.push_back(sequence);
+        inputs.push_back(embedding);
+        for (const auto& value : state.values) inputs.push_back(value.get());
+
+        auto outputs = run(lm_main_.get(), lm_main_io_, inputs);
+        std::vector<ValuePtr> new_state;
+        new_state.reserve(outputs.size() - 2);
+        for (std::size_t index = 2; index < outputs.size(); ++index) {
+            new_state.push_back(std::move(outputs[index]));
+        }
+        state.values = std::move(new_state);
+        return {std::move(outputs[0]), std::move(outputs[1])};
+    }
+
+    std::vector<float> run_flow(const OrtValue* conditioning,
+                                const std::vector<float>& noise) const {
+        std::vector<float> latent = noise;
+        float start = 0.0f;
+        float end = 0.0f;
+        const std::vector<std::int64_t> scalar_shape = {1, 1};
+        auto start_tensor = tensor_view(
+            &start, 1, scalar_shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+        auto end_tensor = tensor_view(
+            &end, 1, scalar_shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+        auto latent_tensor = tensor_view(
+            latent.data(), latent.size(), {1, 32}, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+        const float delta = 1.0f / static_cast<float>(config_.flow_steps);
+
+        for (int step = 0; step < config_.flow_steps; ++step) {
+            start = static_cast<float>(step) / static_cast<float>(config_.flow_steps);
+            end = start + delta;
+            const std::vector<const OrtValue*> inputs = {
+                conditioning, start_tensor.get(), end_tensor.get(), latent_tensor.get()};
+            auto outputs = run(lm_flow_.get(), lm_flow_io_, inputs);
+            if (tensor_element_count(outputs[0].get()) != latent.size()) {
+                throw std::runtime_error("Pocket TTS flow graph returned an unexpected shape");
+            }
+            float* direction = nullptr;
+            ort_check(api_, api_->GetTensorMutableData(
+                outputs[0].get(), reinterpret_cast<void**>(&direction)));
+            for (std::size_t index = 0; index < latent.size(); ++index) {
+                latent[index] += direction[index] * delta;
+            }
+        }
+        return latent;
+    }
+
+    ValuePtr run_decoder(const OrtValue* latent, State& state) const {
+        std::vector<const OrtValue*> inputs;
+        inputs.reserve(1 + state.values.size());
+        inputs.push_back(latent);
+        for (const auto& value : state.values) inputs.push_back(value.get());
+
+        auto outputs = run(decoder_.get(), decoder_io_, inputs);
+        std::vector<ValuePtr> new_state;
+        new_state.reserve(outputs.size() - 1);
+        for (std::size_t index = 1; index < outputs.size(); ++index) {
+            new_state.push_back(std::move(outputs[index]));
+        }
+        state.values = std::move(new_state);
+        return std::move(outputs[0]);
+    }
+
+    ValuePtr create_voice_embedding() const {
+        float placeholder = 0.0f;
+        auto audio = tensor_view(
+            &placeholder, 1, {1, 1, 1}, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT);
+        const std::vector<const OrtValue*> inputs = {audio.get()};
+        auto outputs = run(encoder_.get(), encoder_io_, inputs);
+        return std::move(outputs[0]);
+    }
+
+    std::vector<std::int64_t> tensor_shape(const OrtValue* value) const {
+        OrtTensorTypeAndShapeInfo* info = nullptr;
+        ort_check(api_, api_->GetTensorTypeAndShape(value, &info));
+        size_t rank = 0;
+        ort_check(api_, api_->GetDimensionsCount(info, &rank));
+        std::vector<std::int64_t> shape(rank);
+        ort_check(api_, api_->GetDimensions(info, shape.data(), rank));
+        api_->ReleaseTensorTypeAndShapeInfo(info);
+        return shape;
+    }
+
+    std::size_t tensor_element_count(const OrtValue* value) const {
+        OrtTensorTypeAndShapeInfo* info = nullptr;
+        ort_check(api_, api_->GetTensorTypeAndShape(value, &info));
+        size_t count = 0;
+        ort_check(api_, api_->GetTensorShapeElementCount(info, &count));
+        api_->ReleaseTensorTypeAndShapeInfo(info);
+        return count;
+    }
+
+    float first_float(OrtValue* value) const {
+        if (tensor_element_count(value) < 1) {
+            throw std::runtime_error("Pocket TTS EOS output is empty");
+        }
+        float* data = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(
+            value, reinterpret_cast<void**>(&data)));
+        return data[0];
+    }
+
+    std::uint32_t resolve_seed() const {
+        if (config_.seed >= 0) return static_cast<std::uint32_t>(config_.seed);
+        std::random_device source;
+        std::seed_seq sequence{source(), source(), source(), source()};
+        std::vector<std::uint32_t> output(1);
+        sequence.generate(output.begin(), output.end());
+        return output[0];
+    }
+
+    void publish_metrics(const PocketTtsMetrics& metrics) {
+        std::lock_guard<std::mutex> lock(metrics_mutex_);
+        last_metrics_ = metrics;
+    }
+
+    PocketTtsConfig config_;
+    const OrtApi* api_ = nullptr;
+    OrtMemoryInfo* memory_ = nullptr;
+    OrtAllocator* allocator_ = nullptr;
+
+    SessionPtr lm_main_{nullptr, SessionDeleter{}};
+    SessionPtr lm_flow_{nullptr, SessionDeleter{}};
+    SessionPtr decoder_{nullptr, SessionDeleter{}};
+    SessionPtr conditioner_{nullptr, SessionDeleter{}};
+    SessionPtr encoder_{nullptr, SessionDeleter{}};
+    IoNames lm_main_io_;
+    IoNames lm_flow_io_;
+    IoNames decoder_io_;
+    IoNames conditioner_io_;
+    IoNames encoder_io_;
+
+    std::unique_ptr<PocketTtsTokenizer> tokenizer_;
+    ValuePtr voice_embedding_{nullptr, ValueDeleter{}};
+    int voice_tokens_ = 0;
+    int lm_cache_length_ = 0;
+
+    std::mutex synthesis_mutex_;
+    std::atomic<bool> cancelled_{false};
+    mutable std::mutex metrics_mutex_;
+    PocketTtsMetrics last_metrics_;
+};
+
+OnnxPocketTts::OnnxPocketTts(const std::string& bundle_directory,
+                             PocketTtsConfig config)
+    : impl_(std::make_unique<Impl>(bundle_directory, config)) {}
+
+OnnxPocketTts::~OnnxPocketTts() = default;
+
+void OnnxPocketTts::synthesize(const std::string& text,
+                               const std::string& language,
+                               TTSChunkCallback on_chunk) {
+    impl_->synthesize(text, language, std::move(on_chunk));
+}
+
+void OnnxPocketTts::cancel() {
+    impl_->cancel();
+}
+
+PocketTtsMetrics OnnxPocketTts::last_metrics() const {
+    return impl_->last_metrics();
+}
+
+}  // namespace speech_core

--- a/src/models/pocket/pocket_tts_tokenizer.cpp
+++ b/src/models/pocket/pocket_tts_tokenizer.cpp
@@ -1,0 +1,219 @@
+#include "speech_core/models/pocket_tts_tokenizer.h"
+
+#include "nlohmann/json.hpp"
+
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace speech_core {
+
+namespace {
+
+// The dynamic-programming tokenization scheme is adapted from sherpa-onnx's
+// SentencePieceTokenizer (Apache-2.0, Copyright 2026 Xiaomi Corporation).
+// It consumes the same vocab.json/token_scores.json representation produced
+// by the Pocket TTS ONNX exporter.
+constexpr float kNegativeInfinity = -1.0e30f;
+
+nlohmann::json load_json(const std::string& filename) {
+    if (filename.empty()) {
+        throw std::invalid_argument("Pocket TTS tokenizer JSON path is empty");
+    }
+    std::ifstream stream(filename);
+    if (!stream) {
+        throw std::runtime_error("Cannot open Pocket TTS tokenizer file: " + filename);
+    }
+    nlohmann::json value;
+    stream >> value;
+    if (!value.is_object()) {
+        throw std::runtime_error("Pocket TTS tokenizer file is not a JSON object: " + filename);
+    }
+    return value;
+}
+
+}  // namespace
+
+class PocketTtsTokenizer::Impl {
+public:
+    Impl(const std::string& vocab_json, const std::string& token_scores_json) {
+        const auto vocabulary = load_json(vocab_json);
+        const auto scores = load_json(token_scores_json);
+        if (vocabulary.size() != scores.size()) {
+            throw std::runtime_error("Pocket TTS vocabulary and score table sizes differ");
+        }
+
+        token_to_id_.reserve(vocabulary.size());
+        id_to_token_.resize(vocabulary.size());
+        for (const auto& item : vocabulary.items()) {
+            const auto id = item.value().get<std::int32_t>();
+            if (id < 0 || static_cast<std::size_t>(id) >= id_to_token_.size()) {
+                throw std::runtime_error("Pocket TTS vocabulary contains an out-of-range token ID");
+            }
+            token_to_id_.emplace(item.key(), id);
+            id_to_token_[static_cast<std::size_t>(id)] = item.key();
+        }
+
+        token_to_score_.reserve(scores.size());
+        for (const auto& item : scores.items()) {
+            token_to_score_.emplace(item.key(), item.value().get<float>());
+        }
+
+        byte_token_id_.fill(-1);
+        byte_token_score_.fill(kNegativeInfinity);
+        build_trie();
+    }
+
+    std::vector<std::int32_t> encode_ids(const std::string& text) const {
+        std::vector<std::int32_t> ids;
+        encode(text, &ids, nullptr);
+        return ids;
+    }
+
+    std::vector<std::string> encode_tokens(const std::string& text) const {
+        std::vector<std::string> tokens;
+        encode(text, nullptr, &tokens);
+        return tokens;
+    }
+
+private:
+    struct TrieNode {
+        std::unordered_map<unsigned char, std::int32_t> next;
+        std::int32_t token_id = -1;
+        float score = 0.0f;
+    };
+
+    void build_trie() {
+        trie_.reserve(token_to_id_.size() * 2);
+        trie_.emplace_back();
+
+        for (const auto& entry : token_to_id_) {
+            const std::string& token = entry.first;
+            std::int32_t node = 0;
+            for (const unsigned char byte : token) {
+                auto next = trie_[static_cast<std::size_t>(node)].next.find(byte);
+                if (next == trie_[static_cast<std::size_t>(node)].next.end()) {
+                    const auto new_node = static_cast<std::int32_t>(trie_.size());
+                    trie_[static_cast<std::size_t>(node)].next.emplace(byte, new_node);
+                    trie_.emplace_back();
+                    node = new_node;
+                } else {
+                    node = next->second;
+                }
+            }
+            const auto score = token_to_score_.find(token);
+            if (score == token_to_score_.end()) {
+                throw std::runtime_error("Pocket TTS token is missing its score: " + token);
+            }
+            auto& leaf = trie_[static_cast<std::size_t>(node)];
+            leaf.token_id = entry.second;
+            leaf.score = score->second;
+        }
+
+        for (std::int32_t byte = 0; byte < 256; ++byte) {
+            char name[8];
+            std::snprintf(name, sizeof(name), "<0x%02X>", byte);
+            const auto id = token_to_id_.find(name);
+            const auto score = token_to_score_.find(name);
+            if (id != token_to_id_.end() && score != token_to_score_.end()) {
+                byte_token_id_[static_cast<std::size_t>(byte)] = id->second;
+                byte_token_score_[static_cast<std::size_t>(byte)] = score->second;
+            }
+        }
+    }
+
+    void encode(const std::string& input,
+                std::vector<std::int32_t>* ids,
+                std::vector<std::string>* tokens) const {
+        std::string text;
+        text.reserve(input.size() + 8);
+        for (const char character : input) {
+            if (character == ' ') {
+                text.append("\xE2\x96\x81");  // SentencePiece whitespace marker: U+2581.
+            } else {
+                text.push_back(character);
+            }
+        }
+        if (text.rfind("\xE2\x96\x81", 0) != 0) {
+            text.insert(0, "\xE2\x96\x81");
+        }
+
+        const auto length = static_cast<std::int32_t>(text.size());
+        std::vector<float> best(static_cast<std::size_t>(length + 1), kNegativeInfinity);
+        std::vector<std::int32_t> back(static_cast<std::size_t>(length + 1), -1);
+        std::vector<std::int32_t> back_id(static_cast<std::size_t>(length + 1), -1);
+        best[static_cast<std::size_t>(length)] = 0.0f;
+
+        for (std::int32_t start = length - 1; start >= 0; --start) {
+            std::int32_t node = 0;
+            for (std::int32_t end = start; end < length; ++end) {
+                const auto byte = static_cast<unsigned char>(text[static_cast<std::size_t>(end)]);
+                const auto next = trie_[static_cast<std::size_t>(node)].next.find(byte);
+                if (next == trie_[static_cast<std::size_t>(node)].next.end()) {
+                    break;
+                }
+                node = next->second;
+                const auto& candidate = trie_[static_cast<std::size_t>(node)];
+                if (candidate.token_id >= 0) {
+                    const float score = candidate.score + best[static_cast<std::size_t>(end + 1)];
+                    if (score > best[static_cast<std::size_t>(start)]) {
+                        best[static_cast<std::size_t>(start)] = score;
+                        back[static_cast<std::size_t>(start)] = end + 1;
+                        back_id[static_cast<std::size_t>(start)] = candidate.token_id;
+                    }
+                }
+            }
+
+            if (back[static_cast<std::size_t>(start)] < 0) {
+                const auto byte = static_cast<unsigned char>(text[static_cast<std::size_t>(start)]);
+                const auto fallback_id = byte_token_id_[byte];
+                if (fallback_id >= 0) {
+                    best[static_cast<std::size_t>(start)] =
+                        byte_token_score_[byte] + best[static_cast<std::size_t>(start + 1)];
+                    back_id[static_cast<std::size_t>(start)] = fallback_id;
+                }
+                back[static_cast<std::size_t>(start)] = start + 1;
+            }
+        }
+
+        for (std::int32_t offset = 0; offset < length;) {
+            const auto next = back[static_cast<std::size_t>(offset)];
+            const auto id = back_id[static_cast<std::size_t>(offset)];
+            if (next <= offset || id < 0 || static_cast<std::size_t>(id) >= id_to_token_.size()) {
+                throw std::runtime_error("Pocket TTS tokenizer could not reconstruct its best path");
+            }
+            if (ids) ids->push_back(id);
+            if (tokens) tokens->push_back(id_to_token_[static_cast<std::size_t>(id)]);
+            offset = next;
+        }
+    }
+
+    std::vector<TrieNode> trie_;
+    std::vector<std::string> id_to_token_;
+    std::unordered_map<std::string, std::int32_t> token_to_id_;
+    std::unordered_map<std::string, float> token_to_score_;
+    std::array<std::int32_t, 256> byte_token_id_{};
+    std::array<float, 256> byte_token_score_{};
+};
+
+PocketTtsTokenizer::PocketTtsTokenizer(const std::string& vocab_json,
+                                       const std::string& token_scores_json)
+    : impl_(std::make_unique<Impl>(vocab_json, token_scores_json)) {}
+
+PocketTtsTokenizer::~PocketTtsTokenizer() = default;
+PocketTtsTokenizer::PocketTtsTokenizer(PocketTtsTokenizer&&) noexcept = default;
+PocketTtsTokenizer& PocketTtsTokenizer::operator=(PocketTtsTokenizer&&) noexcept = default;
+
+std::vector<std::int32_t> PocketTtsTokenizer::encode_ids(const std::string& text) const {
+    return impl_->encode_ids(text);
+}
+
+std::vector<std::string> PocketTtsTokenizer::encode_tokens(const std::string& text) const {
+    return impl_->encode_tokens(text);
+}
+
+}  // namespace speech_core

--- a/tests/bench_ort_models.cpp
+++ b/tests/bench_ort_models.cpp
@@ -33,7 +33,9 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <psapi.h>
 #pragma comment(lib, "psapi.lib")

--- a/tests/test_pocket_tts.cpp
+++ b/tests/test_pocket_tts.cpp
@@ -1,0 +1,99 @@
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "speech_core/models/onnx_pocket_tts.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string bundle_path() {
+    const char* value = std::getenv("SPEECH_POCKET_TTS_BUNDLE");
+    return value ? value : "";
+}
+
+void test_streaming_frame_contract(speech_core::OnnxPocketTts& tts) {
+    int audio_callbacks = 0;
+    int final_callbacks = 0;
+    std::size_t sample_count = 0;
+    float peak = 0.0f;
+    tts.synthesize("Hello world.", "en", [&](const float* samples,
+                                               std::size_t length,
+                                               bool final) {
+        if (final) {
+            ++final_callbacks;
+            assert(samples == nullptr);
+            assert(length == 0);
+            return;
+        }
+        ++audio_callbacks;
+        assert(samples != nullptr);
+        assert(length == 1920);
+        sample_count += length;
+        for (std::size_t index = 0; index < length; ++index) {
+            assert(std::isfinite(samples[index]));
+            peak = std::max(peak, std::abs(samples[index]));
+        }
+    });
+
+    const auto metrics = tts.last_metrics();
+    assert(audio_callbacks > 0);
+    assert(final_callbacks == 1);
+    assert(sample_count == static_cast<std::size_t>(audio_callbacks) * 1920);
+    assert(metrics.frames_generated == audio_callbacks);
+    assert(metrics.output_samples == static_cast<int>(sample_count));
+    assert(metrics.first_audio_ms > metrics.conditioning_ms);
+    assert(metrics.total_ms >= metrics.first_audio_ms);
+    assert(metrics.stopped_on_eos);
+    assert(!metrics.cancelled);
+    assert(peak > 0.01f && peak <= 1.5f);
+    std::printf("  PASS: streaming_frame_contract (%d frames)\n", audio_callbacks);
+}
+
+void test_callback_can_cancel(speech_core::OnnxPocketTts& tts) {
+    int audio_callbacks = 0;
+    int final_callbacks = 0;
+    tts.synthesize("This sentence would normally generate several frames.", "en",
+        [&](const float*, std::size_t length, bool final) {
+            if (final) {
+                ++final_callbacks;
+                return;
+            }
+            assert(length == 1920);
+            ++audio_callbacks;
+            tts.cancel();
+        });
+    const auto metrics = tts.last_metrics();
+    assert(audio_callbacks == 1);
+    assert(final_callbacks == 1);
+    assert(metrics.frames_generated == 1);
+    assert(metrics.cancelled);
+    std::printf("  PASS: callback_can_cancel\n");
+}
+
+}  // namespace
+
+int main() {
+    const std::string bundle = bundle_path();
+    if (bundle.empty()) {
+        std::printf("SKIP: SPEECH_POCKET_TTS_BUNDLE is unset\n");
+        return 0;
+    }
+
+    speech_core::PocketTtsConfig config;
+    config.seed = 42;
+    config.max_frames = 100;
+    config.intra_threads = 2;
+    speech_core::OnnxPocketTts tts(bundle, config);
+    test_streaming_frame_contract(tts);
+    test_callback_can_cancel(tts);
+    std::printf("All Pocket TTS integration tests passed.\n");
+    return 0;
+}

--- a/tests/test_pocket_tts_tokenizer.cpp
+++ b/tests/test_pocket_tts_tokenizer.cpp
@@ -1,0 +1,116 @@
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "speech_core/models/pocket_tts_tokenizer.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Fixture {
+    std::filesystem::path directory;
+    std::filesystem::path vocabulary;
+    std::filesystem::path scores;
+
+    Fixture() {
+        const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+        directory = std::filesystem::temp_directory_path() /
+            ("speech-core-pocket-tokenizer-" + std::to_string(suffix));
+        std::filesystem::create_directories(directory);
+        vocabulary = directory / "vocab.json";
+        scores = directory / "token_scores.json";
+
+        std::ofstream(vocabulary) << R"({
+  "<unk>": 0,
+  "\u2581hello": 1,
+  "\u2581world": 2,
+  ".": 3,
+  "\u2581": 4,
+  "a": 5,
+  "\u2581a": 6,
+  "<0xC3>": 7,
+  "<0xA9>": 8
+})";
+        std::ofstream(scores) << R"({
+  "<unk>": -100.0,
+  "\u2581hello": -1.0,
+  "\u2581world": -1.0,
+  ".": -0.1,
+  "\u2581": -0.1,
+  "a": -0.1,
+  "\u2581a": -1.0,
+  "<0xC3>": -2.0,
+  "<0xA9>": -2.0
+})";
+    }
+
+    ~Fixture() {
+        std::error_code ignored;
+        std::filesystem::remove_all(directory, ignored);
+    }
+};
+
+void test_words_and_whitespace() {
+    Fixture fixture;
+    speech_core::PocketTtsTokenizer tokenizer(
+        fixture.vocabulary.string(), fixture.scores.string());
+    assert((tokenizer.encode_ids("hello world.") ==
+            std::vector<std::int32_t>{1, 2, 3}));
+    assert((tokenizer.encode_tokens("hello world.") ==
+            std::vector<std::string>{"\xE2\x96\x81hello", "\xE2\x96\x81world", "."}));
+    std::printf("  PASS: words_and_whitespace\n");
+}
+
+void test_unigram_scores_choose_best_path() {
+    Fixture fixture;
+    speech_core::PocketTtsTokenizer tokenizer(
+        fixture.vocabulary.string(), fixture.scores.string());
+    // Split marker + character scores -0.2, which beats the -1.0 whole token.
+    assert((tokenizer.encode_ids("a") == std::vector<std::int32_t>{4, 5}));
+    std::printf("  PASS: unigram_scores_choose_best_path\n");
+}
+
+void test_utf8_byte_fallback() {
+    Fixture fixture;
+    speech_core::PocketTtsTokenizer tokenizer(
+        fixture.vocabulary.string(), fixture.scores.string());
+    assert((tokenizer.encode_ids("\xC3\xA9") ==
+            std::vector<std::int32_t>{4, 7, 8}));
+    std::printf("  PASS: utf8_byte_fallback\n");
+}
+
+void test_real_bundle_when_available() {
+    const char* bundle = std::getenv("SPEECH_POCKET_TTS_BUNDLE");
+    if (!bundle || bundle[0] == '\0') {
+        std::printf("  SKIP: real_bundle (SPEECH_POCKET_TTS_BUNDLE unset)\n");
+        return;
+    }
+    const auto root = std::filesystem::path(bundle);
+    speech_core::PocketTtsTokenizer tokenizer(
+        (root / "vocab.json").string(), (root / "token_scores.json").string());
+    assert((tokenizer.encode_ids("Hello world.") ==
+            std::vector<std::int32_t>{2994, 578, 263}));
+    assert((tokenizer.encode_ids("I can call your contacts,") ==
+            std::vector<std::int32_t>{268, 303, 583, 312, 331, 2444, 261, 262}));
+    std::printf("  PASS: real_bundle\n");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("test_pocket_tts_tokenizer:\n");
+    test_words_and_whitespace();
+    test_unigram_scores_choose_best_path();
+    test_utf8_byte_fallback();
+    test_real_bundle_when_available();
+    std::printf("All Pocket TTS tokenizer tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a C++17 `OnnxPocketTts` backend that interleaves one autoregressive latent frame with one Mimi decoder frame, emitting playable 80 ms chunks
- add the SentencePiece-compatible Pocket tokenizer, model-contract validation, deterministic metrics, cancellation, and streaming tests
- add a checksum-pinned downloader for `soniqo/Pocket-TTS-100M-ONNX-INT8@v1.0.0`
- add a device benchmark plus a 46-phrase Pocket TTS -> Parakeet-EOU intelligibility gate
- document runtime usage, Galaxy S23 results, CC BY 4.0 licensing, Alba MacKenna attribution, English-only scope, and no arbitrary voice cloning

Published bundle: https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8  
Release: `v1.0.0` / `ad5d3fae3fb2f10024583708597afca8337c094c`

## Test plan

- `cmake --build build-pocket-default --config Release`
- `ctest --test-dir build-pocket-default -C Release --output-on-failure` — 21/21 passed
- ONNX build and explicit `speech_pocket_tts_bench` / `speech_pocket_tts_roundtrip` targets
- `SPEECH_POCKET_TTS_BUNDLE=<anonymous-v1.0.0-snapshot> ctest --test-dir build-pocket-onnx -C Release --output-on-failure` — 24/24 passed
- Android NDK arm64-v8a cross-build passed
- downloader syntax and all release SHA-256 checks passed
- Galaxy S23 Ultra, Android 16, ORT CPU, two threads: TTFA p50/p95 130.0/136.0 ms; total p50/p95 459.4/480.4 ms; median RTF 0.442; peak RSS 373.1 MiB
- exact-head physical-device round trip: 46 phrases, 31 exact, 8.00% WER, 3.47% CER, zero empty audio, empty transcript, or EOS failure; gate passed