### PR TITLE
Add OpenAI-compatible speech transcription endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,9 @@ jobs:
           test -x "$server"
           test -x "$dispatcher"
           "$server" --help | grep -q /v1/audio/speech
+          "$server" --help | grep -q /v1/audio/transcriptions
           "$dispatcher" serve --help | grep -q /v1/audio/speech
+          "$dispatcher" serve --help | grep -q /v1/audio/transcriptions
 
       - name: Test
         # Integration tests (test_models, speech_linux_pipeline) skip
@@ -232,7 +234,9 @@ jobs:
           }
           $help = & (Join-Path $root.FullName "bin/speech-server.exe") --help 2>&1 |
             Out-String
-          if ($LASTEXITCODE -ne 0 -or $help -notmatch "/v1/audio/speech") {
+          if ($LASTEXITCODE -ne 0 -or
+              $help -notmatch "/v1/audio/speech" -or
+              $help -notmatch "/v1/audio/transcriptions") {
             throw "Packaged speech-server.exe failed its help smoke test"
           }
           foreach ($executable in @("speech_transcribe.exe", "speech_synthesize.exe", "speech_phonemize.exe")) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,9 @@ jobs:
               # Multiplexer dispatch must reach the real binaries.
               /usr/bin/speech --help | grep -q transcribe
               /usr/bin/speech-server --help | grep -q /v1/audio/speech
+              /usr/bin/speech-server --help | grep -q /v1/audio/transcriptions
               /usr/bin/speech serve --help | grep -q /v1/audio/speech
+              /usr/bin/speech serve --help | grep -q /v1/audio/transcriptions
               out=$(/usr/bin/speech phonemize 2>&1 | head -2 || true)
               [ -n "$out" ] || { echo "speech phonemize dispatch failed"; exit 1; }
               out=$(/usr/bin/speech download-models voxcpm2 /proc/not-writable 2>&1 | head -2 || true)
@@ -290,7 +292,9 @@ jobs:
           }
           $server = Join-Path $root.FullName "bin/speech-server.exe"
           $help = & $server --help 2>&1 | Out-String
-          if ($LASTEXITCODE -ne 0 -or $help -notmatch "/v1/audio/speech") {
+          if ($LASTEXITCODE -ne 0 -or
+              $help -notmatch "/v1/audio/speech" -or
+              $help -notmatch "/v1/audio/transcriptions") {
             throw "speech-server.exe did not start and print endpoint help"
           }
           foreach ($executable in @("speech_transcribe.exe", "speech_synthesize.exe", "speech_phonemize.exe")) {
@@ -406,7 +410,7 @@ jobs:
 
             - Linux amd64/arm64: `.deb` and `.tar.gz` CLI/server packages
             - Windows x64: self-contained `.zip` with ONNX Runtime and PowerShell model downloader
-            - OpenAI-compatible local TTS: `POST /v1/audio/speech`
+            - OpenAI-compatible local audio: `POST /v1/audio/speech` and `POST /v1/audio/transcriptions`
 
             ## SpeechCore XCFramework
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(SPEECH_CORE_WITH_LITERT "Build the speech_core_models_litert target with 
 option(SPEECH_CORE_WITH_LITERT_LM "Build the liblitert-lm-backed reference LLM (LiteRTFunctionGemmaLLM) as a standalone target (speech_core_models_litert_lm). Independent of SPEECH_CORE_WITH_LITERT — Android consumers need this without libLiteRt. Requires LITERT_LM_DIR pointing at liblitert-lm.{so,dylib,dll}: on macOS use scripts/fetch_litert_lm.sh, on Android use scripts/build_litert_lm_android.sh." OFF)
 option(SPEECH_CORE_WITH_HF_DOWNLOAD "Enable libcurl-backed Hugging Face model downloads (sc_voxcpm2_create_from_pretrained: resumable, retried first-run fetch of the LiteRT bundle). Requires SPEECH_CORE_WITH_LITERT=ON and libcurl (find_package(CURL))." OFF)
 option(SPEECH_CORE_BUILD_EXAMPLES "Build examples/ (Linux C ABI lib, ALSA demo, CLI tools, integration tests). Requires SPEECH_CORE_WITH_ONNX=ON." OFF)
-option(SPEECH_CORE_BUILD_HTTP_SERVER "Build the OpenAI-compatible speech-server sidecar. Requires SPEECH_CORE_WITH_ONNX=ON for Kokoro TTS." OFF)
+option(SPEECH_CORE_BUILD_HTTP_SERVER "Build the OpenAI-compatible speech-server sidecar. Requires SPEECH_CORE_WITH_ONNX=ON for Kokoro TTS and Parakeet STT." OFF)
 option(SPEECH_CORE_WITH_OLLAMA "Build the speech_core_llm_ollama target — Ollama HTTP LLM adapter (tool-calling agents over /api/chat). Vendors cpp-httplib + nlohmann/json under third_party/; no system deps beyond OS sockets." OFF)
 option(SPEECH_CORE_PACKAGE "Add install rules for CLI/server tools and bundled runtimes, then configure CPack (Linux .deb/.tar.gz or Windows .zip)." OFF)
 set(SPEECH_CORE_PACKAGE_VERSION "${PROJECT_VERSION}" CACHE STRING "Version stamped into binary packages. The release workflow passes the git tag (e.g. 0.0.8); local builds default to the project version.")
@@ -25,7 +25,7 @@ endif()
 if(SPEECH_CORE_BUILD_HTTP_SERVER AND NOT SPEECH_CORE_WITH_ONNX)
     message(FATAL_ERROR
         "SPEECH_CORE_BUILD_HTTP_SERVER=ON requires SPEECH_CORE_WITH_ONNX=ON "
-        "(the released sidecar uses Kokoro ONNX)")
+        "(the released sidecar uses Kokoro and Parakeet ONNX)")
 endif()
 
 # ---------------------------------------------------------------------------
@@ -575,12 +575,12 @@ if(SPEECH_CORE_WITH_OLLAMA)
 endif()
 
 # ---------------------------------------------------------------------------
-# OpenAI-compatible local TTS HTTP sidecar (optional executable)
+# OpenAI-compatible local audio HTTP sidecar (optional executable)
 #
 # The protocol/encoding adapter is also built for the default unit suite so
 # its HTTP contract stays covered without ONNX Runtime or model downloads.
 # The executable itself is gated on SPEECH_CORE_BUILD_HTTP_SERVER and links
-# the released Kokoro ONNX backend.
+# the released Kokoro and Parakeet ONNX backends.
 # ---------------------------------------------------------------------------
 
 if(SPEECH_CORE_BUILD_HTTP_SERVER OR SPEECH_CORE_BUILD_TESTS)
@@ -666,6 +666,8 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_pocket_tts_tokenizer"
            OR TEST_NAME STREQUAL "test_litert_functiongemma_llm"
            OR TEST_NAME STREQUAL "test_openai_tts_server"
+           OR TEST_NAME STREQUAL "test_openai_stt_server_e2e"
+           OR TEST_NAME STREQUAL "test_mel_parakeet_contract"
            OR TEST_NAME STREQUAL "test_ollama_llm"
            OR TEST_NAME STREQUAL "test_pipeline_ollama_e2e"
            OR TEST_NAME STREQUAL "test_fdb_bench_smoke"
@@ -715,11 +717,8 @@ if(SPEECH_CORE_BUILD_TESTS)
     # models, no ORT.
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_mel_parakeet_contract.cpp)
         add_executable(test_mel_parakeet_contract
-            tests/test_mel_parakeet_contract.cpp
-            src/audio/mel.cpp
-            src/audio/fft.cpp)
-        target_include_directories(test_mel_parakeet_contract PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/include)
+            tests/test_mel_parakeet_contract.cpp)
+        target_link_libraries(test_mel_parakeet_contract PRIVATE speech_core)
         add_test(NAME test_mel_parakeet_contract
                  COMMAND test_mel_parakeet_contract)
     endif()
@@ -779,6 +778,26 @@ if(SPEECH_CORE_BUILD_TESTS)
                 target_compile_definitions(bench_ort_models PRIVATE NOMINMAX)
             endif()
         endif()
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_openai_stt_server_e2e.cpp)
+        add_executable(test_openai_stt_server_e2e
+            tests/test_openai_stt_server_e2e.cpp)
+        target_include_directories(test_openai_stt_server_e2e PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/http
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/httplib
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+        target_link_libraries(test_openai_stt_server_e2e PRIVATE
+            speech_core_http_support speech_core_models)
+        target_compile_definitions(test_openai_stt_server_e2e PRIVATE
+            SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+        if(MSVC)
+            target_compile_definitions(test_openai_stt_server_e2e PRIVATE
+                _USE_MATH_DEFINES NOMINMAX _WIN32_WINNT=0x0A00)
+        endif()
+        add_test(NAME test_openai_stt_server_e2e
+                 COMMAND test_openai_stt_server_e2e)
     endif()
 
     if(SPEECH_CORE_WITH_ONNX AND

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ On-device speech infrastructure in **C++17** for **Linux, Windows, and Android**
 
 Runs locally on CPU. No cloud, no Python at inference, and no audio leaves the machine.
 
-**[📚 Full documentation →](https://soniqo.audio/speech-core)** · **[🐧 Linux](https://soniqo.audio/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Full documentation →](https://soniqo.audio/speech-core)** · **[🐧 Linux](https://soniqo.audio/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP audio](docs/http-server.md)**
 
 **[🤗 Models](https://huggingface.co/soniqo)** · **[🍎 Apple sibling](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -12,7 +12,7 @@
 
 تعمل محلياً على المعالج. لا سحابة ولا Python أثناء الاستدلال، ولا يغادر الصوت الجهاز.
 
-**[📚 الوثائق الكاملة ←](https://soniqo.audio/ar/speech-core)** · **[🐧 Linux](https://soniqo.audio/ar/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ar/getting-started/windows)** · **[⌨️ واجهة سطح المكتب](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 الوثائق الكاملة ←](https://soniqo.audio/ar/speech-core)** · **[🐧 Linux](https://soniqo.audio/ar/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ar/getting-started/windows)** · **[⌨️ واجهة سطح المكتب](docs/cli.md)** · **[🔊 صوت HTTP](docs/http-server.md)**
 
 **[🤗 النماذج](https://huggingface.co/soniqo)** · **[🍎 مشروع Apple الشقيق](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_de.md
+++ b/README_de.md
@@ -10,7 +10,7 @@ Lokale Sprachinfrastruktur in **C++17** für **Linux, Windows und Android**: Spr
 
 Läuft lokal auf der CPU. Keine Cloud, kein Python bei der Inferenz und keine Audiodaten verlassen das Gerät.
 
-**[📚 Vollständige Dokumentation →](https://soniqo.audio/de/speech-core)** · **[🐧 Linux](https://soniqo.audio/de/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/de/getting-started/windows)** · **[⌨️ Desktop-CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Vollständige Dokumentation →](https://soniqo.audio/de/speech-core)** · **[🐧 Linux](https://soniqo.audio/de/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/de/getting-started/windows)** · **[⌨️ Desktop-CLI](docs/cli.md)** · **[🔊 HTTP-Audio](docs/http-server.md)**
 
 **[🤗 Modelle](https://huggingface.co/soniqo)** · **[🍎 Apple-Schwesterprojekt](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_es.md
+++ b/README_es.md
@@ -10,7 +10,7 @@ Infraestructura de voz local en **C++17** para **Linux, Windows y Android**: det
 
 Se ejecuta localmente en CPU. Sin nube, sin Python durante la inferencia y sin enviar audio fuera del dispositivo.
 
-**[📚 Documentación completa →](https://soniqo.audio/es/speech-core)** · **[🐧 Linux](https://soniqo.audio/es/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/es/getting-started/windows)** · **[⌨️ CLI de escritorio](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Documentación completa →](https://soniqo.audio/es/speech-core)** · **[🐧 Linux](https://soniqo.audio/es/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/es/getting-started/windows)** · **[⌨️ CLI de escritorio](docs/cli.md)** · **[🔊 Audio HTTP](docs/http-server.md)**
 
 **[🤗 Modelos](https://huggingface.co/soniqo)** · **[🍎 Proyecto hermano para Apple](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -10,7 +10,7 @@ Infrastructure vocale embarquée en **C++17** pour **Linux, Windows et Android**
 
 Tout s'exécute localement sur CPU. Aucun cloud, aucun Python à l'inférence et aucun son ne quitte l'appareil.
 
-**[📚 Documentation complète →](https://soniqo.audio/fr/speech-core)** · **[🐧 Linux](https://soniqo.audio/fr/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/fr/getting-started/windows)** · **[⌨️ CLI desktop](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Documentation complète →](https://soniqo.audio/fr/speech-core)** · **[🐧 Linux](https://soniqo.audio/fr/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/fr/getting-started/windows)** · **[⌨️ CLI desktop](docs/cli.md)** · **[🔊 Audio HTTP](docs/http-server.md)**
 
 **[🤗 Modèles](https://huggingface.co/soniqo)** · **[🍎 Projet Apple associé](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_hi.md
+++ b/README_hi.md
@@ -10,7 +10,7 @@
 
 यह CPU पर पूरी तरह स्थानीय रूप से चलता है। inference के समय cloud या Python नहीं चाहिए और audio device से बाहर नहीं जाता।
 
-**[📚 पूरा documentation →](https://soniqo.audio/hi/speech-core)** · **[🐧 Linux](https://soniqo.audio/hi/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/hi/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 पूरा documentation →](https://soniqo.audio/hi/speech-core)** · **[🐧 Linux](https://soniqo.audio/hi/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/hi/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP audio](docs/http-server.md)**
 
 **[🤗 Models](https://huggingface.co/soniqo)** · **[🍎 Apple sibling](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,7 +10,7 @@
 
 CPU 上でローカルに動作します。推論時にクラウドや Python は不要で、音声が端末の外へ送信されることもありません。
 
-**[📚 完全なドキュメント →](https://soniqo.audio/ja/speech-core)** · **[🐧 Linux](https://soniqo.audio/ja/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ja/getting-started/windows)** · **[⌨️ デスクトップ CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 完全なドキュメント →](https://soniqo.audio/ja/speech-core)** · **[🐧 Linux](https://soniqo.audio/ja/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ja/getting-started/windows)** · **[⌨️ デスクトップ CLI](docs/cli.md)** · **[🔊 HTTP オーディオ](docs/http-server.md)**
 
 **[🤗 モデル](https://huggingface.co/soniqo)** · **[🍎 Apple 向け兄弟プロジェクト](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -10,7 +10,7 @@
 
 CPU에서 완전히 로컬로 실행됩니다. 추론 시 클라우드나 Python이 필요 없으며, 오디오가 기기 밖으로 나가지 않습니다.
 
-**[📚 전체 문서 →](https://soniqo.audio/ko/speech-core)** · **[🐧 Linux](https://soniqo.audio/ko/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ko/getting-started/windows)** · **[⌨️ 데스크톱 CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 전체 문서 →](https://soniqo.audio/ko/speech-core)** · **[🐧 Linux](https://soniqo.audio/ko/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ko/getting-started/windows)** · **[⌨️ 데스크톱 CLI](docs/cli.md)** · **[🔊 HTTP 오디오](docs/http-server.md)**
 
 **[🤗 모델](https://huggingface.co/soniqo)** · **[🍎 Apple용 자매 프로젝트](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -10,7 +10,7 @@ Infraestrutura de voz no dispositivo em **C++17** para **Linux, Windows e Androi
 
 Executa localmente na CPU. Sem nuvem, sem Python na inferência e sem áudio saindo do dispositivo.
 
-**[📚 Documentação completa →](https://soniqo.audio/pt/speech-core)** · **[🐧 Linux](https://soniqo.audio/pt/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/pt/getting-started/windows)** · **[⌨️ CLI desktop](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Documentação completa →](https://soniqo.audio/pt/speech-core)** · **[🐧 Linux](https://soniqo.audio/pt/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/pt/getting-started/windows)** · **[⌨️ CLI desktop](docs/cli.md)** · **[🔊 Áudio HTTP](docs/http-server.md)**
 
 **[🤗 Modelos](https://huggingface.co/soniqo)** · **[🍎 Projeto irmão para Apple](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -10,7 +10,7 @@
 
 Работает локально на CPU. Без облака и Python во время инференса; аудио не покидает устройство.
 
-**[📚 Полная документация →](https://soniqo.audio/ru/speech-core)** · **[🐧 Linux](https://soniqo.audio/ru/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ru/getting-started/windows)** · **[⌨️ Настольный CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Полная документация →](https://soniqo.audio/ru/speech-core)** · **[🐧 Linux](https://soniqo.audio/ru/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/ru/getting-started/windows)** · **[⌨️ Настольный CLI](docs/cli.md)** · **[🔊 HTTP-аудио](docs/http-server.md)**
 
 **[🤗 Модели](https://huggingface.co/soniqo)** · **[🍎 Проект для Apple](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_th.md
+++ b/README_th.md
@@ -10,7 +10,7 @@
 
 ทำงานภายในเครื่องบน CPU ไม่ใช้คลาวด์หรือ Python ระหว่าง inference และเสียงไม่ออกจากอุปกรณ์
 
-**[📚 เอกสารฉบับเต็ม →](https://soniqo.audio/th/speech-core)** · **[🐧 Linux](https://soniqo.audio/th/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/th/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 เอกสารฉบับเต็ม →](https://soniqo.audio/th/speech-core)** · **[🐧 Linux](https://soniqo.audio/th/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/th/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 เสียง HTTP](docs/http-server.md)**
 
 **[🤗 โมเดล](https://huggingface.co/soniqo)** · **[🍎 โปรเจกต์สำหรับ Apple](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_tr.md
+++ b/README_tr.md
@@ -10,7 +10,7 @@
 
 CPU üzerinde yerel çalışır. Çıkarımda bulut veya Python yoktur; ses cihazdan ayrılmaz.
 
-**[📚 Tam belgeler →](https://soniqo.audio/tr/speech-core)** · **[🐧 Linux](https://soniqo.audio/tr/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/tr/getting-started/windows)** · **[⌨️ Masaüstü CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Tam belgeler →](https://soniqo.audio/tr/speech-core)** · **[🐧 Linux](https://soniqo.audio/tr/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/tr/getting-started/windows)** · **[⌨️ Masaüstü CLI](docs/cli.md)** · **[🔊 HTTP ses](docs/http-server.md)**
 
 **[🤗 Modeller](https://huggingface.co/soniqo)** · **[🍎 Apple kardeş projesi](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -10,7 +10,7 @@ Hạ tầng giọng nói chạy trên thiết bị bằng **C++17** cho **Linux,
 
 Chạy cục bộ trên CPU. Không đám mây, không Python khi suy luận và âm thanh không rời khỏi thiết bị.
 
-**[📚 Tài liệu đầy đủ →](https://soniqo.audio/vi/speech-core)** · **[🐧 Linux](https://soniqo.audio/vi/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/vi/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 Tài liệu đầy đủ →](https://soniqo.audio/vi/speech-core)** · **[🐧 Linux](https://soniqo.audio/vi/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/vi/getting-started/windows)** · **[⌨️ Desktop CLI](docs/cli.md)** · **[🔊 Âm thanh HTTP](docs/http-server.md)**
 
 **[🤗 Mô hình](https://huggingface.co/soniqo)** · **[🍎 Dự án Apple](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 完全在本地 CPU 上运行。推理不依赖云端或 Python，音频不会离开设备。
 
-**[📚 完整文档 →](https://soniqo.audio/zh/speech-core)** · **[🐧 Linux](https://soniqo.audio/zh/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/zh/getting-started/windows)** · **[⌨️ 桌面 CLI](docs/cli.md)** · **[🔊 HTTP TTS](docs/http-server.md)**
+**[📚 完整文档 →](https://soniqo.audio/zh/speech-core)** · **[🐧 Linux](https://soniqo.audio/zh/getting-started/linux)** · **[🪟 Windows](https://soniqo.audio/zh/getting-started/windows)** · **[⌨️ 桌面 CLI](docs/cli.md)** · **[🔊 HTTP 音频](docs/http-server.md)**
 
 **[🤗 模型](https://huggingface.co/soniqo)** · **[🍎 Apple 端项目](https://github.com/soniqo/speech-swift)** · **[💬 Discord](https://discord.gg/TnCryqEMgu)**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ than the Apple CLI documented at [soniqo.audio/cli](https://soniqo.audio/cli).
 **[Speech Core overview](https://soniqo.audio/speech-core)** ·
 **[Linux guide](https://soniqo.audio/getting-started/linux)** ·
 **[Windows guide](https://soniqo.audio/getting-started/windows)** ·
-**[HTTP TTS server](http-server.md)**
+**[HTTP audio server](http-server.md)**
 
 ## Install a release package
 
@@ -48,7 +48,7 @@ Set-ExecutionPolicy -Scope Process Bypass
 | Transcription | `speech transcribe` | `speech_transcribe.exe` | ✓ | ✓ | ✓ |
 | Kokoro synthesis | `speech speak` | `speech_synthesize.exe` | ✓ | ✓ | ✓ |
 | Kokoro phonemizer | `speech phonemize` | `speech_phonemize.exe` | ✓ | ✓ | ✓ |
-| OpenAI-compatible HTTP TTS | `speech serve` | `speech-server.exe` | ✓ | ✓ | ✓ |
+| OpenAI-compatible HTTP audio | `speech serve` | `speech-server.exe` | ✓ | ✓ | ✓ |
 | VoxCPM2 voice cloning | `speech clone` | — | ✓ | — | — |
 | ALSA microphone pipeline | `speech demo` | — | ✓ | — | — |
 | ONNX model downloader | `speech download-models` | `speech_download_models.ps1` | ✓ | ✓ | ✓ |

--- a/docs/http-server.md
+++ b/docs/http-server.md
@@ -1,14 +1,17 @@
-# OpenAI-compatible local TTS server
+# OpenAI-compatible local audio server
 
-`speech-server` exposes Kokoro ONNX through the OpenAI speech-synthesis request
-shape. It runs locally on Linux and Windows and does not send text or audio to
-a remote service.
+`speech-server` exposes Kokoro ONNX text-to-speech and Parakeet ONNX
+speech-to-text through OpenAI-compatible request shapes. It runs locally on
+Linux and Windows and does not send text or audio to a remote service.
 
 ```text
 POST /v1/audio/speech
+POST /v1/audio/transcriptions
 ```
 
-The server is included in speech-core release packages starting with v0.0.11.
+The server is included in speech-core release packages. Parakeet is loaded only
+on the first transcription request, so TTS-only startup time and resident model
+memory remain unchanged.
 
 ## Install and start
 
@@ -47,7 +50,7 @@ needed:
 .\speech-server.exe --model-dir D:\speech-models
 ```
 
-## Request contract
+## Speech synthesis
 
 The JSON body follows the OpenAI speech endpoint shape:
 
@@ -104,6 +107,34 @@ The model downloader installs `af_alloy`, `af_bella`, `af_heart`, `af_nicole`,
 `af_sky`, `am_adam`, `am_michael`, `bf_emma`, and `bm_george`. A native voice
 ID selects the matching file from the model directory's `voices` folder.
 
+## Speech transcription
+
+The transcription endpoint accepts the standard multipart form shape. The
+`file` must be an uncompressed RIFF/WAVE file containing PCM16, PCM24, PCM32,
+or Float32 audio. Mono and multichannel input from 8 kHz through 384 kHz is
+accepted; the adapter downmixes and resamples it to the Parakeet model's 16 kHz
+mono Float32 input.
+
+| Field | Required | Behavior |
+|---|:---:|---|
+| `file` | ✓ | One WAV file, at most 25 MiB and 10 minutes |
+| `model` | ✓ | A non-empty OpenAI model name such as `whisper-1`; the local server always routes it to the installed Parakeet model |
+| `response_format` |  | `json` by default, or `text`, `verbose_json`, `srt`, or `vtt` |
+| `language` |  | Accepted for client compatibility; Parakeet auto-detects language and cannot force it |
+| `prompt` |  | Accepted for client compatibility; the Parakeet export has no prompt channel |
+| `temperature` |  | Accepted in the OpenAI range `0...1`; greedy Parakeet decoding does not sample |
+
+```bash
+curl http://127.0.0.1:8080/v1/audio/transcriptions \
+  -F 'file=@recording.wav;type=audio/wav' \
+  -F 'model=whisper-1'
+```
+
+The default JSON response is `{"text":"..."}`. `verbose_json`, SRT, and VTT
+contain one utterance-level segment because the bundled Parakeet interface does
+not expose word or segment timestamps. Compressed inputs such as MP3, M4A, and
+WebM are rejected so the package does not need an additional codec runtime.
+
 ## Authentication and network exposure
 
 The default bind address is `127.0.0.1`. Configure a bearer token with the
@@ -114,7 +145,8 @@ export SPEECH_SERVER_API_KEY='replace-with-a-random-value'
 speech serve --host 0.0.0.0
 ```
 
-Clients then send `Authorization: Bearer replace-with-a-random-value`.
+Clients then send `Authorization: Bearer replace-with-a-random-value` to either
+audio endpoint.
 `--api-key` is also accepted for short-lived local sessions. A non-loopback
 bind is rejected when no key is configured unless
 `--allow-unauthenticated-remote` is passed explicitly. That override should be
@@ -124,9 +156,11 @@ The server speaks plaintext HTTP. For access beyond a trusted, isolated
 network, keep bearer authentication enabled and place it behind a
 TLS-terminating reverse proxy and firewall.
 
-The server limits request bodies to 1 MiB, caps input at 4,096 characters, and
-serializes inference through one resident Kokoro instance. Text is not written
-to server logs.
+The server keeps speech-synthesis requests at the existing 1 MiB limit and caps
+uploaded transcription files at 25 MiB. It caps synthesis text and transcription
+prompts at 4,096 characters. Kokoro remains resident, Parakeet loads lazily, and
+all inference is serialized through one model lock. Text and transcripts are
+not written to server logs.
 
 ## Build from source
 
@@ -142,5 +176,7 @@ cmake --build build-server --parallel --target speech_server
 ```
 
 The model-independent HTTP contract tests are part of the default CTest suite
-and do not download model weights. A build with ONNX additionally compiles and
-links the production `speech-server` executable.
+and do not download model weights. A build with ONNX additionally compiles the
+production `speech-server` executable and a real-model transcription endpoint
+test. Set `SPEECH_MODEL_DIR` to a downloaded model bundle to run that E2E path;
+it skips when the bundle is unavailable.

--- a/examples/http/speech_server.cpp
+++ b/examples/http/speech_server.cpp
@@ -1,6 +1,7 @@
 #include "openai_tts_server.h"
 
 #include "speech_core/models/kokoro_tts.h"
+#include "speech_core/models/parakeet_stt.h"
 
 #include "default_model_dir.h"
 #include "httplib.h"
@@ -45,13 +46,15 @@ void print_usage(const char* executable) {
     std::cout
         << "usage: " << executable << " [options]\n"
         << "\n"
-        << "OpenAI-compatible local TTS server backed by Kokoro ONNX.\n"
-        << "Endpoint: POST /v1/audio/speech\n"
+        << "OpenAI-compatible local audio server backed by ONNX models.\n"
+        << "Endpoints:\n"
+        << "  POST /v1/audio/speech          Kokoro text-to-speech\n"
+        << "  POST /v1/audio/transcriptions  Parakeet speech-to-text\n"
         << "\n"
         << "options:\n"
         << "  --host HOST       bind address (default: 127.0.0.1)\n"
         << "  --port PORT       listen port (default: 8080)\n"
-        << "  --model-dir PATH  Kokoro ONNX bundle directory\n"
+        << "  --model-dir PATH  Kokoro and Parakeet ONNX bundle directory\n"
         << "                    (default: $SPEECH_MODEL_DIR or platform cache)\n"
         << "  --api-key KEY     require Authorization: Bearer KEY\n"
         << "                    (default: $SPEECH_SERVER_API_KEY or no auth)\n"
@@ -119,6 +122,11 @@ int main(int argc, char** argv) {
         const fs::path model_dir(options.model_dir);
         const fs::path model_path = model_dir / "kokoro-e2e.onnx";
         const fs::path voices_dir = model_dir / "voices";
+        const fs::path stt_encoder_path =
+            model_dir / "parakeet-encoder-int8.onnx";
+        const fs::path stt_decoder_path =
+            model_dir / "parakeet-decoder-joint-int8.onnx";
+        const fs::path stt_vocab_path = model_dir / "vocab.json";
         if (!is_nonempty_regular_file(model_path)) {
             throw std::runtime_error(
                 "missing " + model_path.string() +
@@ -150,6 +158,7 @@ int main(int argc, char** argv) {
             voices_dir.string(),
             model_dir.string(),
             /*hw_accel=*/false);
+        std::unique_ptr<speech_core::ParakeetStt> stt;
         std::mutex inference_mutex;
 
         httplib::Server server;
@@ -176,6 +185,29 @@ int main(int argc, char** argv) {
                     std::move(samples), tts->output_sample_rate()};
             },
             options.api_key);
+        speech_core::http::register_openai_transcription_routes(
+            server,
+            [&](const speech_core::http::OpenAITranscriptionRequest& request) {
+                std::lock_guard<std::mutex> lock(inference_mutex);
+                if (!stt) {
+                    for (const fs::path& path : {
+                             stt_encoder_path, stt_decoder_path, stt_vocab_path}) {
+                        if (!is_nonempty_regular_file(path)) {
+                            throw std::runtime_error(
+                                "missing or empty " + path.string());
+                        }
+                    }
+                    stt = std::make_unique<speech_core::ParakeetStt>(
+                        stt_encoder_path.string(),
+                        stt_decoder_path.string(),
+                        stt_vocab_path.string(),
+                        /*hw_accel=*/false);
+                }
+                return stt->transcribe(
+                    request.samples.data(), request.samples.size(),
+                    request.sample_rate);
+            },
+            options.api_key);
 
         if (!is_loopback_host(options.host) &&
             options.allow_unauthenticated_remote && options.api_key.empty()) {
@@ -187,7 +219,8 @@ int main(int argc, char** argv) {
         }
         std::cout << "speech-server listening on http://" << options.host << ':'
                   << options.port << "\n";
-        std::cout << "POST /v1/audio/speech\n" << std::flush;
+        std::cout << "POST /v1/audio/speech\n"
+                  << "POST /v1/audio/transcriptions\n" << std::flush;
         if (!server.listen_after_bind()) {
             throw std::runtime_error("server stopped before accepting requests");
         }

--- a/scripts/speech-dispatch.sh
+++ b/scripts/speech-dispatch.sh
@@ -48,7 +48,7 @@ usage: speech <command> [args]
 commands:
   transcribe <input.wav>             speech-to-text (Parakeet + Silero VAD)
   speak "<text>" [out.wav]           text-to-speech (Kokoro)
-  serve [--host HOST] [--port PORT]  OpenAI-compatible local TTS server
+  serve [--host HOST] [--port PORT]  OpenAI-compatible local audio server
   clone <ref.wav> "<text>" <out.wav> voice cloning (VoxCPM2)
   phonemize "<text>" [language]      text -> phonemes (Kokoro phonemizer)
   demo [--transcribe-only]           live ALSA mic loop

--- a/src/http/openai_tts_server.cpp
+++ b/src/http/openai_tts_server.cpp
@@ -1,6 +1,7 @@
 #include "openai_tts_server.h"
 
 #include "speech_core/audio/pcm_codec.h"
+#include "speech_core/audio/resampler.h"
 
 #include "httplib.h"
 #include "nlohmann/json.hpp"
@@ -10,7 +11,11 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <limits>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -21,8 +26,15 @@ namespace speech_core::http {
 namespace {
 
 constexpr size_t kMaximumInputCharacters = 4096;
-constexpr size_t kMaximumRequestBytes = 1024 * 1024;
+constexpr size_t kMaximumTtsRequestBytes = 1024 * 1024;
+constexpr size_t kMaximumAudioFileBytes = 25 * 1024 * 1024;
+constexpr size_t kMaximumServerRequestBytes = 26 * 1024 * 1024;
 constexpr size_t kMaximumVoiceIdBytes = 128;
+constexpr size_t kMaximumModelBytes = 128;
+constexpr size_t kMaximumFilenameBytes = 255;
+constexpr size_t kMaximumLanguageBytes = 64;
+constexpr int kTranscriptionSampleRate = 16000;
+constexpr size_t kMaximumAudioSeconds = 10 * 60;
 
 const std::unordered_set<std::string> kModelAliases = {
     "kokoro",
@@ -37,6 +49,11 @@ const std::unordered_set<std::string> kModelAliases = {
 const std::unordered_set<std::string> kOpenAIVoices = {
     "alloy", "ash", "ballad", "cedar", "coral", "echo", "fable",
     "juniper", "marin", "nova", "onyx", "sage", "shimmer", "verse",
+};
+
+class RequestTooLarge : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
 };
 
 std::string trim_ascii(std::string value) {
@@ -126,6 +143,16 @@ void set_openai_error(httplib::Response& response,
             {"param", nullptr},
         }},
     });
+}
+
+void set_text(httplib::Response& response,
+              int status,
+              std::string body,
+              const char* content_type) {
+    response.status = status;
+    response.set_header("Cache-Control", "no-store");
+    response.set_header("X-Content-Type-Options", "nosniff");
+    response.set_content(std::move(body), content_type);
 }
 
 bool constant_time_equal(const std::string& lhs, const std::string& rhs) {
@@ -269,6 +296,310 @@ OpenAITtsRequest parse_request(const std::string& body) {
     return request;
 }
 
+uint16_t read_u16(const std::string& bytes, size_t offset) {
+    return static_cast<uint16_t>(
+        static_cast<unsigned char>(bytes[offset]) |
+        (static_cast<uint16_t>(static_cast<unsigned char>(bytes[offset + 1])) << 8u));
+}
+
+uint32_t read_u32(const std::string& bytes, size_t offset) {
+    return static_cast<uint32_t>(static_cast<unsigned char>(bytes[offset])) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(bytes[offset + 1])) << 8u) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(bytes[offset + 2])) << 16u) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(bytes[offset + 3])) << 24u);
+}
+
+std::vector<float> decode_wav_to_mono_16k(const std::string& bytes) {
+    if (bytes.size() < 12 || bytes.compare(0, 4, "RIFF") != 0 ||
+        bytes.compare(8, 4, "WAVE") != 0) {
+        throw InvalidSpeechRequest("The uploaded file must be a valid RIFF/WAVE file");
+    }
+
+    const uint64_t declared_end = static_cast<uint64_t>(read_u32(bytes, 4)) + 8u;
+    if (declared_end < 12u || declared_end > bytes.size()) {
+        throw InvalidSpeechRequest("The uploaded WAV file is truncated");
+    }
+    const size_t riff_end = static_cast<size_t>(declared_end);
+
+    bool have_format = false;
+    bool have_data = false;
+    uint16_t format = 0;
+    uint16_t channels = 0;
+    uint16_t block_align = 0;
+    uint16_t bits_per_sample = 0;
+    uint32_t sample_rate = 0;
+    size_t data_offset = 0;
+    size_t data_size = 0;
+
+    size_t offset = 12;
+    while (offset + 8u <= riff_end) {
+        const uint32_t chunk_size_u32 = read_u32(bytes, offset + 4u);
+        const size_t chunk_size = static_cast<size_t>(chunk_size_u32);
+        const size_t content_offset = offset + 8u;
+        if (chunk_size > riff_end - content_offset) {
+            throw InvalidSpeechRequest("The uploaded WAV file contains a truncated chunk");
+        }
+        if (bytes.compare(offset, 4, "fmt ") == 0 && !have_format) {
+            if (chunk_size < 16u) {
+                throw InvalidSpeechRequest("The uploaded WAV file has an invalid format chunk");
+            }
+            format = read_u16(bytes, content_offset);
+            channels = read_u16(bytes, content_offset + 2u);
+            sample_rate = read_u32(bytes, content_offset + 4u);
+            block_align = read_u16(bytes, content_offset + 12u);
+            bits_per_sample = read_u16(bytes, content_offset + 14u);
+            have_format = true;
+        } else if (bytes.compare(offset, 4, "data") == 0 && !have_data) {
+            data_offset = content_offset;
+            data_size = chunk_size;
+            have_data = true;
+        }
+
+        const size_t padded_size = chunk_size + (chunk_size & 1u);
+        if (padded_size > riff_end - content_offset) {
+            if (chunk_size == riff_end - content_offset) break;
+            throw InvalidSpeechRequest("The uploaded WAV file contains an invalid chunk size");
+        }
+        offset = content_offset + padded_size;
+    }
+
+    if (!have_format || !have_data || data_size == 0u) {
+        throw InvalidSpeechRequest("The uploaded WAV file must contain format and audio data");
+    }
+    if (channels == 0u || channels > 32u) {
+        throw InvalidSpeechRequest("The uploaded WAV file has an unsupported channel count");
+    }
+    if (sample_rate < 8000u || sample_rate > 384000u) {
+        throw InvalidSpeechRequest("The uploaded WAV file has an unsupported sample rate");
+    }
+
+    const bool is_pcm = format == 1u &&
+        (bits_per_sample == 16u || bits_per_sample == 24u || bits_per_sample == 32u);
+    const bool is_float = format == 3u && bits_per_sample == 32u;
+    if (!is_pcm && !is_float) {
+        throw InvalidSpeechRequest(
+            "Unsupported WAV encoding; use PCM16, PCM24, PCM32, or Float32");
+    }
+    const size_t bytes_per_sample = bits_per_sample / 8u;
+    const size_t expected_block_align = static_cast<size_t>(channels) * bytes_per_sample;
+    if (block_align != expected_block_align || data_size % expected_block_align != 0u) {
+        throw InvalidSpeechRequest("The uploaded WAV file has an invalid sample layout");
+    }
+
+    const size_t frame_count = data_size / expected_block_align;
+    if (static_cast<uint64_t>(frame_count) >
+        static_cast<uint64_t>(sample_rate) * kMaximumAudioSeconds) {
+        throw InvalidSpeechRequest(
+            "The uploaded WAV file must not exceed 10 minutes");
+    }
+    std::vector<float> mono;
+    mono.reserve(frame_count);
+    for (size_t frame = 0; frame < frame_count; ++frame) {
+        double sum = 0.0;
+        for (size_t channel = 0; channel < channels; ++channel) {
+            const size_t sample_offset = data_offset +
+                frame * expected_block_align + channel * bytes_per_sample;
+            float sample = 0.0f;
+            if (is_float) {
+                const uint32_t raw = read_u32(bytes, sample_offset);
+                static_assert(sizeof(float) == sizeof(raw), "Float32 must be 32 bits");
+                std::memcpy(&sample, &raw, sizeof(sample));
+            } else if (bits_per_sample == 16u) {
+                int32_t value = read_u16(bytes, sample_offset);
+                if (value >= (1 << 15)) value -= (1 << 16);
+                sample = static_cast<float>(value) / 32768.0f;
+            } else if (bits_per_sample == 24u) {
+                int32_t value =
+                    static_cast<unsigned char>(bytes[sample_offset]) |
+                    (static_cast<int32_t>(
+                         static_cast<unsigned char>(bytes[sample_offset + 1u])) << 8u) |
+                    (static_cast<int32_t>(
+                         static_cast<unsigned char>(bytes[sample_offset + 2u])) << 16u);
+                if (value >= (1 << 23)) value -= (1 << 24);
+                sample = static_cast<float>(value) / 8388608.0f;
+            } else {
+                int64_t value = read_u32(bytes, sample_offset);
+                if (value >= (int64_t{1} << 31)) value -= (int64_t{1} << 32);
+                sample = static_cast<float>(
+                    static_cast<double>(value) / 2147483648.0);
+            }
+            if (!std::isfinite(sample)) {
+                throw InvalidSpeechRequest("The uploaded WAV file contains non-finite audio");
+            }
+            sample = std::clamp(sample, -1.0f, 1.0f);
+            sum += sample;
+        }
+        mono.push_back(static_cast<float>(sum / channels));
+    }
+
+    if (sample_rate == kTranscriptionSampleRate) return mono;
+    std::vector<float> resampled = speech_core::Resampler::resample(
+        mono.data(), mono.size(), static_cast<int>(sample_rate),
+        kTranscriptionSampleRate);
+    if (resampled.empty()) {
+        throw InvalidSpeechRequest("The uploaded WAV file contains too little audio");
+    }
+    if (!std::all_of(resampled.begin(), resampled.end(),
+                     [](float sample) { return std::isfinite(sample); })) {
+        throw InvalidSpeechRequest("The uploaded WAV file produced invalid audio");
+    }
+    return resampled;
+}
+
+std::string single_form_field(const httplib::Request& request,
+                              const char* name,
+                              bool required,
+                              size_t maximum_bytes) {
+    const size_t count = request.form.get_field_count(name);
+    if (count > 1u) {
+        throw InvalidSpeechRequest(std::string("Duplicate '") + name + "' field");
+    }
+    std::string value = count == 1u ? request.form.get_field(name) : std::string{};
+    value = trim_ascii(std::move(value));
+    if (required && value.empty()) {
+        throw InvalidSpeechRequest(std::string("Missing '") + name + "' field");
+    }
+    if (value.size() > maximum_bytes) {
+        throw InvalidSpeechRequest(
+            std::string("The '") + name + "' field is too long");
+    }
+    return value;
+}
+
+OpenAITranscriptionRequest parse_transcription_request(
+    const httplib::Request& request) {
+    if (!request.is_multipart_form_data()) {
+        throw InvalidSpeechRequest(
+            "The transcription endpoint requires multipart/form-data");
+    }
+    if (request.form.get_file_count("file") == 0u) {
+        throw InvalidSpeechRequest("Missing 'file' field");
+    }
+    if (request.form.get_file_count("file") != 1u) {
+        throw InvalidSpeechRequest("Duplicate 'file' field");
+    }
+
+    const httplib::FormData& file = request.form.files.find("file")->second;
+    if (file.content.empty()) {
+        throw InvalidSpeechRequest("The uploaded audio file is empty");
+    }
+    if (file.content.size() > kMaximumAudioFileBytes) {
+        throw RequestTooLarge("The uploaded audio file must not exceed 25 MiB");
+    }
+
+    OpenAITranscriptionRequest parsed;
+    parsed.model = single_form_field(request, "model", true, kMaximumModelBytes);
+    parsed.filename = file.filename.empty() ? "audio.wav" : file.filename;
+    if (parsed.filename.size() > kMaximumFilenameBytes) {
+        throw InvalidSpeechRequest("The uploaded filename is too long");
+    }
+    parsed.language = single_form_field(
+        request, "language", false, kMaximumLanguageBytes);
+    parsed.prompt = single_form_field(
+        request, "prompt", false, kMaximumInputCharacters * 4u);
+    if (utf8_character_count(parsed.prompt) > kMaximumInputCharacters) {
+        throw InvalidSpeechRequest("The 'prompt' field must not exceed 4096 characters");
+    }
+
+    parsed.response_format = ascii_lower(single_form_field(
+        request, "response_format", false, 32u));
+    if (parsed.response_format.empty()) parsed.response_format = "json";
+    static const std::unordered_set<std::string> formats = {
+        "json", "text", "verbose_json", "srt", "vtt"};
+    if (!formats.count(parsed.response_format)) {
+        throw InvalidSpeechRequest(
+            "Unsupported response format '" + parsed.response_format +
+            "'; use 'json', 'text', 'verbose_json', 'srt', or 'vtt'");
+    }
+
+    const std::string temperature = single_form_field(
+        request, "temperature", false, 32u);
+    if (!temperature.empty()) {
+        size_t consumed = 0;
+        double value = 0.0;
+        try {
+            value = std::stod(temperature, &consumed);
+        } catch (const std::exception&) {
+            throw InvalidSpeechRequest("The 'temperature' field must be a number");
+        }
+        if (consumed != temperature.size() || !std::isfinite(value) ||
+            value < 0.0 || value > 1.0) {
+            throw InvalidSpeechRequest(
+                "The 'temperature' field must be between 0 and 1");
+        }
+        parsed.temperature = static_cast<float>(value);
+    }
+    parsed.samples = decode_wav_to_mono_16k(file.content);
+    parsed.sample_rate = kTranscriptionSampleRate;
+    return parsed;
+}
+
+std::string timestamp(double seconds, char separator) {
+    if (!std::isfinite(seconds) || seconds < 0.0) seconds = 0.0;
+    const uint64_t milliseconds = static_cast<uint64_t>(std::llround(seconds * 1000.0));
+    const uint64_t hours = milliseconds / 3600000u;
+    const uint64_t minutes = (milliseconds / 60000u) % 60u;
+    const uint64_t whole_seconds = (milliseconds / 1000u) % 60u;
+    const uint64_t remainder = milliseconds % 1000u;
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "%02llu:%02llu:%02llu%c%03llu",
+                  static_cast<unsigned long long>(hours),
+                  static_cast<unsigned long long>(minutes),
+                  static_cast<unsigned long long>(whole_seconds), separator,
+                  static_cast<unsigned long long>(remainder));
+    return buffer;
+}
+
+void set_transcription_response(
+    httplib::Response& response,
+    const OpenAITranscriptionRequest& request,
+    const speech_core::TranscriptionResult& result) {
+    const double duration = static_cast<double>(request.samples.size()) /
+        static_cast<double>(request.sample_rate);
+    const double start = std::isfinite(result.start_time)
+        ? std::clamp(static_cast<double>(result.start_time), 0.0, duration) : 0.0;
+    const double requested_end = result.end_time > result.start_time
+        ? static_cast<double>(result.end_time) : duration;
+    const double end = std::isfinite(requested_end)
+        ? std::clamp(requested_end, start, duration) : duration;
+    if (request.response_format == "text") {
+        set_text(response, 200, result.text, "text/plain; charset=utf-8");
+    } else if (request.response_format == "srt") {
+        set_text(response, 200,
+                 "1\n" + timestamp(start, ',') + " --> " + timestamp(end, ',') +
+                     "\n" + result.text + "\n",
+                 "application/x-subrip; charset=utf-8");
+    } else if (request.response_format == "vtt") {
+        set_text(response, 200,
+                 "WEBVTT\n\n" + timestamp(start, '.') + " --> " +
+                     timestamp(end, '.') + "\n" + result.text + "\n",
+                 "text/vtt; charset=utf-8");
+    } else if (request.response_format == "verbose_json") {
+        const std::string language = !result.language.empty()
+            ? result.language : (!request.language.empty() ? request.language : "unknown");
+        set_json(response, 200, {
+            {"task", "transcribe"},
+            {"language", language},
+            {"duration", duration},
+            {"text", result.text},
+            {"segments", nlohmann::json::array({{
+                {"id", 0},
+                {"seek", 0},
+                {"start", start},
+                {"end", end},
+                {"text", result.text},
+                {"tokens", nlohmann::json::array()},
+                {"temperature", request.temperature},
+                {"avg_logprob", 0.0},
+                {"compression_ratio", 1.0},
+                {"no_speech_prob", 0.0},
+            }})},
+        });
+    } else {
+        set_json(response, 200, {{"text", result.text}});
+    }
+}
+
 }  // namespace
 
 std::vector<uint8_t> encode_wav_pcm16(
@@ -314,7 +645,10 @@ void register_openai_tts_routes(
     if (!synthesize) {
         throw std::invalid_argument("OpenAI TTS server requires a synthesis callback");
     }
-    server.set_payload_max_length(kMaximumRequestBytes);
+    // Preserve the original transport cap when this is the only registered
+    // audio route. The transcription registrar raises the shared server limit;
+    // the handler-level check below still protects TTS in a combined server.
+    server.set_payload_max_length(kMaximumTtsRequestBytes);
 
     server.Get("/health", [](const httplib::Request&, httplib::Response& response) {
         set_json(response, 200, {{"status", "ok"}});
@@ -331,6 +665,11 @@ void register_openai_tts_routes(
             }
 
             try {
+                if (http_request.body.size() > kMaximumTtsRequestBytes) {
+                    set_openai_error(
+                        response, 413, "The request body must not exceed 1 MiB");
+                    return;
+                }
                 const OpenAITtsRequest request = parse_request(http_request.body);
                 TtsAudio audio = synthesize(request);
                 if (audio.samples.empty() || audio.sample_rate <= 0) {
@@ -364,6 +703,48 @@ void register_openai_tts_routes(
                 // Do not expose backend exception strings: they can contain
                 // local paths, runtime details, or future model diagnostics.
                 set_openai_error(response, 500, "Speech synthesis failed");
+            }
+        });
+}
+
+void register_openai_transcription_routes(
+    httplib::Server& server,
+    TranscribeCallback transcribe,
+    std::string api_key) {
+    if (!transcribe) {
+        throw std::invalid_argument(
+            "OpenAI transcription server requires a transcription callback");
+    }
+    server.set_payload_max_length(kMaximumServerRequestBytes);
+    auto request_mutex = std::make_shared<std::mutex>();
+
+    server.Post("/v1/audio/transcriptions",
+        [transcribe = std::move(transcribe), api_key = std::move(api_key),
+         request_mutex = std::move(request_mutex)](
+            const httplib::Request& http_request,
+            httplib::Response& response) {
+            if (!authorized(http_request, api_key)) {
+                response.set_header("WWW-Authenticate", "Bearer");
+                set_openai_error(response, 401, "Invalid API key");
+                return;
+            }
+
+            // Bound decoded-audio and model memory even when cpp-httplib
+            // dispatches several large multipart requests concurrently.
+            std::lock_guard<std::mutex> request_lock(*request_mutex);
+            try {
+                OpenAITranscriptionRequest request =
+                    parse_transcription_request(http_request);
+                const speech_core::TranscriptionResult result = transcribe(request);
+                set_transcription_response(response, request, result);
+            } catch (const RequestTooLarge& error) {
+                set_openai_error(response, 413, error.what());
+            } catch (const InvalidSpeechRequest& error) {
+                set_openai_error(response, 400, error.what());
+            } catch (const std::exception&) {
+                // Do not expose backend exception strings: they can contain
+                // local paths, runtime details, or model diagnostics.
+                set_openai_error(response, 500, "Speech transcription failed");
             }
         });
 }

--- a/src/http/openai_tts_server.h
+++ b/src/http/openai_tts_server.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "speech_core/interfaces.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -32,9 +34,20 @@ struct TtsAudio {
     int sample_rate = 0;
 };
 
-/// Throw from the synthesis callback when a request is syntactically valid
-/// but cannot be served (for example, an unknown native voice). The HTTP
-/// adapter maps this to an OpenAI-shaped 400 response instead of a server 500.
+struct OpenAITranscriptionRequest {
+    std::string model;
+    std::string filename;
+    std::string language;
+    std::string prompt;
+    std::string response_format = "json";
+    float temperature = 0.0f;
+    std::vector<float> samples;
+    int sample_rate = 16000;
+};
+
+/// Throw from a backend callback when a request is syntactically valid but
+/// cannot be served (for example, an unknown native voice). The HTTP adapter
+/// maps this to an OpenAI-shaped 400 response instead of a server 500.
 class InvalidSpeechRequest : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
@@ -42,6 +55,10 @@ public:
 
 using SynthesizeCallback =
     std::function<TtsAudio(const OpenAITtsRequest& request)>;
+
+using TranscribeCallback =
+    std::function<speech_core::TranscriptionResult(
+        const OpenAITranscriptionRequest& request)>;
 
 /// Register the local health route and OpenAI-compatible speech endpoint on
 /// an existing cpp-httplib server. When api_key is non-empty, requests must
@@ -51,6 +68,17 @@ using SynthesizeCallback =
 void register_openai_tts_routes(
     httplib::Server& server,
     SynthesizeCallback synthesize,
+    std::string api_key = {});
+
+/// Register the OpenAI-compatible multipart transcription endpoint on an
+/// existing cpp-httplib server. Uploaded WAV audio is decoded, downmixed, and
+/// resampled to 16 kHz mono Float32 before the callback runs. Transcription
+/// requests through this registrar are serialized to bound decoded-audio and
+/// model memory. The callback must still coordinate with other routes that
+/// share its mutable model state.
+void register_openai_transcription_routes(
+    httplib::Server& server,
+    TranscribeCallback transcribe,
     std::string api_key = {});
 
 /// Encode mono Float32 PCM as a RIFF/WAVE byte buffer containing PCM16-LE.

--- a/tests/test_openai_stt_server_e2e.cpp
+++ b/tests/test_openai_stt_server_e2e.cpp
@@ -1,0 +1,110 @@
+#include "openai_tts_server.h"
+
+#include "speech_core/models/parakeet_stt.h"
+
+#include "httplib.h"
+#include "nlohmann/json.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+#define REQUIRE(condition) do {                                                \
+    if (!(condition)) {                                                        \
+        std::fprintf(stderr, "REQUIRE failed at %s:%d: %s\n",                \
+                     __FILE__, __LINE__, #condition);                          \
+        std::abort();                                                          \
+    }                                                                          \
+} while (false)
+
+bool is_nonempty_file(const std::filesystem::path& path) {
+    std::error_code error;
+    return std::filesystem::is_regular_file(path, error) && !error &&
+        std::filesystem::file_size(path, error) > 0u && !error;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) throw std::runtime_error("could not open test audio");
+    return {std::istreambuf_iterator<char>(stream),
+            std::istreambuf_iterator<char>()};
+}
+
+}  // namespace
+
+int main() {
+    const char* configured_dir = std::getenv("SPEECH_MODEL_DIR");
+    if (!configured_dir || !*configured_dir) {
+        std::puts("OpenAI transcription E2E skipped: SPEECH_MODEL_DIR is not set");
+        return 0;
+    }
+
+    const std::filesystem::path model_dir(configured_dir);
+    const std::filesystem::path encoder =
+        model_dir / "parakeet-encoder-int8.onnx";
+    const std::filesystem::path decoder =
+        model_dir / "parakeet-decoder-joint-int8.onnx";
+    const std::filesystem::path vocabulary = model_dir / "vocab.json";
+    if (!is_nonempty_file(encoder) || !is_nonempty_file(decoder) ||
+        !is_nonempty_file(vocabulary)) {
+        std::puts("OpenAI transcription E2E skipped: Parakeet bundle is incomplete");
+        return 0;
+    }
+
+    speech_core::ParakeetStt stt(
+        encoder.string(), decoder.string(), vocabulary.string(),
+        /*hw_accel=*/false);
+    httplib::Server server;
+    speech_core::http::register_openai_transcription_routes(
+        server,
+        [&](const speech_core::http::OpenAITranscriptionRequest& request) {
+            return stt.transcribe(
+                request.samples.data(), request.samples.size(),
+                request.sample_rate);
+        });
+
+    const int port = server.bind_to_any_port("127.0.0.1");
+    REQUIRE(port > 0);
+    std::thread thread([&] { server.listen_after_bind(); });
+    while (!server.is_running()) std::this_thread::sleep_for(2ms);
+
+    httplib::Client client("127.0.0.1", port);
+    const std::string audio = read_file(
+        std::filesystem::path(SPEECH_CORE_TEST_DATA_DIR) / "test_audio.wav");
+    const httplib::UploadFormDataItems form = {
+        {"file", audio, "test_audio.wav", "audio/wav"},
+        {"model", "whisper-1", "", ""},
+        {"response_format", "json", "", ""},
+    };
+    auto response = client.Post("/v1/audio/transcriptions", form);
+    server.stop();
+    thread.join();
+
+    REQUIRE(response && response->status == 200);
+    const auto body = nlohmann::json::parse(response->body);
+    REQUIRE(body.contains("text") && body["text"].is_string());
+    std::string transcript = body["text"].get<std::string>();
+    std::transform(transcript.begin(), transcript.end(), transcript.begin(),
+                   [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                   });
+    int matched_words = 0;
+    for (const char* word : {"guarantee", "replacement", "shipped", "tomorrow"}) {
+        if (transcript.find(word) != std::string::npos) ++matched_words;
+    }
+    REQUIRE(matched_words >= 2);
+    std::puts("OpenAI transcription E2E passed");
+    return 0;
+}

--- a/tests/test_openai_tts_server.cpp
+++ b/tests/test_openai_tts_server.cpp
@@ -3,11 +3,13 @@
 #include "httplib.h"
 #include "nlohmann/json.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <mutex>
@@ -18,6 +20,7 @@
 #include <vector>
 
 using speech_core::http::AudioResponseFormat;
+using speech_core::http::OpenAITranscriptionRequest;
 using speech_core::http::OpenAITtsRequest;
 using speech_core::http::TtsAudio;
 using namespace std::chrono_literals;
@@ -39,12 +42,58 @@ uint32_t read_u32(const std::string& value, size_t offset) {
            (static_cast<uint32_t>(static_cast<unsigned char>(value[offset + 3])) << 24u);
 }
 
+void append_u16(std::string& value, uint16_t number) {
+    value.push_back(static_cast<char>(number & 0xffu));
+    value.push_back(static_cast<char>((number >> 8u) & 0xffu));
+}
+
+void append_u24(std::string& value, uint32_t number) {
+    value.push_back(static_cast<char>(number & 0xffu));
+    value.push_back(static_cast<char>((number >> 8u) & 0xffu));
+    value.push_back(static_cast<char>((number >> 16u) & 0xffu));
+}
+
+void append_u32(std::string& value, uint32_t number) {
+    value.push_back(static_cast<char>(number & 0xffu));
+    value.push_back(static_cast<char>((number >> 8u) & 0xffu));
+    value.push_back(static_cast<char>((number >> 16u) & 0xffu));
+    value.push_back(static_cast<char>((number >> 24u) & 0xffu));
+}
+
+std::string make_wav(uint16_t format,
+                     uint16_t channels,
+                     uint32_t sample_rate,
+                     uint16_t bits_per_sample,
+                     const std::string& payload) {
+    std::string wav = "RIFF";
+    append_u32(wav, static_cast<uint32_t>(36u + payload.size()));
+    wav += "WAVEfmt ";
+    append_u32(wav, 16u);
+    append_u16(wav, format);
+    append_u16(wav, channels);
+    append_u32(wav, sample_rate);
+    const uint16_t block_align = static_cast<uint16_t>(
+        channels * (bits_per_sample / 8u));
+    append_u32(wav, sample_rate * block_align);
+    append_u16(wav, block_align);
+    append_u16(wav, bits_per_sample);
+    wav += "data";
+    append_u32(wav, static_cast<uint32_t>(payload.size()));
+    wav += payload;
+    return wav;
+}
+
 class TestServer {
 public:
     TestServer(speech_core::http::SynthesizeCallback callback,
-               std::string api_key = {}) {
+               std::string api_key = {},
+               speech_core::http::TranscribeCallback transcribe = {}) {
         speech_core::http::register_openai_tts_routes(
-            server_, std::move(callback), std::move(api_key));
+            server_, std::move(callback), api_key);
+        if (transcribe) {
+            speech_core::http::register_openai_transcription_routes(
+                server_, std::move(transcribe), std::move(api_key));
+        }
         port_ = server_.bind_to_any_port("127.0.0.1");
         if (port_ <= 0) throw std::runtime_error("could not bind test server");
         thread_ = std::thread([this] { server_.listen_after_bind(); });
@@ -63,6 +112,57 @@ private:
     int port_ = 0;
     std::thread thread_;
 };
+
+class TranscriptionTestServer {
+public:
+    TranscriptionTestServer(speech_core::http::TranscribeCallback callback,
+                            std::string api_key = {}) {
+        speech_core::http::register_openai_transcription_routes(
+            server_, std::move(callback), std::move(api_key));
+        port_ = server_.bind_to_any_port("127.0.0.1");
+        if (port_ <= 0) throw std::runtime_error("could not bind test server");
+        thread_ = std::thread([this] { server_.listen_after_bind(); });
+        while (!server_.is_running()) std::this_thread::sleep_for(2ms);
+    }
+
+    ~TranscriptionTestServer() {
+        server_.stop();
+        if (thread_.joinable()) thread_.join();
+    }
+
+    int port() const { return port_; }
+
+private:
+    httplib::Server server_;
+    int port_ = 0;
+    std::thread thread_;
+};
+
+std::string wav_bytes(const std::vector<float>& samples, int sample_rate) {
+    const std::vector<uint8_t> wav = speech_core::http::encode_wav_pcm16(
+        samples.data(), samples.size(), sample_rate);
+    return std::string(reinterpret_cast<const char*>(wav.data()), wav.size());
+}
+
+httplib::UploadFormDataItems transcription_form(
+    const std::string& wav,
+    std::string response_format = "json") {
+    httplib::UploadFormDataItems items = {
+        {"file", wav, "recording.wav", "audio/wav"},
+        {"model", "whisper-1", "", ""},
+    };
+    if (!response_format.empty()) {
+        items.push_back({"response_format", std::move(response_format), "", ""});
+    }
+    return items;
+}
+
+httplib::Result post_transcription(
+    httplib::Client& client,
+    const httplib::UploadFormDataItems& items,
+    const httplib::Headers& headers = {}) {
+    return client.Post("/v1/audio/transcriptions", headers, items);
+}
 
 nlohmann::json error_body(const httplib::Result& response) {
     REQUIRE(response);
@@ -233,6 +333,270 @@ void test_authentication_and_error_envelopes() {
             "Speech synthesis failed");
 }
 
+void test_tts_payload_limit_remains_one_mibibyte() {
+    TestServer server([](const OpenAITtsRequest&) {
+        return TtsAudio{{0.0f}, 24000};
+    }, {}, [](const OpenAITranscriptionRequest&) {
+        return speech_core::TranscriptionResult{};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    const std::string oversized(1024 * 1024 + 1, 'x');
+    auto response = client.Post(
+        "/v1/audio/speech", oversized, "application/json");
+    REQUIRE(response && response->status == 413);
+    REQUIRE(error_body(response)["error"]["message"] ==
+            "The request body must not exceed 1 MiB");
+}
+
+void test_transcription_json_contract_and_resampling() {
+    OpenAITranscriptionRequest captured;
+    TranscriptionTestServer server([&](const OpenAITranscriptionRequest& request) {
+        captured = request;
+        return speech_core::TranscriptionResult{
+            "hello world", "en", 0.9f, 0.0f, 0.1f};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+
+    std::vector<float> samples(800);
+    for (size_t i = 0; i < samples.size(); ++i) {
+        samples[i] = std::sin(static_cast<float>(i) * 0.05f) * 0.25f;
+    }
+    auto form = transcription_form(wav_bytes(samples, 8000));
+    form.push_back({"language", "en", "", ""});
+    form.push_back({"prompt", "product names", "", ""});
+    form.push_back({"temperature", "0.25", "", ""});
+    auto response = post_transcription(client, form);
+
+    REQUIRE(response && response->status == 200);
+    REQUIRE(response->get_header_value("Content-Type") == "application/json");
+    REQUIRE(nlohmann::json::parse(response->body)["text"] == "hello world");
+    REQUIRE(captured.model == "whisper-1");
+    REQUIRE(captured.filename == "recording.wav");
+    REQUIRE(captured.language == "en");
+    REQUIRE(captured.prompt == "product names");
+    REQUIRE(captured.temperature == 0.25f);
+    REQUIRE(captured.response_format == "json");
+    REQUIRE(captured.sample_rate == 16000);
+    REQUIRE(captured.samples.size() == 1600);
+    REQUIRE(std::all_of(
+        captured.samples.begin(), captured.samples.end(),
+        [](float sample) { return std::isfinite(sample); }));
+}
+
+void assert_bad_transcription(
+    const httplib::UploadFormDataItems& items,
+    const std::string& message_fragment);
+
+void test_transcription_response_formats() {
+    TranscriptionTestServer server([](const OpenAITranscriptionRequest&) {
+        return speech_core::TranscriptionResult{
+            "format test", "fr", 0.8f, 0.0f, 0.25f};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    const std::string wav = wav_bytes(std::vector<float>(4000, 0.1f), 16000);
+
+    auto text_response = post_transcription(
+        client, transcription_form(wav, "text"));
+    REQUIRE(text_response && text_response->status == 200);
+    REQUIRE(text_response->get_header_value("Content-Type") ==
+            "text/plain; charset=utf-8");
+    REQUIRE(text_response->body == "format test");
+
+    auto verbose_response = post_transcription(
+        client, transcription_form(wav, "verbose_json"));
+    REQUIRE(verbose_response && verbose_response->status == 200);
+    const auto verbose = nlohmann::json::parse(verbose_response->body);
+    REQUIRE(verbose["task"] == "transcribe");
+    REQUIRE(verbose["language"] == "fr");
+    REQUIRE(verbose["duration"] == 0.25);
+    REQUIRE(verbose["segments"].size() == 1);
+    REQUIRE(verbose["segments"][0]["text"] == "format test");
+
+    auto srt_response = post_transcription(
+        client, transcription_form(wav, "srt"));
+    REQUIRE(srt_response && srt_response->status == 200);
+    REQUIRE(srt_response->get_header_value("Content-Type") ==
+            "application/x-subrip; charset=utf-8");
+    REQUIRE(srt_response->body.find(
+        "00:00:00,000 --> 00:00:00,250") != std::string::npos);
+
+    auto vtt_response = post_transcription(
+        client, transcription_form(wav, "vtt"));
+    REQUIRE(vtt_response && vtt_response->status == 200);
+    REQUIRE(vtt_response->get_header_value("Content-Type") ==
+            "text/vtt; charset=utf-8");
+    REQUIRE(vtt_response->body.find(
+        "WEBVTT\n\n00:00:00.000 --> 00:00:00.250") == 0);
+}
+
+void test_transcription_wav_decoding_and_downmix() {
+    OpenAITranscriptionRequest captured;
+    TranscriptionTestServer server([&](const OpenAITranscriptionRequest& request) {
+        captured = request;
+        return speech_core::TranscriptionResult{"decoded", "en"};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+
+    std::string stereo_pcm16;
+    append_u16(stereo_pcm16, 32767u);
+    append_u16(stereo_pcm16, 32768u);
+    append_u16(stereo_pcm16, 16384u);
+    append_u16(stereo_pcm16, 49152u);
+    auto stereo_response = post_transcription(
+        client, transcription_form(
+            make_wav(1, 2, 16000, 16, stereo_pcm16)));
+    REQUIRE(stereo_response && stereo_response->status == 200);
+    REQUIRE(captured.samples.size() == 2);
+    REQUIRE(std::abs(captured.samples[0]) < 0.00002f);
+    REQUIRE(std::abs(captured.samples[1]) < 0.00002f);
+
+    std::string pcm24;
+    append_u24(pcm24, 0x400000u);
+    auto pcm24_response = post_transcription(
+        client, transcription_form(make_wav(1, 1, 16000, 24, pcm24)));
+    REQUIRE(pcm24_response && pcm24_response->status == 200);
+    REQUIRE(captured.samples.size() == 1);
+    REQUIRE(std::abs(captured.samples[0] - 0.5f) < 0.000001f);
+
+    std::string pcm32;
+    append_u32(pcm32, 0x40000000u);
+    auto pcm32_response = post_transcription(
+        client, transcription_form(make_wav(1, 1, 16000, 32, pcm32)));
+    REQUIRE(pcm32_response && pcm32_response->status == 200);
+    REQUIRE(captured.samples.size() == 1);
+    REQUIRE(std::abs(captured.samples[0] - 0.5f) < 0.000001f);
+
+    std::string float32;
+    float sample = 0.25f;
+    uint32_t sample_bits = 0;
+    std::memcpy(&sample_bits, &sample, sizeof(sample_bits));
+    append_u32(float32, sample_bits);
+    auto float32_response = post_transcription(
+        client, transcription_form(make_wav(3, 1, 16000, 32, float32)));
+    REQUIRE(float32_response && float32_response->status == 200);
+    REQUIRE(captured.samples.size() == 1);
+    REQUIRE(captured.samples[0] == 0.25f);
+
+    std::string non_finite;
+    sample = std::numeric_limits<float>::quiet_NaN();
+    std::memcpy(&sample_bits, &sample, sizeof(sample_bits));
+    append_u32(non_finite, sample_bits);
+    assert_bad_transcription(
+        transcription_form(make_wav(3, 1, 16000, 32, non_finite)),
+        "non-finite audio");
+}
+
+void assert_bad_transcription(
+    const httplib::UploadFormDataItems& items,
+    const std::string& message_fragment) {
+    TranscriptionTestServer server([](const OpenAITranscriptionRequest&) {
+        return speech_core::TranscriptionResult{};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    auto response = post_transcription(client, items);
+    REQUIRE(response && response->status == 400);
+    const auto parsed = error_body(response);
+    REQUIRE(parsed["error"]["type"] == "invalid_request_error");
+    REQUIRE(parsed["error"]["message"].get<std::string>().find(message_fragment) !=
+            std::string::npos);
+}
+
+void test_transcription_request_validation() {
+    const std::string wav = wav_bytes(std::vector<float>(160, 0.0f), 16000);
+    assert_bad_transcription(
+        {{"model", "whisper-1", "", ""}}, "Missing 'file'");
+    assert_bad_transcription(
+        {{"file", wav, "audio.wav", "audio/wav"}}, "Missing 'model'");
+    assert_bad_transcription(
+        {{"file", "not a wav", "audio.wav", "audio/wav"},
+         {"model", "whisper-1", "", ""}},
+        "valid RIFF/WAVE");
+
+    auto unsupported = transcription_form(wav, "mp3");
+    assert_bad_transcription(unsupported, "Unsupported response format");
+
+    auto duplicate_file = transcription_form(wav);
+    duplicate_file.push_back({"file", wav, "second.wav", "audio/wav"});
+    assert_bad_transcription(duplicate_file, "Duplicate 'file'");
+
+    auto invalid_temperature = transcription_form(wav);
+    invalid_temperature.push_back({"temperature", "1.1", "", ""});
+    assert_bad_transcription(invalid_temperature, "between 0 and 1");
+
+    TranscriptionTestServer server([](const OpenAITranscriptionRequest&) {
+        return speech_core::TranscriptionResult{};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    auto wrong_content_type = client.Post(
+        "/v1/audio/transcriptions", "{}", "application/json");
+    REQUIRE(wrong_content_type && wrong_content_type->status == 400);
+    REQUIRE(error_body(wrong_content_type)["error"]["message"] ==
+            "The transcription endpoint requires multipart/form-data");
+}
+
+void test_transcription_file_size_limit() {
+    bool called = false;
+    TranscriptionTestServer server([&](const OpenAITranscriptionRequest&) {
+        called = true;
+        return speech_core::TranscriptionResult{};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    const std::string oversized(25 * 1024 * 1024 + 1, 'x');
+    auto response = post_transcription(
+        client, transcription_form(oversized));
+    REQUIRE(response && response->status == 413);
+    REQUIRE(error_body(response)["error"]["message"] ==
+            "The uploaded audio file must not exceed 25 MiB");
+    REQUIRE(!called);
+}
+
+void test_transcription_duration_limit() {
+    bool called = false;
+    TranscriptionTestServer server([&](const OpenAITranscriptionRequest&) {
+        called = true;
+        return speech_core::TranscriptionResult{};
+    });
+    httplib::Client client("127.0.0.1", server.port());
+    const std::string pcm((8000 * 10 * 60 + 1) * 2, '\0');
+    auto response = post_transcription(
+        client, transcription_form(make_wav(1, 1, 8000, 16, pcm)));
+    REQUIRE(response && response->status == 400);
+    REQUIRE(error_body(response)["error"]["message"] ==
+            "The uploaded WAV file must not exceed 10 minutes");
+    REQUIRE(!called);
+}
+
+void test_transcription_authentication_and_backend_errors() {
+    const std::string wav = wav_bytes(std::vector<float>(160, 0.0f), 16000);
+    TranscriptionTestServer authenticated(
+        [](const OpenAITranscriptionRequest&) {
+            return speech_core::TranscriptionResult{"ok", "en"};
+        },
+        "secret");
+    httplib::Client auth_client("127.0.0.1", authenticated.port());
+    const auto form = transcription_form(wav);
+
+    auto unauthorized = post_transcription(auth_client, form);
+    REQUIRE(unauthorized && unauthorized->status == 401);
+    REQUIRE(unauthorized->get_header_value("WWW-Authenticate") == "Bearer");
+    REQUIRE(error_body(unauthorized)["error"]["type"] == "authentication_error");
+
+    auto authorized = post_transcription(
+        auth_client, form, {{"Authorization", "Bearer secret"}});
+    REQUIRE(authorized && authorized->status == 200);
+
+    TranscriptionTestServer failing(
+        [](const OpenAITranscriptionRequest&) -> speech_core::TranscriptionResult {
+            throw std::runtime_error("/private/model/path");
+        });
+    httplib::Client fail_client("127.0.0.1", failing.port());
+    auto failure = post_transcription(fail_client, form);
+    REQUIRE(failure && failure->status == 500);
+    REQUIRE(error_body(failure)["error"]["message"] ==
+            "Speech transcription failed");
+    REQUIRE(failure->body.find("/private/model/path") == std::string::npos);
+}
+
 }  // namespace
 
 int main() {
@@ -240,6 +604,14 @@ int main() {
     test_pcm_and_optional_fields();
     test_request_validation();
     test_authentication_and_error_envelopes();
-    std::puts("OpenAI TTS server tests passed");
+    test_tts_payload_limit_remains_one_mibibyte();
+    test_transcription_json_contract_and_resampling();
+    test_transcription_response_formats();
+    test_transcription_wav_decoding_and_downmix();
+    test_transcription_request_validation();
+    test_transcription_file_size_limit();
+    test_transcription_duration_limit();
+    test_transcription_authentication_and_backend_errors();
+    std::puts("OpenAI audio server tests passed");
     return 0;
 }


### PR DESCRIPTION
## Summary

- add `POST /v1/audio/transcriptions` to `speech-server` with the standard multipart request shape
- decode PCM16/24/32 and Float32 WAV, downmix and resample to 16 kHz, then lazily load the bundled Parakeet ONNX backend
- support `json`, `text`, `verbose_json`, `srt`, and `vtt` responses plus the existing bearer authentication envelope
- preserve the 1 MiB TTS limit while bounding STT uploads to 25 MiB and 10 minutes and serializing decode/inference memory
- document both HTTP audio endpoints, update package smoke checks, and keep all README language links synchronized
- repair the dependency-free Parakeet mel-contract test registration/linkage exposed by a clean configure

## Architecture and risk

The HTTP layer remains model-independent through a transcription callback. The production sidecar owns model selection and lazy Parakeet initialization, so existing TTS startup time and resident memory do not change. TTS and STT share the existing inference lock. The main compatibility limit is deliberate: uploads must be uncompressed RIFF/WAVE because release packages do not ship a codec runtime.

## Validation

- dependency-free CTest suite: 25/25 passed
- HTTP contract regression suite: passed
- AddressSanitizer and UndefinedBehaviorSanitizer HTTP suite: passed
- ONNX-enabled `speech-server` and endpoint E2E target: compiled and linked with ONNX Runtime 1.19.0
- model-backed E2E target: verified to skip cleanly when `SPEECH_MODEL_DIR` is unavailable
- `actionlint` on CI and release workflows: passed
- `shellcheck scripts/speech-dispatch.sh`: passed