### PR TITLE
Fix DeepFilterNet3 DSP parity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,16 @@ endif()
 # speech_core — orchestration core (always built, no ML deps)
 # ---------------------------------------------------------------------------
 
+# The project enables CXX only, so build the C++-clean kissfft sources as C++.
+# Keeping one copy in speech_core lets both the ONNX DeepFilterNet3 frontend
+# and the LiteRT Indic-Mio ISTFT use arbitrary-size real FFTs without duplicate
+# symbols when both optional model targets are linked into one application.
+set_source_files_properties(
+    third_party/kissfft/kiss_fft.c
+    third_party/kissfft/kiss_fftr.c
+    PROPERTIES LANGUAGE CXX
+)
+
 add_library(speech_core
     src/pipeline/voice_pipeline.cpp
     src/pipeline/turn_detector.cpp
@@ -38,6 +48,8 @@ add_library(speech_core
     src/audio/offline_spectral_de_esser.cpp
     third_party/fftooura/ooura_fft_engine.cpp
     third_party/fftooura/fft4g.cpp
+    third_party/kissfft/kiss_fft.c
+    third_party/kissfft/kiss_fftr.c
     src/audio/mel.cpp
     src/audio/stft.cpp
     src/audio/seamless_fbank.cpp
@@ -61,6 +73,7 @@ target_include_directories(speech_core
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/fftooura
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/kissfft
 )
 
 if(MSVC)
@@ -124,6 +137,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/pocket/onnx_pocket_tts.cpp
         src/models/pocket/pocket_tts_tokenizer.cpp
         src/models/deepfilter/deepfilter.cpp
+        src/models/deepfilter/deepfilter_dsp.cpp
         src/models/sidon/onnx_sidon_restorer.cpp
         src/models/cosyvoice3/onnx_cosyvoice3_tts.cpp
         src/models/voxcpm/onnx_voxcpm_tts.cpp
@@ -309,10 +323,6 @@ if(SPEECH_CORE_WITH_LITERT)
         src/models/litert/indic_mio_istft.cpp
         src/models/litert/litert_indic_mio_tts.cpp
         src/models/litert/indic_mio_c.cpp
-        # kissfft (BSD-3): arbitrary-N real FFT for the Indic-Mio host ISTFT
-        # (n_fft 1920 = 2^7*3*5; the in-tree Ooura engine is radix-2 only).
-        third_party/kissfft/kiss_fft.c
-        third_party/kissfft/kiss_fftr.c
     )
 
     # Kokoro uses the legacy TensorFlow Lite interpreter C API. The validated
@@ -326,14 +336,6 @@ if(SPEECH_CORE_WITH_LITERT)
         target_compile_definitions(speech_core_models_litert
             PUBLIC SPEECH_CORE_HAS_LITERT_KOKORO=1)
     endif()
-
-    # The project enables CXX only, so .c sources would be silently dropped —
-    # build the (C++-clean) kissfft translation units as C++.
-    set_source_files_properties(
-        third_party/kissfft/kiss_fft.c
-        third_party/kissfft/kiss_fftr.c
-        PROPERTIES LANGUAGE CXX
-    )
 
     target_include_directories(speech_core_models_litert
         PUBLIC
@@ -595,6 +597,7 @@ if(SPEECH_CORE_BUILD_TESTS)
         # LiteRT — handled below when SPEECH_CORE_WITH_LITERT=ON.
         if(TEST_NAME STREQUAL "test_models" OR TEST_NAME STREQUAL "test_litert_models"
            OR TEST_NAME STREQUAL "test_litert_chatterbox"
+           OR TEST_NAME STREQUAL "test_deepfilter_dsp"
            OR TEST_NAME STREQUAL "test_hf_download"
            OR TEST_NAME STREQUAL "test_litert_voxcpm2_clone_cli"
            OR TEST_NAME STREQUAL "test_indic_mio_istft"
@@ -613,6 +616,21 @@ if(SPEECH_CORE_BUILD_TESTS)
         target_link_libraries(${TEST_NAME} PRIVATE speech_core)
         add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     endforeach()
+
+    # DeepFilterNet3's frontend/postfilter is pure DSP but normally compiled
+    # into the optional ONNX target. Build it directly here so native-960 FFT,
+    # normalization/layout, temporal filtering, and delay parity remain covered
+    # in the dependency-free test configuration too.
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_deepfilter_dsp.cpp)
+        add_executable(test_deepfilter_dsp
+            tests/test_deepfilter_dsp.cpp
+            src/models/deepfilter/deepfilter_dsp.cpp)
+        target_include_directories(test_deepfilter_dsp PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+        target_link_libraries(test_deepfilter_dsp PRIVATE speech_core)
+        add_test(NAME test_deepfilter_dsp COMMAND test_deepfilter_dsp)
+    endif()
 
     # HF downloader decision-logic test — the pure resume/skip/restart rules
     # behind sc_voxcpm2_create_from_pretrained. Needs no libcurl or LiteRT, so it

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -67,6 +67,15 @@ for the complete texts.
 - Copyright Takuya OOURA, 1996-2001.
 - **Used by:** `speech_core::audio::fft_real` / `speech_core::audio::ifft_real`
 
+### KISS FFT
+
+- **Files:** `third_party/kissfft/`
+- **Source:** https://github.com/mborgerding/kissfft
+- **License:** BSD 3-Clause (see `third_party/kissfft/COPYING`)
+- Copyright (c) 2003-2010 Mark Borgerding.
+- **Used by:** the native 960-point DeepFilterNet3 STFT/iSTFT and the
+  arbitrary-size Indic-Mio host ISTFT.
+
 ## Models
 
 No machine-learning models are included in any speech-core package. Models

--- a/docs/models.md
+++ b/docs/models.md
@@ -1073,8 +1073,7 @@ Voice embeddings are 256-float `.bin` files in `voices_dir`. Default voice is `a
 #include <speech_core/models/deepfilter.h>
 
 speech_core::DeepFilterEnhancer enh(
-    "/models/deepfilter.onnx",
-    "/models/deepfilter_aux.bin");
+    "/models/deepfilter.onnx");
 
 std::vector<float> clean(audio.size());
 enh.enhance(audio.data(), audio.size(), 48000, clean.data());
@@ -1082,9 +1081,18 @@ enh.enhance(audio.data(), audio.size(), 48000, clean.data());
 
 - DeepFilterNet3 — ~2.1M params, real-time speech enhancement
 - 48 kHz input (caller must resample if needed)
-- STFT (960/480) → ERB filterbank → neural mask + deep filter coefficients → inverse STFT
-- Auxiliary binary file holds precomputed ERB filterbanks and Vorbis window: `erb_fb [481*32] | erb_inv_fb [32*481] | window [960]` (float32)
-- Model files: [soniqo/DeepFilterNet3-ONNX](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) — `deepfilter.onnx` (~8 MB FP16), `deepfilter-auxiliary.bin`
+- Native 960-point STFT (480-sample hop) with libdf analysis scaling, ERB and
+  complex-feature normalization, neural mask + deep-filter coefficients, and
+  streaming overlap-add with 480-sample delay compensation
+- The canonical Vorbis window, disjoint ERB widths, and normalization states
+  are generated in-process. The optional legacy `auxiliary_path` argument
+  accepts `deepfilter-auxiliary.bin` and validates it for compatibility, but
+  does not trust artifact matrices for inference.
+- The ONNX graph contract is `feat_erb [1,1,T,32]`,
+  `feat_spec [1,2,T,96]` → `erb_mask [1,1,T,32]`,
+  `df_coefs [1,5,T,96,2]`; incompatible output shapes fail explicitly.
+- Distribution repository: [soniqo/DeepFilterNet3-ONNX](https://huggingface.co/soniqo/DeepFilterNet3-ONNX). The runtime needs `deepfilter.onnx`
+  (~8.2 MiB, FP32); `deepfilter-auxiliary.bin` is legacy/optional.
 
 ## OnnxSidonRestorer
 

--- a/include/speech_core/models/deepfilter.h
+++ b/include/speech_core/models/deepfilter.h
@@ -24,9 +24,12 @@ public:
         int sample_rate = 48000;
     };
 
-    DeepFilterEnhancer(const std::string& model_path,
-                       const std::string& auxiliary_path,
-                       bool hw_accel = true);
+    /// Canonical DSP tables are generated in-process. An optional legacy
+    /// auxiliary file is checked for parity, but its matrices are never
+    /// trusted for inference.
+    explicit DeepFilterEnhancer(const std::string& model_path,
+                                const std::string& auxiliary_path = {},
+                                bool hw_accel = true);
     ~DeepFilterEnhancer() override;
 
     /// Enhance audio by removing noise.
@@ -41,24 +44,16 @@ public:
 
 private:
     void load_auxiliary(const std::string& path);
-    void compute_erb_features(const float* spectrum_real,
-                              const float* spectrum_imag,
-                              int num_frames,
-                              std::vector<float>& feat_erb,
-                              std::vector<float>& feat_spec);
-    void apply_erb_mask(float* spectrum_real, float* spectrum_imag,
-                        const float* mask, int num_frames);
-    void apply_deep_filter(float* spectrum_real, float* spectrum_imag,
-                           const float* coefs, int num_frames);
 
-    const OrtApi* api_;
+    const OrtApi* api_ = nullptr;
     OrtSession* session_ = nullptr;
     Config cfg_;
 
-    // ERB filterbanks
-    std::vector<float> erb_fb_;       // [freq_bins, erb_bands]
-    std::vector<float> erb_inv_fb_;   // [erb_bands, freq_bins]
-    std::vector<float> window_;       // Vorbis window [fft_size]
+    // Canonical libdf frontend data. The historical auxiliary path remains in
+    // the constructor for bundle compatibility, but these values are derived
+    // in-process so a transposed/normalized artifact cannot corrupt audio.
+    std::vector<int> erb_widths_;
+    std::vector<float> window_;
 };
 
 }  // namespace speech_core

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -36,8 +36,9 @@ FILES=(
     "Kokoro-82M-ONNX/dict_pt.json"
     "Kokoro-82M-ONNX/dict_hi.json"
     "Kokoro-82M-ONNX/voices/af_heart.bin"
+    # DeepFilterNet3's libdf DSP tables are generated in-process, so the legacy
+    # auxiliary binary is no longer a runtime dependency.
     "DeepFilterNet3-ONNX/deepfilter.onnx"
-    "DeepFilterNet3-ONNX/deepfilter-auxiliary.bin"
 )
 
 for entry in "${FILES[@]}"; do

--- a/src/models/deepfilter/deepfilter.cpp
+++ b/src/models/deepfilter/deepfilter.cpp
@@ -1,23 +1,93 @@
 #include "speech_core/models/deepfilter.h"
 
-#include "speech_core/audio/stft.h"
+#include "deepfilter_dsp.h"
 #include "speech_core/models/onnx_engine.h"
 
+#include <algorithm>
 #include <cmath>
-#include <cstring>
 #include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace speech_core {
+namespace {
+
+deepfilter_dsp::Config to_dsp_config(const DeepFilterEnhancer::Config& cfg) {
+    deepfilter_dsp::Config out;
+    out.fft_size = cfg.fft_size;
+    out.hop_size = cfg.hop_size;
+    out.erb_bands = cfg.erb_bands;
+    out.df_bins = cfg.df_bins;
+    out.df_order = cfg.df_order;
+    out.df_lookahead = cfg.df_lookahead;
+    out.freq_bins = cfg.freq_bins;
+    out.sample_rate = cfg.sample_rate;
+    return out;
+}
+
+class OrtValueGuard {
+public:
+    OrtValueGuard(const OrtApi* api, OrtValue* value) : api_(api), value_(value) {}
+    ~OrtValueGuard() {
+        if (value_) api_->ReleaseValue(value_);
+    }
+    OrtValueGuard(const OrtValueGuard&) = delete;
+    OrtValueGuard& operator=(const OrtValueGuard&) = delete;
+    OrtValue* get() const { return value_; }
+
+private:
+    const OrtApi* api_;
+    OrtValue* value_;
+};
+
+class OrtShapeGuard {
+public:
+    OrtShapeGuard(const OrtApi* api, OrtTensorTypeAndShapeInfo* info)
+        : api_(api), info_(info) {}
+    ~OrtShapeGuard() { api_->ReleaseTensorTypeAndShapeInfo(info_); }
+    OrtTensorTypeAndShapeInfo* get() const { return info_; }
+
+private:
+    const OrtApi* api_;
+    OrtTensorTypeAndShapeInfo* info_;
+};
+
+void require_shape(const OrtApi* api, OrtValue* value,
+                   const std::vector<int64_t>& expected,
+                   const char* output_name) {
+    OrtTensorTypeAndShapeInfo* raw_info = nullptr;
+    ort_check(api, api->GetTensorTypeAndShape(value, &raw_info));
+    OrtShapeGuard info(api, raw_info);
+
+    size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(info.get(), &rank));
+    std::vector<int64_t> actual(rank);
+    if (rank > 0) ort_check(api, api->GetDimensions(info.get(), actual.data(), rank));
+    ONNXTensorElementDataType element_type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    ort_check(api, api->GetTensorElementType(info.get(), &element_type));
+    if (actual != expected || element_type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        std::string message = "DeepFilterNet3: unexpected ";
+        message += output_name;
+        message += " tensor contract";
+        throw std::runtime_error(message);
+    }
+}
+
+bool approximately_equal(float a, float b, float tolerance = 1e-5f) {
+    return std::fabs(a - b) <= tolerance;
+}
+
+}  // namespace
 
 DeepFilterEnhancer::DeepFilterEnhancer(
     const std::string& model_path,
     const std::string& auxiliary_path,
-    bool hw_accel)
-{
+    bool hw_accel) {
+    load_auxiliary(auxiliary_path);
     auto& engine = OnnxEngine::get();
     api_ = engine.api();
     session_ = engine.load(model_path, hw_accel);
-    load_auxiliary(auxiliary_path);
 }
 
 DeepFilterEnhancer::~DeepFilterEnhancer() {
@@ -25,174 +95,151 @@ DeepFilterEnhancer::~DeepFilterEnhancer() {
 }
 
 void DeepFilterEnhancer::load_auxiliary(const std::string& path) {
-    // Load precomputed ERB filterbanks and window from binary file.
-    // Format: erb_fb [481*32] | erb_inv_fb [32*481] | window [960]  (float32)
-    std::ifstream file(path, std::ios::binary);
+    const deepfilter_dsp::Config dsp_cfg = to_dsp_config(cfg_);
+    erb_widths_ = deepfilter_dsp::make_erb_widths(dsp_cfg);
+    window_ = deepfilter_dsp::make_vorbis_window(cfg_.fft_size);
+
+    // The first published binary used overlapping, normalized triangular
+    // matrices. libdf actually uses disjoint ERB widths (mean on analysis,
+    // repetition on synthesis). Keep accepting the constructor argument for
+    // existing bundles, but only use it as a compatibility check; canonical
+    // tables above are cheap to derive and cannot suffer layout drift.
+    if (path.empty()) return;
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
     if (!file.is_open()) {
-        LOGE("Auxiliary file not found: %s", path.c_str());
+        LOGI("DeepFilterNet3 auxiliary file unavailable; using built-in libdf tables: %s",
+             path.c_str());
         return;
     }
 
-    erb_fb_.resize(cfg_.freq_bins * cfg_.erb_bands);
-    erb_inv_fb_.resize(cfg_.erb_bands * cfg_.freq_bins);
-    window_.resize(cfg_.fft_size);
+    const size_t matrix_values = static_cast<size_t>(cfg_.freq_bins) * cfg_.erb_bands;
+    const size_t expected_values = matrix_values * 2 + static_cast<size_t>(cfg_.fft_size);
+    const std::streamoff byte_count = file.tellg();
+    if (byte_count != static_cast<std::streamoff>(expected_values * sizeof(float))) {
+        LOGI("DeepFilterNet3 auxiliary layout is incompatible; using built-in libdf tables");
+        return;
+    }
+    file.seekg(0);
+    std::vector<float> values(expected_values);
+    file.read(reinterpret_cast<char*>(values.data()),
+              static_cast<std::streamsize>(values.size() * sizeof(float)));
+    if (!file) {
+        LOGI("DeepFilterNet3 auxiliary file is truncated; using built-in libdf tables");
+        return;
+    }
 
-    file.read(reinterpret_cast<char*>(erb_fb_.data()),
-              erb_fb_.size() * sizeof(float));
-    file.read(reinterpret_cast<char*>(erb_inv_fb_.data()),
-              erb_inv_fb_.size() * sizeof(float));
-    file.read(reinterpret_cast<char*>(window_.data()),
-              window_.size() * sizeof(float));
-}
-
-void DeepFilterEnhancer::compute_erb_features(
-    const float* spec_real, const float* spec_imag, int num_frames,
-    std::vector<float>& feat_erb, std::vector<float>& feat_spec)
-{
-    feat_erb.resize(num_frames * cfg_.erb_bands);
-    feat_spec.resize(num_frames * 2 * cfg_.df_bins);
-
-    for (int t = 0; t < num_frames; t++) {
-        // Power spectrum → ERB bands
-        for (int b = 0; b < cfg_.erb_bands; b++) {
-            float sum = 0.0f;
-            for (int f = 0; f < cfg_.freq_bins; f++) {
-                float re = spec_real[t * cfg_.freq_bins + f];
-                float im = spec_imag[t * cfg_.freq_bins + f];
-                sum += (re * re + im * im) * erb_fb_[f * cfg_.erb_bands + b];
+    bool canonical = true;
+    int frequency_offset = 0;
+    for (int band = 0; band < cfg_.erb_bands && canonical; ++band) {
+        const int width = erb_widths_[static_cast<size_t>(band)];
+        for (int frequency = 0; frequency < cfg_.freq_bins; ++frequency) {
+            const bool in_band = frequency >= frequency_offset &&
+                                 frequency < frequency_offset + width;
+            const float expected_forward = in_band ? 1.0f / static_cast<float>(width) : 0.0f;
+            const float expected_inverse = in_band ? 1.0f : 0.0f;
+            const size_t forward_index =
+                static_cast<size_t>(frequency) * cfg_.erb_bands + band;
+            const size_t inverse_index = matrix_values +
+                static_cast<size_t>(band) * cfg_.freq_bins + frequency;
+            if (!approximately_equal(values[forward_index], expected_forward) ||
+                !approximately_equal(values[inverse_index], expected_inverse)) {
+                canonical = false;
+                break;
             }
-            feat_erb[t * cfg_.erb_bands + b] = 10.0f * std::log10(sum + 1e-10f);
         }
-
-        // Complex spectrum for deep-filtered bins
-        for (int f = 0; f < cfg_.df_bins; f++) {
-            feat_spec[t * 2 * cfg_.df_bins + f] =
-                spec_real[t * cfg_.freq_bins + f];
-            feat_spec[t * 2 * cfg_.df_bins + cfg_.df_bins + f] =
-                spec_imag[t * cfg_.freq_bins + f];
+        frequency_offset += width;
+    }
+    const size_t window_offset = matrix_values * 2;
+    for (int i = 0; i < cfg_.fft_size && canonical; ++i) {
+        if (!approximately_equal(values[window_offset + static_cast<size_t>(i)],
+                                 window_[static_cast<size_t>(i)])) {
+            canonical = false;
         }
     }
-}
-
-void DeepFilterEnhancer::apply_erb_mask(
-    float* spec_real, float* spec_imag,
-    const float* mask, int num_frames)
-{
-    for (int t = 0; t < num_frames; t++) {
-        for (int f = 0; f < cfg_.freq_bins; f++) {
-            // Expand ERB mask to full spectrum
-            float gain = 0.0f;
-            for (int b = 0; b < cfg_.erb_bands; b++) {
-                gain += mask[t * cfg_.erb_bands + b]
-                        * erb_inv_fb_[b * cfg_.freq_bins + f];
-            }
-            spec_real[t * cfg_.freq_bins + f] *= gain;
-            spec_imag[t * cfg_.freq_bins + f] *= gain;
-        }
-    }
-}
-
-void DeepFilterEnhancer::apply_deep_filter(
-    float* spec_real, float* spec_imag,
-    const float* coefs, int num_frames)
-{
-    int pad_before = cfg_.df_order - 1 - cfg_.df_lookahead;
-
-    for (int t = 0; t < num_frames; t++) {
-        for (int f = 0; f < cfg_.df_bins; f++) {
-            float out_re = 0.0f, out_im = 0.0f;
-
-            for (int n = 0; n < cfg_.df_order; n++) {
-                int src_t = t + n - pad_before;
-                if (src_t < 0 || src_t >= num_frames) continue;
-
-                float x_re = spec_real[src_t * cfg_.freq_bins + f];
-                float x_im = spec_imag[src_t * cfg_.freq_bins + f];
-
-                // coefs layout: [1, df_order, T, df_bins, 2]
-                int idx = (n * num_frames * cfg_.df_bins + t * cfg_.df_bins + f) * 2;
-                float w_re = coefs[idx];
-                float w_im = coefs[idx + 1];
-
-                // Complex multiply
-                out_re += x_re * w_re - x_im * w_im;
-                out_im += x_re * w_im + x_im * w_re;
-            }
-
-            spec_real[t * cfg_.freq_bins + f] = out_re;
-            spec_imag[t * cfg_.freq_bins + f] = out_im;
-        }
+    if (!canonical) {
+        LOGI("DeepFilterNet3 auxiliary values do not match libdf; using built-in tables");
     }
 }
 
 void DeepFilterEnhancer::enhance(
-    const float* audio, size_t length, int /*sample_rate*/, float* output)
-{
-    auto* mem = OnnxEngine::get().cpu_memory();
+    const float* audio, size_t length, int sample_rate, float* output) {
+    if (sample_rate != cfg_.sample_rate) {
+        throw std::invalid_argument("DeepFilterNet3 requires 48000 Hz input");
+    }
+    if (length == 0) return;
+    if (!audio || !output) {
+        throw std::invalid_argument("DeepFilterNet3 received a null audio buffer");
+    }
 
-    // --- STFT ---
+    const deepfilter_dsp::Config dsp_cfg = to_dsp_config(cfg_);
+    std::vector<float> spec_real;
+    std::vector<float> spec_imag;
+    deepfilter_dsp::analyze(audio, length, dsp_cfg, window_, spec_real, spec_imag);
+    const int num_frames = deepfilter_dsp::frame_count(length, dsp_cfg);
 
-    int num_frames = audio::stft_num_frames(length, cfg_.fft_size, cfg_.hop_size);
-    std::vector<float> spec_real(num_frames * cfg_.freq_bins);
-    std::vector<float> spec_imag(num_frames * cfg_.freq_bins);
+    std::vector<float> feat_erb;
+    std::vector<float> feat_spec;
+    deepfilter_dsp::compute_features(spec_real, spec_imag, num_frames,
+                                     dsp_cfg, erb_widths_, feat_erb, feat_spec);
 
-    audio::stft_forward(audio, length, cfg_.fft_size, cfg_.hop_size,
-                        window_.data(), spec_real.data(), spec_imag.data());
+    auto* memory = OnnxEngine::get().cpu_memory();
+    const int64_t frames = num_frames;
+    const int64_t erb_shape[] = {1, 1, frames, cfg_.erb_bands};
+    const int64_t spec_shape[] = {1, 2, frames, cfg_.df_bins};
 
-    // --- features ---
-
-    std::vector<float> feat_erb, feat_spec;
-    compute_erb_features(spec_real.data(), spec_imag.data(),
-                         num_frames, feat_erb, feat_spec);
-
-    // --- ONNX inference ---
-
-    int64_t T = num_frames;
-    const int64_t erb_shape[]  = {1, 1, T, cfg_.erb_bands};
-    const int64_t spec_shape[] = {1, 2, T, cfg_.df_bins};
-
-    OrtValue* t_erb = nullptr;
+    OrtValue* raw_erb = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-        mem, feat_erb.data(), feat_erb.size() * sizeof(float),
-        erb_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_erb));
+        memory, feat_erb.data(), feat_erb.size() * sizeof(float),
+        erb_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &raw_erb));
+    OrtValueGuard tensor_erb(api_, raw_erb);
 
-    OrtValue* t_spec = nullptr;
+    OrtValue* raw_spec = nullptr;
     ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
-        mem, feat_spec.data(), feat_spec.size() * sizeof(float),
-        spec_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &t_spec));
+        memory, feat_spec.data(), feat_spec.size() * sizeof(float),
+        spec_shape, 4, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &raw_spec));
+    OrtValueGuard tensor_spec(api_, raw_spec);
 
-    const char* in_names[]  = {"feat_erb", "feat_spec"};
-    const char* out_names[] = {"erb_mask", "df_coefs"};
-    OrtValue* inputs[]  = {t_erb, t_spec};
-    OrtValue* outputs[] = {nullptr, nullptr};
+    const char* input_names[] = {"feat_erb", "feat_spec"};
+    const char* output_names[] = {"erb_mask", "df_coefs"};
+    OrtValue* inputs[] = {tensor_erb.get(), tensor_spec.get()};
+    OrtValue* raw_outputs[] = {nullptr, nullptr};
+    OrtStatus* run_status = api_->Run(session_, nullptr,
+                                      input_names, inputs, 2,
+                                      output_names, 2, raw_outputs);
+    if (run_status) {
+        for (OrtValue* value : raw_outputs) {
+            if (value) api_->ReleaseValue(value);
+        }
+        ort_check(api_, run_status);
+    }
+    if (!raw_outputs[0] || !raw_outputs[1]) {
+        for (OrtValue* value : raw_outputs) {
+            if (value) api_->ReleaseValue(value);
+        }
+        throw std::runtime_error("DeepFilterNet3: ONNX graph returned a null output");
+    }
+    OrtValueGuard mask_output(api_, raw_outputs[0]);
+    OrtValueGuard coefficients_output(api_, raw_outputs[1]);
 
-    ort_check(api_, api_->Run(
-        session_, nullptr,
-        in_names, inputs, 2,
-        out_names, 2, outputs));
+    require_shape(api_, mask_output.get(),
+                  {1, 1, frames, cfg_.erb_bands}, "erb_mask");
+    require_shape(api_, coefficients_output.get(),
+                  {1, cfg_.df_order, frames, cfg_.df_bins, 2}, "df_coefs");
 
     float* erb_mask = nullptr;
-    ort_check(api_, api_->GetTensorMutableData(outputs[0], (void**)&erb_mask));
+    ort_check(api_, api_->GetTensorMutableData(mask_output.get(),
+                                               reinterpret_cast<void**>(&erb_mask)));
     float* df_coefs = nullptr;
-    ort_check(api_, api_->GetTensorMutableData(outputs[1], (void**)&df_coefs));
+    ort_check(api_, api_->GetTensorMutableData(coefficients_output.get(),
+                                               reinterpret_cast<void**>(&df_coefs)));
 
-    // --- apply mask + deep filter ---
-
-    apply_erb_mask(spec_real.data(), spec_imag.data(), erb_mask, num_frames);
-    apply_deep_filter(spec_real.data(), spec_imag.data(), df_coefs, num_frames);
-
-    // --- inverse STFT ---
-
-    audio::stft_inverse(spec_real.data(), spec_imag.data(), num_frames,
-                        cfg_.fft_size, cfg_.hop_size,
-                        window_.data(), output, length);
-
-    // --- cleanup ---
-
-    api_->ReleaseValue(outputs[1]);
-    api_->ReleaseValue(outputs[0]);
-    api_->ReleaseValue(t_spec);
-    api_->ReleaseValue(t_erb);
+    std::vector<float> enhanced_real;
+    std::vector<float> enhanced_imag;
+    deepfilter_dsp::apply_network_output(
+        spec_real, spec_imag, erb_mask, df_coefs, num_frames,
+        dsp_cfg, erb_widths_, enhanced_real, enhanced_imag);
+    deepfilter_dsp::synthesize(enhanced_real, enhanced_imag, num_frames,
+                              dsp_cfg, window_, output, length);
 }
 
 }  // namespace speech_core

--- a/src/models/deepfilter/deepfilter_dsp.cpp
+++ b/src/models/deepfilter/deepfilter_dsp.cpp
@@ -1,0 +1,403 @@
+#include "deepfilter_dsp.h"
+
+#include "kissfft/kiss_fftr.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+
+namespace speech_core::deepfilter_dsp {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846264338327950288;
+
+void validate_config(const Config& cfg) {
+    if (cfg.fft_size <= 0 || cfg.fft_size % 2 != 0 ||
+        cfg.hop_size <= 0 || cfg.hop_size * 2 > cfg.fft_size ||
+        cfg.erb_bands <= 0 || cfg.df_bins <= 0 ||
+        cfg.df_bins > cfg.freq_bins || cfg.df_order <= 0 ||
+        cfg.df_lookahead < 0 || cfg.df_lookahead >= cfg.df_order ||
+        cfg.freq_bins != cfg.fft_size / 2 + 1 ||
+        cfg.sample_rate <= 0 || cfg.min_erb_freqs <= 0 ||
+        cfg.norm_tau <= 0.0f) {
+        throw std::invalid_argument("DeepFilterNet3: invalid DSP configuration");
+    }
+}
+
+void validate_widths(const std::vector<int>& widths, const Config& cfg) {
+    if (widths.size() != static_cast<size_t>(cfg.erb_bands) ||
+        std::any_of(widths.begin(), widths.end(), [](int width) { return width <= 0; }) ||
+        std::accumulate(widths.begin(), widths.end(), 0) != cfg.freq_bins) {
+        throw std::invalid_argument("DeepFilterNet3: invalid ERB widths");
+    }
+}
+
+class KissRealPlan {
+public:
+    KissRealPlan(int fft_size, bool inverse)
+        : cfg_(kiss_fftr_alloc(fft_size, inverse ? 1 : 0, nullptr, nullptr)) {
+        if (!cfg_) {
+            throw std::runtime_error("DeepFilterNet3: kiss_fftr_alloc failed");
+        }
+    }
+
+    ~KissRealPlan() { kiss_fftr_free(cfg_); }
+
+    KissRealPlan(const KissRealPlan&) = delete;
+    KissRealPlan& operator=(const KissRealPlan&) = delete;
+
+    kiss_fftr_cfg get() const { return cfg_; }
+
+private:
+    kiss_fftr_cfg cfg_;
+};
+
+std::vector<float> linspace(float first, float last, int count) {
+    if (count <= 0) return {};
+    if (count == 1) return {first};
+    std::vector<float> values(static_cast<size_t>(count));
+    const float step = (last - first) / static_cast<float>(count - 1);
+    for (int i = 0; i < count; ++i) {
+        values[static_cast<size_t>(i)] = first + static_cast<float>(i) * step;
+    }
+    return values;
+}
+
+}  // namespace
+
+std::vector<int> make_erb_widths(const Config& cfg) {
+    validate_config(cfg);
+
+    auto freq_to_erb = [](float frequency) {
+        return 9.265f * std::log1p(frequency / (24.7f * 9.265f));
+    };
+    auto erb_to_freq = [](float erb) {
+        return 24.7f * 9.265f * (std::exp(erb / 9.265f) - 1.0f);
+    };
+
+    const float nyquist = static_cast<float>(cfg.sample_rate / 2);
+    const float bin_width = static_cast<float>(cfg.sample_rate) /
+                            static_cast<float>(cfg.fft_size);
+    const float erb_low = freq_to_erb(0.0f);
+    const float erb_high = freq_to_erb(nyquist);
+    const float step = (erb_high - erb_low) / static_cast<float>(cfg.erb_bands);
+
+    std::vector<int> widths(static_cast<size_t>(cfg.erb_bands), 0);
+    int previous_bin = 0;
+    int bins_carried = 0;
+    for (int band = 1; band <= cfg.erb_bands; ++band) {
+        const float frequency = erb_to_freq(erb_low + static_cast<float>(band) * step);
+        const int boundary_bin = static_cast<int>(std::round(frequency / bin_width));
+        int width = boundary_bin - previous_bin - bins_carried;
+        if (width < cfg.min_erb_freqs) {
+            bins_carried = cfg.min_erb_freqs - width;
+            width = cfg.min_erb_freqs;
+        } else {
+            bins_carried = 0;
+        }
+        widths[static_cast<size_t>(band - 1)] = width;
+        previous_bin = boundary_bin;
+    }
+
+    // Include Nyquist, then remove any enforced-bin overflow from the final
+    // band exactly as libdf::erb_fb does.
+    ++widths.back();
+    const int excess = std::accumulate(widths.begin(), widths.end(), 0) - cfg.freq_bins;
+    if (excess > 0) widths.back() -= excess;
+    validate_widths(widths, cfg);
+    return widths;
+}
+
+std::vector<float> make_vorbis_window(int fft_size) {
+    if (fft_size <= 0) {
+        throw std::invalid_argument("DeepFilterNet3: invalid Vorbis window size");
+    }
+    std::vector<float> window(static_cast<size_t>(fft_size));
+    for (int i = 0; i < fft_size; ++i) {
+        const double inner = std::sin(kPi * (static_cast<double>(i) + 0.5) /
+                                      static_cast<double>(fft_size));
+        window[static_cast<size_t>(i)] =
+            static_cast<float>(std::sin(0.5 * kPi * inner * inner));
+    }
+    return window;
+}
+
+std::vector<float> make_mean_norm_state(int erb_bands) {
+    return linspace(-60.0f, -90.0f, erb_bands);
+}
+
+std::vector<float> make_unit_norm_state(int df_bins) {
+    return linspace(0.001f, 0.0001f, df_bins);
+}
+
+float normalization_alpha(const Config& cfg) {
+    validate_config(cfg);
+    const double dt = static_cast<double>(cfg.hop_size) /
+                      static_cast<double>(cfg.sample_rate);
+    const double unrounded = std::exp(-dt / static_cast<double>(cfg.norm_tau));
+    double scale = 1000.0;
+    for (;;) {
+        const double rounded = std::round(unrounded * scale) / scale;
+        if (rounded < 1.0) return static_cast<float>(rounded);
+        scale *= 10.0;
+        if (!std::isfinite(scale)) return static_cast<float>(unrounded);
+    }
+}
+
+int frame_count(size_t input_length, const Config& cfg) {
+    validate_config(cfg);
+    const size_t padded = input_length + static_cast<size_t>(cfg.fft_size);
+    if (padded < input_length) {
+        throw std::overflow_error("DeepFilterNet3: input length overflow");
+    }
+    const size_t frames = padded / static_cast<size_t>(cfg.hop_size);
+    if (frames > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        throw std::overflow_error("DeepFilterNet3: too many STFT frames");
+    }
+    return static_cast<int>(frames);
+}
+
+void analyze(const float* audio, size_t length,
+             const Config& cfg, const std::vector<float>& window,
+             std::vector<float>& spec_real,
+             std::vector<float>& spec_imag) {
+    validate_config(cfg);
+    if (length > 0 && !audio) {
+        throw std::invalid_argument("DeepFilterNet3: null audio input");
+    }
+    if (window.size() != static_cast<size_t>(cfg.fft_size)) {
+        throw std::invalid_argument("DeepFilterNet3: invalid analysis window");
+    }
+
+    const int frames = frame_count(length, cfg);
+    const size_t spectrum_size = static_cast<size_t>(frames) * cfg.freq_bins;
+    spec_real.assign(spectrum_size, 0.0f);
+    spec_imag.assign(spectrum_size, 0.0f);
+
+    const size_t history = static_cast<size_t>(cfg.fft_size - cfg.hop_size);
+    const size_t padded_size = history + length + static_cast<size_t>(cfg.fft_size);
+    if (padded_size < length) {
+        throw std::overflow_error("DeepFilterNet3: padded input length overflow");
+    }
+    std::vector<float> padded(padded_size, 0.0f);
+    if (length > 0) std::copy_n(audio, length, padded.data() + history);
+
+    KissRealPlan plan(cfg.fft_size, false);
+    std::vector<kiss_fft_scalar> frame(static_cast<size_t>(cfg.fft_size));
+    std::vector<kiss_fft_cpx> spectrum(static_cast<size_t>(cfg.freq_bins));
+    const float scale = (2.0f * static_cast<float>(cfg.hop_size)) /
+                        (static_cast<float>(cfg.fft_size) *
+                         static_cast<float>(cfg.fft_size));
+
+    for (int t = 0; t < frames; ++t) {
+        const size_t start = static_cast<size_t>(t) * cfg.hop_size;
+        for (int i = 0; i < cfg.fft_size; ++i) {
+            frame[static_cast<size_t>(i)] =
+                padded[start + static_cast<size_t>(i)] * window[static_cast<size_t>(i)];
+        }
+        kiss_fftr(plan.get(), frame.data(), spectrum.data());
+        const size_t base = static_cast<size_t>(t) * cfg.freq_bins;
+        for (int f = 0; f < cfg.freq_bins; ++f) {
+            spec_real[base + static_cast<size_t>(f)] =
+                spectrum[static_cast<size_t>(f)].r * scale;
+            spec_imag[base + static_cast<size_t>(f)] =
+                spectrum[static_cast<size_t>(f)].i * scale;
+        }
+    }
+}
+
+void compute_features(const std::vector<float>& spec_real,
+                      const std::vector<float>& spec_imag,
+                      int num_frames,
+                      const Config& cfg,
+                      const std::vector<int>& erb_widths,
+                      std::vector<float>& feat_erb,
+                      std::vector<float>& feat_spec) {
+    validate_config(cfg);
+    validate_widths(erb_widths, cfg);
+    if (num_frames < 0 ||
+        spec_real.size() != static_cast<size_t>(num_frames) * cfg.freq_bins ||
+        spec_imag.size() != spec_real.size()) {
+        throw std::invalid_argument("DeepFilterNet3: invalid spectrum shape");
+    }
+
+    feat_erb.assign(static_cast<size_t>(num_frames) * cfg.erb_bands, 0.0f);
+    feat_spec.assign(static_cast<size_t>(2) * num_frames * cfg.df_bins, 0.0f);
+    std::vector<float> mean_state = make_mean_norm_state(cfg.erb_bands);
+    std::vector<float> unit_state = make_unit_norm_state(cfg.df_bins);
+    const float alpha = normalization_alpha(cfg);
+    const float one_minus_alpha = 1.0f - alpha;
+    const size_t spec_channel_stride = static_cast<size_t>(num_frames) * cfg.df_bins;
+
+    for (int t = 0; t < num_frames; ++t) {
+        const size_t spectrum_base = static_cast<size_t>(t) * cfg.freq_bins;
+        int frequency = 0;
+        for (int band = 0; band < cfg.erb_bands; ++band) {
+            const int width = erb_widths[static_cast<size_t>(band)];
+            float power = 0.0f;
+            for (int j = 0; j < width; ++j, ++frequency) {
+                const float re = spec_real[spectrum_base + static_cast<size_t>(frequency)];
+                const float im = spec_imag[spectrum_base + static_cast<size_t>(frequency)];
+                power += re * re + im * im;
+            }
+            power /= static_cast<float>(width);
+            const float x = 10.0f * std::log10(power + 1e-10f);
+            float& state = mean_state[static_cast<size_t>(band)];
+            state = x * one_minus_alpha + state * alpha;
+            feat_erb[static_cast<size_t>(t) * cfg.erb_bands + band] =
+                (x - state) / 40.0f;
+        }
+
+        const size_t feature_base = static_cast<size_t>(t) * cfg.df_bins;
+        for (int f = 0; f < cfg.df_bins; ++f) {
+            const float re = spec_real[spectrum_base + static_cast<size_t>(f)];
+            const float im = spec_imag[spectrum_base + static_cast<size_t>(f)];
+            const float magnitude = std::sqrt(re * re + im * im);
+            float& state = unit_state[static_cast<size_t>(f)];
+            state = magnitude * one_minus_alpha + state * alpha;
+            const float divisor = std::sqrt(state);
+            feat_spec[feature_base + static_cast<size_t>(f)] = re / divisor;
+            feat_spec[spec_channel_stride + feature_base + static_cast<size_t>(f)] = im / divisor;
+        }
+    }
+}
+
+void apply_network_output(const std::vector<float>& spec_real,
+                          const std::vector<float>& spec_imag,
+                          const float* erb_mask,
+                          const float* df_coefs,
+                          int num_frames,
+                          const Config& cfg,
+                          const std::vector<int>& erb_widths,
+                          std::vector<float>& enhanced_real,
+                          std::vector<float>& enhanced_imag) {
+    validate_config(cfg);
+    validate_widths(erb_widths, cfg);
+    if (!erb_mask || !df_coefs || num_frames < 0 ||
+        spec_real.size() != static_cast<size_t>(num_frames) * cfg.freq_bins ||
+        spec_imag.size() != spec_real.size()) {
+        throw std::invalid_argument("DeepFilterNet3: invalid network output inputs");
+    }
+
+    enhanced_real.resize(spec_real.size());
+    enhanced_imag.resize(spec_imag.size());
+
+    // ERB mask uses a piecewise-constant inverse filterbank. Apply it to the
+    // original spectrum; low bins are replaced by deep filtering below.
+    for (int t = 0; t < num_frames; ++t) {
+        const size_t base = static_cast<size_t>(t) * cfg.freq_bins;
+        int frequency = 0;
+        for (int band = 0; band < cfg.erb_bands; ++band) {
+            const float gain = erb_mask[static_cast<size_t>(t) * cfg.erb_bands + band];
+            const int width = erb_widths[static_cast<size_t>(band)];
+            for (int j = 0; j < width; ++j, ++frequency) {
+                const size_t index = base + static_cast<size_t>(frequency);
+                enhanced_real[index] = spec_real[index] * gain;
+                enhanced_imag[index] = spec_imag[index] * gain;
+            }
+        }
+    }
+
+    const int pad_before = cfg.df_order - 1 - cfg.df_lookahead;
+    for (int t = 0; t < num_frames; ++t) {
+        for (int f = 0; f < cfg.df_bins; ++f) {
+            float out_re = 0.0f;
+            float out_im = 0.0f;
+            for (int tap = 0; tap < cfg.df_order; ++tap) {
+                const int source_t = t + tap - pad_before;
+                if (source_t < 0 || source_t >= num_frames) continue;
+
+                const size_t source_index =
+                    static_cast<size_t>(source_t) * cfg.freq_bins + f;
+                const size_t coefficient_index =
+                    ((static_cast<size_t>(tap) * num_frames + t) * cfg.df_bins + f) * 2;
+                const float x_re = spec_real[source_index];
+                const float x_im = spec_imag[source_index];
+                const float w_re = df_coefs[coefficient_index];
+                const float w_im = df_coefs[coefficient_index + 1];
+                out_re += x_re * w_re - x_im * w_im;
+                out_im += x_re * w_im + x_im * w_re;
+            }
+            const size_t output_index = static_cast<size_t>(t) * cfg.freq_bins + f;
+            enhanced_real[output_index] = out_re;
+            enhanced_imag[output_index] = out_im;
+        }
+    }
+}
+
+void synthesize(const std::vector<float>& spec_real,
+                const std::vector<float>& spec_imag,
+                int num_frames,
+                const Config& cfg,
+                const std::vector<float>& window,
+                float* output,
+                size_t output_length) {
+    validate_config(cfg);
+    if (output_length > 0 && !output) {
+        throw std::invalid_argument("DeepFilterNet3: null audio output");
+    }
+    if (num_frames < 0 ||
+        spec_real.size() != static_cast<size_t>(num_frames) * cfg.freq_bins ||
+        spec_imag.size() != spec_real.size() ||
+        window.size() != static_cast<size_t>(cfg.fft_size)) {
+        throw std::invalid_argument("DeepFilterNet3: invalid synthesis inputs");
+    }
+    if (output_length == 0) return;
+
+    const size_t delay = static_cast<size_t>(cfg.fft_size - cfg.hop_size);
+    const size_t raw_length = static_cast<size_t>(num_frames) * cfg.hop_size;
+    if (delay + output_length < output_length || delay + output_length > raw_length) {
+        throw std::invalid_argument("DeepFilterNet3: insufficient synthesis frames");
+    }
+
+    std::fill_n(output, output_length, 0.0f);
+    KissRealPlan plan(cfg.fft_size, true);
+    std::vector<kiss_fft_cpx> spectrum(static_cast<size_t>(cfg.freq_bins));
+    std::vector<kiss_fft_scalar> time(static_cast<size_t>(cfg.fft_size));
+    std::vector<float> windowed(static_cast<size_t>(cfg.fft_size));
+    std::vector<float> memory(delay, 0.0f);
+
+    for (int t = 0; t < num_frames; ++t) {
+        const size_t spectrum_base = static_cast<size_t>(t) * cfg.freq_bins;
+        for (int f = 0; f < cfg.freq_bins; ++f) {
+            spectrum[static_cast<size_t>(f)].r =
+                spec_real[spectrum_base + static_cast<size_t>(f)];
+            spectrum[static_cast<size_t>(f)].i =
+                spec_imag[spectrum_base + static_cast<size_t>(f)];
+        }
+        kiss_fftri(plan.get(), spectrum.data(), time.data());
+        for (int i = 0; i < cfg.fft_size; ++i) {
+            // kissfft's inverse is intentionally left unnormalized: libdf
+            // normalizes only the analysis transform.
+            windowed[static_cast<size_t>(i)] =
+                time[static_cast<size_t>(i)] * window[static_cast<size_t>(i)];
+        }
+
+        const size_t raw_base = static_cast<size_t>(t) * cfg.hop_size;
+        for (int i = 0; i < cfg.hop_size; ++i) {
+            const float sample = windowed[static_cast<size_t>(i)] +
+                                 memory[static_cast<size_t>(i)];
+            const size_t raw_index = raw_base + static_cast<size_t>(i);
+            if (raw_index >= delay && raw_index < delay + output_length) {
+                output[raw_index - delay] = sample;
+            }
+        }
+
+        // Match libdf's synthesis-memory update for overlap ratios >= 50%.
+        const size_t shift_remainder = delay - static_cast<size_t>(cfg.hop_size);
+        if (shift_remainder > 0) {
+            std::rotate(memory.begin(), memory.begin() + cfg.hop_size, memory.end());
+        }
+        const float* second_half = windowed.data() + cfg.hop_size;
+        for (size_t i = 0; i < shift_remainder; ++i) memory[i] += second_half[i];
+        for (int i = 0; i < cfg.hop_size; ++i) {
+            memory[shift_remainder + static_cast<size_t>(i)] =
+                second_half[shift_remainder + static_cast<size_t>(i)];
+        }
+    }
+}
+
+}  // namespace speech_core::deepfilter_dsp

--- a/src/models/deepfilter/deepfilter_dsp.h
+++ b/src/models/deepfilter/deepfilter_dsp.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace speech_core::deepfilter_dsp {
+
+// Pure C++ signal-processing contract around the DeepFilterNet3 neural graph.
+// Kept independent of ONNX Runtime so it can be regression-tested directly.
+struct Config {
+    int fft_size = 960;
+    int hop_size = 480;
+    int erb_bands = 32;
+    int df_bins = 96;
+    int df_order = 5;
+    int df_lookahead = 2;
+    int freq_bins = 481;
+    int sample_rate = 48000;
+    int min_erb_freqs = 2;
+    float norm_tau = 1.0f;
+};
+
+std::vector<int> make_erb_widths(const Config& cfg);
+std::vector<float> make_vorbis_window(int fft_size);
+std::vector<float> make_mean_norm_state(int erb_bands);
+std::vector<float> make_unit_norm_state(int df_bins);
+float normalization_alpha(const Config& cfg);
+
+int frame_count(size_t input_length, const Config& cfg);
+
+// Streaming-compatible libdf analysis, evaluated as one batch. A zeroed
+// analysis history is prepended and a full fft_size tail is appended.
+void analyze(const float* audio, size_t length,
+             const Config& cfg, const std::vector<float>& window,
+             std::vector<float>& spec_real,
+             std::vector<float>& spec_imag);
+
+// Produces feat_erb [1,1,T,E] and channel-major feat_spec [1,2,T,F].
+// Normalization state starts from the upstream libdf initial values for each
+// batch invocation.
+void compute_features(const std::vector<float>& spec_real,
+                      const std::vector<float>& spec_imag,
+                      int num_frames,
+                      const Config& cfg,
+                      const std::vector<int>& erb_widths,
+                      std::vector<float>& feat_erb,
+                      std::vector<float>& feat_spec);
+
+// Fuses the graph outputs with the immutable noisy spectrum. erb_mask is
+// [1,1,T,E]; df_coefs is [1,O,T,F,2].
+void apply_network_output(const std::vector<float>& spec_real,
+                          const std::vector<float>& spec_imag,
+                          const float* erb_mask,
+                          const float* df_coefs,
+                          int num_frames,
+                          const Config& cfg,
+                          const std::vector<int>& erb_widths,
+                          std::vector<float>& enhanced_real,
+                          std::vector<float>& enhanced_imag);
+
+// Streaming overlap-add synthesis followed by removal of the fft_size-hop
+// algorithmic delay. Writes exactly output_length samples.
+void synthesize(const std::vector<float>& spec_real,
+                const std::vector<float>& spec_imag,
+                int num_frames,
+                const Config& cfg,
+                const std::vector<float>& window,
+                float* output,
+                size_t output_length);
+
+}  // namespace speech_core::deepfilter_dsp

--- a/tests/test_deepfilter_dsp.cpp
+++ b/tests/test_deepfilter_dsp.cpp
@@ -1,0 +1,203 @@
+// Force-enable asserts even under Release builds.
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "models/deepfilter/deepfilter_dsp.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <numeric>
+#include <vector>
+
+namespace dsp = speech_core::deepfilter_dsp;
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846264338327950288;
+
+bool approx(float actual, double expected, double tolerance) {
+    return std::fabs(static_cast<double>(actual) - expected) <= tolerance;
+}
+
+void test_upstream_constants() {
+    const dsp::Config cfg;
+    const std::vector<int> expected_widths = {
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 5, 5, 7,
+        7, 8, 10, 12, 13, 15, 18, 20, 24, 28, 31, 37, 42, 50, 56, 67,
+    };
+    const auto widths = dsp::make_erb_widths(cfg);
+    assert(widths == expected_widths);
+    assert(std::accumulate(widths.begin(), widths.end(), 0) == cfg.freq_bins);
+    assert(approx(dsp::normalization_alpha(cfg), 0.99, 1e-7));
+
+    const auto mean = dsp::make_mean_norm_state(cfg.erb_bands);
+    const auto unit = dsp::make_unit_norm_state(cfg.df_bins);
+    assert(approx(mean.front(), -60.0, 1e-7));
+    assert(approx(mean.back(), -90.0, 1e-6));
+    assert(approx(unit.front(), 0.001, 1e-9));
+    assert(approx(unit.back(), 0.0001, 1e-9));
+
+    const auto window = dsp::make_vorbis_window(cfg.fft_size);
+    for (int i = 0; i < cfg.hop_size; ++i) {
+        const double cola = static_cast<double>(window[static_cast<size_t>(i)]) * window[static_cast<size_t>(i)] +
+                            static_cast<double>(window[static_cast<size_t>(i + cfg.hop_size)]) *
+                                window[static_cast<size_t>(i + cfg.hop_size)];
+        assert(std::fabs(cola - 1.0) < 2e-6);
+    }
+    std::printf("  PASS: upstream_constants\n");
+}
+
+void test_native_960_analysis() {
+    const dsp::Config cfg;
+    const auto window = dsp::make_vorbis_window(cfg.fft_size);
+    const float impulse = 1.0f;
+    std::vector<float> real;
+    std::vector<float> imag;
+    dsp::analyze(&impulse, 1, cfg, window, real, imag);
+
+    assert(dsp::frame_count(1, cfg) == 2);
+    assert(real.size() == static_cast<size_t>(2 * cfg.freq_bins));
+    const double magnitude = static_cast<double>(window[480]) / 960.0;
+    for (int bin : {0, 1, 17, 95, 96, 479, 480}) {
+        const double expected = (bin % 2 == 0) ? magnitude : -magnitude;
+        assert(approx(real[static_cast<size_t>(bin)], expected, 2e-7));
+        assert(std::fabs(imag[static_cast<size_t>(bin)]) < 2e-7f);
+    }
+    std::printf("  PASS: native_960_analysis\n");
+}
+
+void test_streaming_roundtrip_non_aligned() {
+    const dsp::Config cfg;
+    const auto window = dsp::make_vorbis_window(cfg.fft_size);
+    std::vector<float> input(1001);
+    for (size_t i = 0; i < input.size(); ++i) {
+        const double t = static_cast<double>(i) / cfg.sample_rate;
+        input[i] = static_cast<float>(0.31 * std::sin(2.0 * kPi * 437.0 * t) +
+                                      0.08 * std::cos(2.0 * kPi * 1903.0 * t));
+    }
+
+    std::vector<float> real;
+    std::vector<float> imag;
+    dsp::analyze(input.data(), input.size(), cfg, window, real, imag);
+    std::vector<float> output(input.size());
+    dsp::synthesize(real, imag, dsp::frame_count(input.size(), cfg),
+                    cfg, window, output.data(), output.size());
+
+    float max_error = 0.0f;
+    for (size_t i = 0; i < input.size(); ++i) {
+        max_error = std::max(max_error, std::fabs(input[i] - output[i]));
+    }
+    assert(max_error < 2e-5f);
+    std::printf("  PASS: streaming_roundtrip_non_aligned (max_error=%.2g)\n", max_error);
+}
+
+void test_feature_normalization_and_layout() {
+    const dsp::Config cfg;
+    const auto widths = dsp::make_erb_widths(cfg);
+    constexpr int frames = 2;
+    std::vector<float> real(static_cast<size_t>(frames) * cfg.freq_bins);
+    std::vector<float> imag(real.size());
+    for (int t = 0; t < frames; ++t) {
+        for (int f = 0; f < cfg.freq_bins; ++f) {
+            const size_t index = static_cast<size_t>(t) * cfg.freq_bins + f;
+            real[index] = static_cast<float>(1.0 + t + f * 0.001);
+            imag[index] = static_cast<float>(-0.25 + t * 0.75 - f * 0.0002);
+        }
+    }
+
+    std::vector<float> erb;
+    std::vector<float> spec;
+    dsp::compute_features(real, imag, frames, cfg, widths, erb, spec);
+    assert(erb.size() == static_cast<size_t>(frames * cfg.erb_bands));
+    assert(spec.size() == static_cast<size_t>(2 * frames * cfg.df_bins));
+
+    const float alpha = 0.99f;
+    float unit_state = 0.001f;
+    const size_t channel_stride = static_cast<size_t>(frames) * cfg.df_bins;
+    for (int t = 0; t < frames; ++t) {
+        const float re = real[static_cast<size_t>(t) * cfg.freq_bins];
+        const float im = imag[static_cast<size_t>(t) * cfg.freq_bins];
+        unit_state = std::sqrt(re * re + im * im) * (1.0f - alpha) + unit_state * alpha;
+        const float divisor = std::sqrt(unit_state);
+        const size_t index = static_cast<size_t>(t) * cfg.df_bins;
+        assert(approx(spec[index], re / divisor, 2e-6));
+        assert(approx(spec[channel_stride + index], im / divisor, 2e-6));
+    }
+
+    float first_power = 0.0f;
+    for (int f = 0; f < widths.front(); ++f) {
+        first_power += real[static_cast<size_t>(f)] * real[static_cast<size_t>(f)] +
+                       imag[static_cast<size_t>(f)] * imag[static_cast<size_t>(f)];
+    }
+    first_power /= static_cast<float>(widths.front());
+    const float first_db = 10.0f * std::log10(first_power + 1e-10f);
+    const float first_state = first_db * (1.0f - alpha) - 60.0f * alpha;
+    assert(approx(erb[0], (first_db - first_state) / 40.0f, 2e-6));
+    std::printf("  PASS: feature_normalization_and_layout\n");
+}
+
+void test_immutable_deep_filter_and_fusion() {
+    const dsp::Config cfg;
+    const auto widths = dsp::make_erb_widths(cfg);
+    constexpr int frames = 4;
+    std::vector<float> real(static_cast<size_t>(frames) * cfg.freq_bins);
+    std::vector<float> imag(real.size());
+    for (int t = 0; t < frames; ++t) {
+        for (int f = 0; f < cfg.freq_bins; ++f) {
+            const size_t index = static_cast<size_t>(t) * cfg.freq_bins + f;
+            real[index] = static_cast<float>(100 * t + f + 1);
+            imag[index] = static_cast<float>(-10 * t - f * 0.1f);
+        }
+    }
+
+    std::vector<float> mask(static_cast<size_t>(frames) * cfg.erb_bands, 0.25f);
+    std::vector<float> coefs(
+        static_cast<size_t>(cfg.df_order) * frames * cfg.df_bins * 2, 0.0f);
+    // tap=1 maps output t to original t-1 (pad_before=2). If filtering is
+    // performed in place, later frames incorrectly see already-filtered data.
+    for (int t = 0; t < frames; ++t) {
+        for (int f = 0; f < cfg.df_bins; ++f) {
+            const size_t index =
+                ((static_cast<size_t>(1) * frames + t) * cfg.df_bins + f) * 2;
+            coefs[index] = 1.0f;
+        }
+    }
+
+    std::vector<float> enhanced_real;
+    std::vector<float> enhanced_imag;
+    dsp::apply_network_output(real, imag, mask.data(), coefs.data(), frames,
+                              cfg, widths, enhanced_real, enhanced_imag);
+
+    for (int f : {0, 17, 95}) {
+        assert(enhanced_real[static_cast<size_t>(f)] == 0.0f);
+        for (int t = 1; t < frames; ++t) {
+            const size_t output_index = static_cast<size_t>(t) * cfg.freq_bins + f;
+            const size_t source_index = static_cast<size_t>(t - 1) * cfg.freq_bins + f;
+            assert(enhanced_real[output_index] == real[source_index]);
+            assert(enhanced_imag[output_index] == imag[source_index]);
+        }
+    }
+    const int high_bin = cfg.df_bins;
+    for (int t = 0; t < frames; ++t) {
+        const size_t index = static_cast<size_t>(t) * cfg.freq_bins + high_bin;
+        assert(enhanced_real[index] == real[index] * 0.25f);
+        assert(enhanced_imag[index] == imag[index] * 0.25f);
+    }
+    std::printf("  PASS: immutable_deep_filter_and_fusion\n");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("test_deepfilter_dsp:\n");
+    test_upstream_constants();
+    test_native_960_analysis();
+    test_streaming_roundtrip_non_aligned();
+    test_feature_normalization_and_layout();
+    test_immutable_deep_filter_and_fusion();
+    std::printf("All DeepFilterNet3 DSP tests passed.\n");
+    return 0;
+}

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -521,14 +521,16 @@ void test_kokoro_short_turn_profile(const std::string& dir) {
 
 void test_deepfilter(const std::string& dir) {
     std::string model = dir + "/deepfilter.onnx";
-    std::string aux = dir + "/deepfilter-auxiliary.bin";
-    if (!file_exists(model) || !file_exists(aux)) {
-        std::printf("  [skip] deepfilter files not in %s\n", dir.c_str());
+    std::string auxiliary = dir + "/deepfilter-auxiliary.bin";
+    if (!file_exists(model)) {
+        std::printf("  [skip] deepfilter.onnx not in %s\n", dir.c_str());
         return;
     }
     std::printf("  test_deepfilter ... ");
 
-    speech_core::DeepFilterEnhancer enh(model, aux, /*hw_accel=*/false);
+    speech_core::DeepFilterEnhancer enh(model,
+                                        file_exists(auxiliary) ? auxiliary : std::string{},
+                                        /*hw_accel=*/false);
     REQUIRE(enh.input_sample_rate() == 48000);
 
     // 1 second of low-amplitude noise at 48 kHz
@@ -542,14 +544,20 @@ void test_deepfilter(const std::string& dir) {
     // Output should not be all zeros and not contain NaN/Inf
     bool has_signal = false;
     bool has_nan = false;
+    float peak = 0.0f;
     for (float v : clean) {
         if (std::isnan(v) || std::isinf(v)) { has_nan = true; break; }
         if (std::abs(v) > 1e-6f) has_signal = true;
+        peak = std::max(peak, std::abs(v));
     }
     REQUIRE(!has_nan);
     REQUIRE(has_signal);
+    // The previous broken STFT/ERB path produced peaks above 150 for this
+    // 0.05-amplitude input while still satisfying the finite/nonzero smoke
+    // checks. A speech enhancer must remain in a sane PCM range.
+    REQUIRE(peak < 2.0f);
 
-    std::printf("ok\n");
+    std::printf("ok (peak=%.4f)\n", peak);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Restore the DeepFilterNet3 v0.5.6 libdf DSP contract around the ONNX graph.
- Make the historical auxiliary blob optional and generate canonical DSP constants in-process.
- Add regression coverage for the 960-point STFT, normalization/layout, deep-filter fusion, and synthesis delay.

## What changed

- Use native 960-point KISS FFT analysis/synthesis with libdf scaling, Vorbis windowing, tail padding, overlap-add, and 480-sample delay compensation.
- Generate the canonical 32 disjoint ERB bands with `min_nb_erb_freqs=2` and initialize/advance ERB and complex normalization exactly as upstream.
- Feed `feat_spec` in channel-major `[1,2,T,96]` order and apply order-5, lookahead-2 coefficients from an immutable noisy spectrum before mask fusion.
- Validate ONNX output element types and exact dynamic shapes.
- Keep `auxiliary_path` source-compatible, but only validate legacy files; inference uses deterministic built-in tables.
- Centralize the existing vendored KISS FFT objects in `speech_core` so ONNX and LiteRT targets can coexist without duplicate symbols.
- Stop downloading the no-longer-required auxiliary artifact and update model documentation/notices.

## Published model

- Hugging Face revision: https://huggingface.co/soniqo/DeepFilterNet3-ONNX/commit/63d8ba442ba900143c468b798e94a04009b2f0c9
- `deepfilter.onnx` SHA-256: `e1157049059434ae0d5857e32c812abea227b975e946b2eb64d001abbce156d3`
- Fresh exports were byte-identical. PyTorch vs ONNX Runtime worst max-absolute error was `1.49e-6` across 5, 20, and 137 frames.

## Quality validation

20 VoiceBank-DEMAND clips, 101.51 seconds total:

| Implementation | PESQ | STOI | SI-SDR |
|---|---:|---:|---:|
| Previous speech-core path | 1.0859 | 0.18415 | -42.155 dB |
| Official DeepFilterNet v0.5.6 | 2.9585 | 0.96064 | 18.228 dB |
| This PR | 2.9602 | 0.96064 | 18.225 dB |

This PR matches the official enhanced waveforms at 54.85 dB mean SI-SDR with 0.000140 mean RMSE. The previous path could peak above 151; the fixed native smoke input peaks at 0.0419.

## Test plan

- Default Release build: 23/23 tests passed.
- ONNX Release build: 26/26 tests passed.
- Exact Hugging Face revision downloaded into a clean directory and passed `test_deepfilter`, including the corrected auxiliary compatibility check.
- LiteRT build passed `test_deepfilter_dsp` and `test_indic_mio_istft` (2/2).
- Combined ONNX + LiteRT linkage and the same targeted tests passed.