### PR TITLE
Add portable meeting transcription and AEC pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,11 @@ add_library(speech_core
     src/pipeline/turn_detector.cpp
     src/pipeline/speech_queue.cpp
     src/pipeline/conversation_context.cpp
+    src/pipeline/meeting_transcription_track.cpp
+    src/pipeline/recording_speaker_identity.cpp
+    src/pipeline/timestamped_echo_cancellation_stream.cpp
     src/vad/streaming_vad.cpp
+    src/transcription/moss_transcript_parser.cpp
     src/audio/audio_buffer.cpp
     src/audio/resampler.cpp
     src/audio/pcm_codec.cpp
@@ -63,6 +67,8 @@ add_library(speech_core
     src/audio/wespeaker_fbank.cpp
     src/models/kokoro/kokoro_phonemizer.cpp
     src/models/kokoro/kokoro_multilingual.cpp
+    src/models/moss/moss_prompt_processor.cpp
+    src/models/moss/moss_whisper_features.cpp
     src/tools/tool_registry.cpp
     src/tools/intent_matcher.cpp
     src/tools/tool_executor.cpp
@@ -150,9 +156,13 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/voxcpm/onnx_voxcpm_tts.cpp
         src/models/voxcpm2/onnx_voxcpm2_tts.cpp
         src/models/nemotron/onnx_nemotron_streaming_stt.cpp
+        src/models/moss/onnx_moss_transcribe_diarize.cpp
+        src/models/localvqe/localvqe_aec_frontend.cpp
+        src/models/localvqe/onnx_localvqe_echo_canceller.cpp
         src/models/personaplex/onnx_personaplex.cpp
         src/models/whisper/onnx_whisper_stt.cpp
         src/models/pyannote/onnx_pyannote_segmentation.cpp
+        src/models/redimnet/onnx_redimnet_speaker_embedding.cpp
         src/models/wespeaker/onnx_wespeaker_embedding.cpp
     )
     # VoxCPM2 tokenizer is pure C++17 and shared with the LiteRT target. To
@@ -664,6 +674,10 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_litert_indic_mio"
            OR TEST_NAME STREQUAL "test_pocket_tts"
            OR TEST_NAME STREQUAL "test_pocket_tts_tokenizer"
+           OR TEST_NAME STREQUAL "test_onnx_moss_model"
+           OR TEST_NAME STREQUAL "test_onnx_localvqe_model"
+           OR TEST_NAME STREQUAL "test_onnx_redimnet_model"
+           OR TEST_NAME STREQUAL "test_redimnet_audio_preparation"
            OR TEST_NAME STREQUAL "test_litert_functiongemma_llm"
            OR TEST_NAME STREQUAL "test_openai_tts_server"
            OR TEST_NAME STREQUAL "test_openai_stt_server_e2e"
@@ -778,6 +792,48 @@ if(SPEECH_CORE_BUILD_TESTS)
                 target_compile_definitions(bench_ort_models PRIVATE NOMINMAX)
             endif()
         endif()
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_redimnet_audio_preparation.cpp)
+        add_executable(test_redimnet_audio_preparation
+            tests/test_redimnet_audio_preparation.cpp)
+        target_link_libraries(test_redimnet_audio_preparation
+            PRIVATE speech_core_models)
+        add_test(NAME test_redimnet_audio_preparation
+                 COMMAND test_redimnet_audio_preparation)
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_onnx_moss_model.cpp)
+        add_executable(test_onnx_moss_model
+            tests/test_onnx_moss_model.cpp)
+        target_link_libraries(test_onnx_moss_model
+            PRIVATE speech_core_models)
+        target_compile_definitions(test_onnx_moss_model PRIVATE
+            SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
+        add_test(NAME test_onnx_moss_model
+                 COMMAND test_onnx_moss_model)
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_onnx_localvqe_model.cpp)
+        add_executable(test_onnx_localvqe_model
+            tests/test_onnx_localvqe_model.cpp)
+        target_link_libraries(test_onnx_localvqe_model
+            PRIVATE speech_core_models)
+        add_test(NAME test_onnx_localvqe_model
+                 COMMAND test_onnx_localvqe_model)
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_onnx_redimnet_model.cpp)
+        add_executable(test_onnx_redimnet_model
+            tests/test_onnx_redimnet_model.cpp)
+        target_link_libraries(test_onnx_redimnet_model
+            PRIVATE speech_core_models)
+        add_test(NAME test_onnx_redimnet_model
+                 COMMAND test_onnx_redimnet_model)
     endif()
 
     if(SPEECH_CORE_WITH_ONNX AND

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ speech-core separates a small, model-agnostic orchestration layer from optional 
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/guides/whisper) | Multilingual speech-to-text | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/nemotron) | Streaming speech-to-text | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/guides/nemotron) | Prompt-conditioned streaming STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Multilingual transcription + speaker activity | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/guides/dictate) | Streaming STT + end-of-utterance | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/omnilingual) | Multilingual speech-to-text | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/diarize) | Diarization segmentation | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/embed-speaker) | Speaker embedding | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Speaker embedding | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + voice cloning | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/guides/voxcpm2) | 48 kHz TTS + voice cloning | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/guides/cosyvoice) | 24 kHz conditioned TTS | staged | — |
@@ -64,6 +66,7 @@ speech-core separates a small, model-agnostic orchestration layer from optional 
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/kokoro) | Text-to-speech | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming TTS (fixed Alba voice) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/guides/denoise) | Speech enhancement | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Acoustic echo cancellation | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/guides/restore) | Denoise + dereverb (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/guides/respond) | Full-duplex speech-to-speech (CUDA) | structural | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/guides/function-calls) | On-device structured tool calls | — | LiteRT-LM |

--- a/README_ar.md
+++ b/README_ar.md
@@ -53,10 +53,12 @@
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/whisper) | تعرف متعدد اللغات | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/nemotron) | تعرف متدفق | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/ar/guides/nemotron) | STT متدفق مشروط بـprompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | نسخ متعدد اللغات + نشاط المتحدثين | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/ar/guides/dictate) | STT متدفق + نهاية القول | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/omnilingual) | تعرف متعدد اللغات | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/diarize) | تقسيم لفصل المتحدثين | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/embed-speaker) | تضمين المتحدث | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | تضمين المتحدث | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS ‏16 kHz + استنساخ | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/voxcpm2) | TTS ‏48 kHz + استنساخ | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/cosyvoice) | TTS مشروط 24 kHz | مرحلي | — |
@@ -66,6 +68,7 @@
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/kokoro) | تحويل النص إلى كلام | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS متدفق (صوت Alba ثابت) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/denoise) | تحسين الكلام | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | إلغاء الصدى الصوتي | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/restore) | إزالة الضوضاء والصدى (16 ← 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/respond) | كلام إلى كلام مزدوج الاتجاه (CUDA) | هيكلي | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/ar/guides/function-calls) | استدعاءات أدوات منظمة على الجهاز | — | LiteRT-LM |

--- a/README_de.md
+++ b/README_de.md
@@ -47,10 +47,12 @@ speech-core trennt eine kleine, modellunabhängige Orchestrierungsschicht von op
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/whisper) | Mehrsprachiges Speech-to-Text | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/nemotron) | Streaming-STT | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/de/guides/nemotron) | Prompt-gesteuertes Streaming-STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Mehrsprachige Transkription + Sprecheraktivität | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/de/guides/dictate) | Streaming-STT + Äußerungsende | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/omnilingual) | Mehrsprachiges STT | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/diarize) | Diarisierungssegmentierung | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/embed-speaker) | Sprecher-Embedding | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Sprecher-Embedding | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16-kHz-TTS + Stimmklonen | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/voxcpm2) | 48-kHz-TTS + Stimmklonen | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/cosyvoice) | Konditioniertes 24-kHz-TTS | gestuft | — |
@@ -60,6 +62,7 @@ speech-core trennt eine kleine, modellunabhängige Orchestrierungsschicht von op
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/kokoro) | Text-to-Speech | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming-TTS (feste Alba-Stimme) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/denoise) | Sprachverbesserung | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Akustische Echounterdrückung | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/restore) | Entrauschen + Enthallen (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/respond) | Full-Duplex Speech-to-Speech (CUDA) | strukturell | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/de/guides/function-calls) | Strukturierte lokale Tool-Aufrufe | — | LiteRT-LM |

--- a/README_es.md
+++ b/README_es.md
@@ -47,10 +47,12 @@ speech-core separa una pequeña capa de orquestación independiente del modelo d
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/whisper) | Voz a texto multilingüe | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/nemotron) | Voz a texto en streaming | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/es/guides/nemotron) | STT streaming condicionado por prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Transcripción multilingüe + actividad de hablante | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/es/guides/dictate) | STT streaming + fin de enunciado | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/omnilingual) | Voz a texto multilingüe | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/diarize) | Segmentación para diarización | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/embed-speaker) | Embedding de hablante | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Embedding de hablante | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 kHz + clonación | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/voxcpm2) | TTS 48 kHz + clonación | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/cosyvoice) | TTS condicionado 24 kHz | en preparación | — |
@@ -60,6 +62,7 @@ speech-core separa una pequeña capa de orquestación independiente del modelo d
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/kokoro) | Texto a voz | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS en streaming (voz Alba fija) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/denoise) | Mejora de voz | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Cancelación de eco acústico | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/restore) | Reducción de ruido y reverberación (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/respond) | Voz a voz full-duplex (CUDA) | estructura | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/es/guides/function-calls) | Herramientas estructuradas locales | — | LiteRT-LM |

--- a/README_fr.md
+++ b/README_fr.md
@@ -47,10 +47,12 @@ speech-core sépare une petite couche d'orchestration indépendante des modèles
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/whisper) | Parole vers texte multilingue | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/nemotron) | STT en streaming | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/fr/guides/nemotron) | STT streaming conditionné par prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Transcription multilingue + activité des locuteurs | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/fr/guides/dictate) | STT streaming + fin d'énoncé | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/omnilingual) | STT multilingue | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/diarize) | Segmentation de diarisation | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/embed-speaker) | Embedding de locuteur | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Embedding de locuteur | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 kHz + clonage | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/voxcpm2) | TTS 48 kHz + clonage | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/cosyvoice) | TTS conditionné 24 kHz | en préparation | — |
@@ -60,6 +62,7 @@ speech-core sépare une petite couche d'orchestration indépendante des modèles
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/kokoro) | Synthèse vocale | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS en streaming (voix Alba fixe) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/denoise) | Amélioration de la parole | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Annulation d'écho acoustique | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/restore) | Débruitage + déréverbération (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/respond) | Parole-à-parole full-duplex (CUDA) | structurel | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/fr/guides/function-calls) | Appels d'outils structurés embarqués | — | LiteRT-LM |

--- a/README_hi.md
+++ b/README_hi.md
@@ -47,10 +47,12 @@ speech-core एक छोटे, model-agnostic orchestration layer को optio
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/whisper) | Multilingual speech-to-text | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/nemotron) | Streaming speech-to-text | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/hi/guides/nemotron) | Prompt-conditioned streaming STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | बहुभाषी ट्रांसक्रिप्शन + वक्ता गतिविधि | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/hi/guides/dictate) | Streaming STT + utterance end | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/omnilingual) | Multilingual speech-to-text | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/diarize) | Diarization segmentation | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/embed-speaker) | Speaker embedding | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | वक्ता एम्बेडिंग | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + voice cloning | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/voxcpm2) | 48 kHz TTS + voice cloning | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/cosyvoice) | 24 kHz conditioned TTS | staged | — |
@@ -60,6 +62,7 @@ speech-core एक छोटे, model-agnostic orchestration layer को optio
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/kokoro) | Text-to-speech | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Streaming TTS (fixed Alba voice) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/denoise) | Speech enhancement | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | ध्वनिक प्रतिध्वनि निरस्तीकरण | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/restore) | Denoise + dereverb (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/respond) | Full-duplex speech-to-speech (CUDA) | structural | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/hi/guides/function-calls) | On-device structured tool calls | — | LiteRT-LM |

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,10 +51,12 @@ speech-core は、小さくモデル非依存のオーケストレーション�
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/whisper) | 多言語音声認識 | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/nemotron) | ストリーミング音声認識 | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/ja/guides/nemotron) | プロンプト条件付きストリーミング STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | 多言語文字起こし + 話者アクティビティ | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/ja/guides/dictate) | ストリーミング STT + 発話終了 | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/omnilingual) | 多言語音声認識 | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/diarize) | ダイアライゼーション区間分割 | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/embed-speaker) | 話者埋め込み | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | 話者埋め込み | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + 音声クローン | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/voxcpm2) | 48 kHz TTS + 音声クローン | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/cosyvoice) | 24 kHz 条件付き TTS | 段階導入 | — |
@@ -64,6 +66,7 @@ speech-core は、小さくモデル非依存のオーケストレーション�
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/kokoro) | 音声合成 | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | ストリーミング TTS（固定 Alba ボイス） | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/denoise) | 音声強調 | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | 音響エコーキャンセレーション | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/restore) | ノイズ除去 + 残響除去（16 → 48 kHz） | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/respond) | 全二重 Speech-to-Speech（CUDA） | 構造実装 | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/ja/guides/function-calls) | オンデバイスの構造化ツール呼び出し | — | LiteRT-LM |

--- a/README_ko.md
+++ b/README_ko.md
@@ -51,10 +51,12 @@ speech-core는 작고 모델에 독립적인 오케스트레이션 계층과 선
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/whisper) | 다국어 음성 인식 | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/nemotron) | 스트리밍 음성 인식 | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/ko/guides/nemotron) | 프롬프트 조건부 스트리밍 STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | 다국어 전사 + 화자 활동 | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/ko/guides/dictate) | 스트리밍 STT + 발화 종료 | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/omnilingual) | 다국어 음성 인식 | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/diarize) | 화자 분리 세그멘테이션 | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/embed-speaker) | 화자 임베딩 | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | 화자 임베딩 | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + 음성 복제 | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/voxcpm2) | 48 kHz TTS + 음성 복제 | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/cosyvoice) | 24 kHz 조건부 TTS | 단계적 | — |
@@ -64,6 +66,7 @@ speech-core는 작고 모델에 독립적인 오케스트레이션 계층과 선
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/kokoro) | 음성 합성 | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 스트리밍 TTS(고정 Alba 음성) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/denoise) | 음성 향상 | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | 음향 에코 제거 | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/restore) | 노이즈 제거 + 잔향 제거(16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/respond) | 전이중 음성 대 음성(CUDA) | 구조 구현 | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/ko/guides/function-calls) | 온디바이스 구조화 도구 호출 | — | LiteRT-LM |

--- a/README_pt.md
+++ b/README_pt.md
@@ -47,10 +47,12 @@ speech-core separa uma pequena camada de orquestração independente de modelo d
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/whisper) | Voz para texto multilíngue | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/nemotron) | STT streaming | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/pt/guides/nemotron) | STT streaming condicionado por prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Transcrição multilíngue + atividade de locutor | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/pt/guides/dictate) | STT streaming + fim de enunciado | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/omnilingual) | STT multilíngue | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/diarize) | Segmentação para diarização | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/embed-speaker) | Embedding de locutor | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Embedding de locutor | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 kHz + clonagem | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/voxcpm2) | TTS 48 kHz + clonagem | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/cosyvoice) | TTS condicionado 24 kHz | em preparação | — |
@@ -60,6 +62,7 @@ speech-core separa uma pequena camada de orquestração independente de modelo d
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/kokoro) | Texto para voz | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS streaming (voz Alba fixa) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/denoise) | Aprimoramento de voz | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Cancelamento de eco acústico | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/restore) | Redução de ruído e reverberação (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/respond) | Voz para voz full-duplex (CUDA) | estrutural | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/pt/guides/function-calls) | Ferramentas estruturadas locais | — | LiteRT-LM |

--- a/README_ru.md
+++ b/README_ru.md
@@ -47,10 +47,12 @@ speech-core отделяет компактный, независимый от �
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/whisper) | Многоязычное распознавание | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/nemotron) | Потоковое распознавание | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/ru/guides/nemotron) | Потоковый STT с prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Многоязычная транскрипция + активность говорящих | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/ru/guides/dictate) | Потоковый STT + конец реплики | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/omnilingual) | Многоязычный STT | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/diarize) | Сегментация для диаризации | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/embed-speaker) | Эмбеддинг говорящего | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Эмбеддинг говорящего | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 кГц + клонирование | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/voxcpm2) | TTS 48 кГц + клонирование | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/cosyvoice) | Условный TTS 24 кГц | поэтапно | — |
@@ -60,6 +62,7 @@ speech-core отделяет компактный, независимый от �
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/kokoro) | Синтез речи | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Потоковый TTS (фиксированный голос Alba) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/denoise) | Улучшение речи | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Акустическое эхоподавление | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/restore) | Шумоподавление + дереверберация (16 → 48 кГц) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/respond) | Полнодуплексная речь-в-речь (CUDA) | структура | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/ru/guides/function-calls) | Локальные структурированные tool calls | — | LiteRT-LM |

--- a/README_th.md
+++ b/README_th.md
@@ -47,10 +47,12 @@ speech-core แยกชั้น orchestration ขนาดเล็กที�
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/whisper) | เสียงเป็นข้อความหลายภาษา | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/nemotron) | STT streaming | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/th/guides/nemotron) | STT streaming แบบมี prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | การถอดเสียงหลายภาษา + กิจกรรมผู้พูด | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/th/guides/dictate) | STT streaming + จบคำพูด | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/omnilingual) | STT หลายภาษา | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/diarize) | segmentation สำหรับ diarization | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/embed-speaker) | speaker embedding | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | การฝังตัวผู้พูด | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 kHz + โคลนเสียง | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/voxcpm2) | TTS 48 kHz + โคลนเสียง | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/cosyvoice) | TTS แบบมี conditioning 24 kHz | เป็นขั้น | — |
@@ -60,6 +62,7 @@ speech-core แยกชั้น orchestration ขนาดเล็กที�
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/kokoro) | สังเคราะห์เสียง | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS streaming (เสียง Alba คงที่) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/denoise) | ปรับปรุงเสียงพูด | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | การตัดเสียงสะท้อนทางเสียง | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/restore) | ลดเสียงรบกวน + ลดเสียงก้อง (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/respond) | speech-to-speech แบบ full-duplex (CUDA) | โครงสร้าง | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/th/guides/function-calls) | structured tool call บนอุปกรณ์ | — | LiteRT-LM |

--- a/README_tr.md
+++ b/README_tr.md
@@ -47,10 +47,12 @@ speech-core küçük, modelden bağımsız bir orkestrasyon katmanını isteğe 
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/whisper) | Çok dilli konuşmadan metne | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/nemotron) | Akışlı STT | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/tr/guides/nemotron) | Prompt koşullu akışlı STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Çok dilli transkripsiyon + konuşmacı etkinliği | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/tr/guides/dictate) | Akışlı STT + söz sonu | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/omnilingual) | Çok dilli STT | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/diarize) | Diarization segmentasyonu | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/embed-speaker) | Konuşmacı embedding'i | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Konuşmacı embedding'i | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + ses klonlama | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/voxcpm2) | 48 kHz TTS + ses klonlama | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/cosyvoice) | Koşullu 24 kHz TTS | aşamalı | — |
@@ -60,6 +62,7 @@ speech-core küçük, modelden bağımsız bir orkestrasyon katmanını isteğe 
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/kokoro) | Metinden konuşma | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | Akışlı TTS (sabit Alba sesi) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/denoise) | Konuşma iyileştirme | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Akustik yankı giderme | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/restore) | Gürültü ve yankı giderme (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/respond) | Full-duplex konuşmadan konuşmaya (CUDA) | yapısal | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/tr/guides/function-calls) | Cihaz içi yapılandırılmış araç çağrıları | — | LiteRT-LM |

--- a/README_vi.md
+++ b/README_vi.md
@@ -47,10 +47,12 @@ speech-core tách lớp điều phối nhỏ, độc lập với mô hình khỏ
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/whisper) | STT đa ngôn ngữ | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/nemotron) | STT streaming | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/vi/guides/nemotron) | STT streaming theo prompt | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | Phiên âm đa ngôn ngữ + hoạt động người nói | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/vi/guides/dictate) | STT streaming + cuối phát ngôn | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/omnilingual) | STT đa ngôn ngữ | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/diarize) | Phân đoạn diarization | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/embed-speaker) | Embedding người nói | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | Embedding người nói | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | TTS 16 kHz + nhân bản giọng | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/voxcpm2) | TTS 48 kHz + nhân bản giọng | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/cosyvoice) | TTS có điều kiện 24 kHz | từng phần | — |
@@ -60,6 +62,7 @@ speech-core tách lớp điều phối nhỏ, độc lập với mô hình khỏ
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/kokoro) | Tổng hợp giọng nói | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | TTS streaming (giọng Alba cố định) | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/denoise) | Tăng cường giọng nói | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | Khử tiếng vọng âm học | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/restore) | Khử nhiễu + khử vang (16 → 48 kHz) | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/respond) | Giọng nói hai chiều full-duplex (CUDA) | cấu trúc | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/vi/guides/function-calls) | Gọi công cụ có cấu trúc trên thiết bị | — | LiteRT-LM |

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,10 +51,12 @@ speech-core 将小巧、与模型无关的编排层和可选推理后端分离�
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/whisper) | 多语言语音转文字 | ✓ | — |
 | [Nemotron Speech Streaming (0.6B)](https://huggingface.co/soniqo/Nemotron-Speech-Streaming-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/nemotron) | 流式语音转文字 | ✓ | ✓ |
 | [Nemotron-3.5 multilingual (0.6B)](https://huggingface.co/soniqo/Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-FP16) · [soniqo.audio](https://soniqo.audio/zh/guides/nemotron) | 提示词控制的流式 STT | ✓ | ✓ |
+| [MOSS Transcribe-Diarize 0.9B](https://huggingface.co/soniqo/MOSS-Transcribe-Diarize-0.9B-ONNX-FP16) | 多语言转写 + 说话人活动 | ✓ | — |
 | [Parakeet-EOU (120M)](https://huggingface.co/soniqo/Parakeet-EOU-120M-ONNX-INT8) · [soniqo.audio](https://soniqo.audio/zh/guides/dictate) | 流式 STT + 话语结束检测 | ✓ | — |
 | [Omnilingual ASR CTC (300M)](https://huggingface.co/soniqo/Omnilingual-ASR-CTC-300M-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/omnilingual) | 多语言语音转文字 | — | ✓ |
 | [Pyannote Segmentation 3.0](https://huggingface.co/soniqo/Pyannote-Segmentation-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/diarize) | 说话人分离切分 | — | ✓ |
 | [WeSpeaker ResNet34-LM](https://huggingface.co/soniqo/WeSpeaker-ResNet34-LM-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/embed-speaker) | 说话人嵌入 | — | ✓ |
+| [ReDimNet2-B6](https://huggingface.co/soniqo/ReDimNet2-B6-ONNX-FP32) | 说话人嵌入 | ✓ | — |
 | [VoxCPM 0.5B](https://huggingface.co/soniqo/VoxCPM-0.5B-ONNX) | 16 kHz TTS + 声音克隆 | ✓ | — |
 | [VoxCPM2 (2B)](https://huggingface.co/soniqo/VoxCPM2-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/voxcpm2) | 48 kHz TTS + 声音克隆 | ✓ | ✓ |
 | [CosyVoice3 0.5B](https://huggingface.co/soniqo/CosyVoice3-0.5B-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/cosyvoice) | 24 kHz 条件式 TTS | 预备 | — |
@@ -64,6 +66,7 @@ speech-core 将小巧、与模型无关的编排层和可选推理后端分离�
 | [Kokoro 82M](https://huggingface.co/soniqo/Kokoro-82M-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/kokoro) | 文字转语音 | ✓ | ✓ |
 | [Pocket TTS 100M](https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8) | 流式 TTS（固定 Alba 音色） | ✓ | — |
 | [DeepFilterNet3](https://huggingface.co/soniqo/DeepFilterNet3-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/denoise) | 语音增强 | ✓ | — |
+| [LocalVQE v1.4 AEC](https://huggingface.co/soniqo/LocalVQE-v1.4-AEC-200K-ONNX-FP32) | 声学回声消除 | ✓ | — |
 | [Sidon](https://huggingface.co/aufklarer/Sidon-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/restore) | 降噪 + 去混响（16 → 48 kHz） | ✓ | — |
 | [PersonaPlex 7B](https://huggingface.co/soniqo/PersonaPlex-7B-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/respond) | 全双工语音到语音（CUDA） | 结构已实现 | — |
 | [FunctionGemma 270M](https://huggingface.co/soniqo/FunctionGemma-270M-LiteRT-LM) · [soniqo.audio](https://soniqo.audio/zh/guides/function-calls) | 端侧结构化工具调用 | — | LiteRT-LM |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -57,6 +57,26 @@ public:
 
 **Swift counterpart:** `SpeechRecognitionModel` in `AudioCommon/Protocols.swift`.
 
+## TranscribeDiarizeInterface — Joint paragraph transcription and activity
+
+```cpp
+class TranscribeDiarizeInterface {
+public:
+    virtual DiarizedTranscriptionResult transcribe_diarized(
+        const float* audio, size_t length, int sample_rate) = 0;
+    virtual int input_sample_rate() const = 0;
+    virtual void cancel() {}
+};
+```
+
+`DiarizedTranscriptionResult` carries plain lexical `text`, parsed
+`segments{start_time,end_time,speaker,text}`, and the original model
+`raw_text` for fail-closed wire validation. Segment speaker values are scoped
+to one result and are activity-routing metadata, not people. Applications must
+not persist them as identities.
+
+**Reference implementation:** `OnnxMossTranscribeDiarize`.
+
 ## TTSInterface — Text-to-speech
 
 ```cpp
@@ -147,7 +167,39 @@ public:
 };
 ```
 
-Pipeline feeds TTS output via `feed_reference()` and runs `cancel_echo()` on mic input before VAD. Thread-safety: `feed_reference()` and `cancel_echo()` may be called concurrently. No reference implementation is shipped — bring your own (SpeexDSP, WebRTC AEC, platform-native).
+Pipeline feeds TTS output via `feed_reference()` and runs `cancel_echo()` on
+mic input before VAD. Thread-safety: `feed_reference()` and `cancel_echo()` may
+be called concurrently.
+
+**Reference implementation:** `OnnxLocalVQEEchoCanceller`.
+
+### FrameEchoCancellerInterface — Timestamp-aligned passive AEC
+
+```cpp
+class FrameEchoCancellerInterface {
+public:
+    virtual int input_sample_rate() const = 0;
+    virtual size_t frame_size() const = 0;
+    virtual void process_frame(
+        const float* microphone,
+        const float* reference,
+        float* output) = 0;
+    virtual bool prime_delay(
+        const float* microphone,
+        const float* reference,
+        size_t sample_count) = 0;
+    virtual int current_delay_samples() const { return 0; }
+    virtual float delay_confidence() const { return 0.0f; }
+    virtual void reset() = 0;
+};
+```
+
+This interface is for passive recorders that capture microphone and playback
+on independent timestamped streams. The caller supplies exact corresponding
+frames; `TimestampedEchoCancellationStream` provides bounded alignment,
+priming, and fail-closed queueing around it.
+
+**Reference implementation:** `OnnxLocalVQEEchoCanceller`.
 
 ## LLMInterface — Language model
 
@@ -203,7 +255,13 @@ public:
 };
 ```
 
-**Reference implementation:** `LiteRTWeSpeakerEmbedding` (WeSpeaker ResNet34-LM via LiteRT, 256-dim L2-normalised vector).
+`embed_short_utterance()` is an optional conservative retrieval-only path.
+Callers must not create or update an identity from that result alone.
+
+**Reference implementations:** `LiteRTWeSpeakerEmbedding` (WeSpeaker
+ResNet34-LM via LiteRT, 256-dim L2-normalised vector) and
+`OnnxReDimNetSpeakerEmbedding` (ReDimNet2-B6 via ONNX Runtime, 192-dim
+L2-normalised vector with a strict short retrieval probe).
 
 ### DiarizerInterface — end-to-end diarization
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -18,6 +18,9 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 | `OnnxVoxCPM2Tts` | `TTSInterface` | `speech_core/models/onnx_voxcpm2_tts.h` | full |
 | `OnnxNemotronStreamingStt` | `STTInterface` | `speech_core/models/onnx_nemotron_streaming_stt.h` | full (streaming) |
 | `NemotronMultilingualStt` | `STTInterface` | `speech_core/models/nemotron_multilingual_stt.h` | full (streaming, prompt-conditioned) |
+| `OnnxMossTranscribeDiarize` | `TranscribeDiarizeInterface` | `speech_core/models/onnx_moss_transcribe_diarize.h` | full (joint paragraph text/activity) |
+| `OnnxReDimNetSpeakerEmbedding` | `EmbeddingInterface` | `speech_core/models/onnx_redimnet_speaker_embedding.h` | full (long identity + short retrieval probe) |
+| `OnnxLocalVQEEchoCanceller` | `FrameEchoCancellerInterface`, `EchoCancellerInterface` | `speech_core/models/onnx_localvqe_echo_canceller.h` | full (hybrid DSP + neural AEC) |
 | `OnnxPersonaPlex` | `FullDuplexSpeechInterface` | `speech_core/models/onnx_personaplex.h` | structural — see [OnnxPersonaPlex](#onnxpersonaplex) |
 
 ### LiteRT backend (`SPEECH_CORE_WITH_LITERT`)
@@ -102,6 +105,48 @@ combined reference + continuation clone mode.
 `LiteRTVoxCPM2Tts` runs the full 4-graph orchestration end-to-end: `text_prefill → token_step ×N → audio_decode` with explicit K/V cache handoff every step. Voice cloning is surfaced through `set_reference()`. Supplying `set_reference_transcript()` additionally uses VoxCPM2's upstream combined reference + continuation prompt layout. The bundle is large (~8.7 GB fp16 `selective` for ARM at the repo root; ~13 GB fp32-token-step for x86 in the `fp32-p16/` subdir) and inference is slow on CPU, so end-to-end validation runs in the **weekly** workflow (`.github/workflows/weekly-voxcpm2.yml`) rather than the daily nightly.
 
 All ORT wrappers share an internal ONNX Runtime singleton (`OnnxEngine` in `speech_core/models/onnx_engine.h`) that owns the `OrtEnv` and `OrtMemoryInfo`. Most LiteRT wrappers share `LiteRTEngine` (`speech_core/models/litert_engine.h`). Kokoro uses the stable TFLite Interpreter ABI exported by `libLiteRt` so its constructor can set the XNNPACK thread count directly. The current reference wrappers are CPU-only; NNAPI / GPU / Hexagon delegates are not wired here.
+
+## Passive meeting transcription models
+
+The portable passive-recording stack mirrors speech-swift's fixed meeting
+pipeline:
+
+- `NemotronMultilingualStt` emits revisable, text-only previews.
+- `OnnxMossTranscribeDiarize` replaces them with authoritative paragraph text
+  and paragraph-local speaker activity.
+- `OnnxReDimNetSpeakerEmbedding` maps clean, non-overlapped activity audio to
+  recording-local or saved voice identities.
+- `OnnxLocalVQEEchoCanceller` removes an independently captured playback
+  reference from microphone audio before microphone VAD or ASR.
+
+Each model remains independently usable. `MeetingTranscriptionTrack`,
+`RecordingSpeakerIdentity`, and `TimestampedEchoCancellationStream` in
+`speech_core/pipeline/` provide the shared orchestration used by applications.
+Construct one meeting track per capture source; do not mix system and
+microphone PCM or share source-local VAD/streaming state.
+
+```cpp
+#include <speech_core/models/onnx_localvqe_echo_canceller.h>
+#include <speech_core/models/onnx_moss_transcribe_diarize.h>
+#include <speech_core/models/onnx_redimnet_speaker_embedding.h>
+
+speech_core::OnnxMossTranscribeDiarize moss("/models/moss");
+speech_core::OnnxReDimNetSpeakerEmbedding identity(
+    "/models/redimnet/ReDimNet2B6.onnx");
+speech_core::OnnxLocalVQEEchoCanceller aec("/models/localvqe");
+```
+
+MOSS's `S01`… values are result-local activity labels, never durable people.
+ReDimNet embeddings are identity hints, not authentication. The ordinary
+identity path requires at least two seconds of clean audio; the strict
+0.6-to-2-second path may only retrieve an already-established identity.
+
+LocalVQE's ONNX graph is only the recurrent residual-mask network. Its C++
+wrapper also runs the released delay estimator, adaptive filter/controller,
+STFT codec, and overlap-add state. Passive recorders should timestamp-align
+the still-separate microphone and playback streams through
+`TimestampedEchoCancellationStream`; alignment or inference failures must be
+handled explicitly rather than substituting raw microphone PCM.
 
 ## Building with ONNX support
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -39,6 +39,37 @@ Speech-to-text only — emits `TranscriptionCompleted` events but produces no au
 audio → VAD → STT → text
 ```
 
+## Passive meeting tracks
+
+`MeetingTranscriptionTrack` is separate from the conversational
+`VoicePipeline`. It implements the fixed source-local path used by passive
+meeting recorders:
+
+```text
+timestamped PCM -> Silero VAD -> Nemotron revisable preview
+                              -> MOSS authoritative paragraph text/activity
+```
+
+Construct one instance per capture source. PCM, VAD state, Nemotron stream,
+paragraph state, and timestamps never cross instances. A MOSS runtime may be
+shared when its implementation serializes inference. The default meeting
+configuration closes a paragraph after 550 ms of silence, retains 200 ms of
+pre/post-roll, first publishes continuous speech at ten seconds, and then
+revises a rolling window capped at twenty seconds.
+
+`MeetingTrackEvent::Preview` is non-durable text. A
+`MeetingTrackEvent::Revision` supplies an exact source-local replacement
+interval and authoritative blocks. MOSS activity labels remain scoped to that
+one result. `RecordingSpeakerIdentity` applies independent embedding evidence,
+within-result different-speaker constraints, conservative short-fragment
+galleries, and exact-range backfills. Ambiguous evidence remains unlabelled.
+
+For microphone capture, feed raw microphone and the independently captured
+playback reference to `TimestampedEchoCancellationStream`. Only its cleaned
+output should enter the microphone meeting track. Missing timestamps, buffer
+overrun, or AEC inference errors surface as failures; the class never emits
+raw microphone PCM as a fallback.
+
 ## State Machine
 
 Five states with automatic transitions:

--- a/include/speech_core/audio/resampler.h
+++ b/include/speech_core/audio/resampler.h
@@ -30,6 +30,8 @@ public:
     static void clear_cache();
 
 private:
+    friend class StreamingResampler;
+
     /// Filter half-width in output-domain taps (before scaling by ratio).
     static constexpr int kHalfWidth = 8;
 
@@ -47,6 +49,50 @@ private:
 
     static std::mutex cache_mutex_;
     static std::unordered_map<uint64_t, KernelTable> cache_;
+};
+
+/// Stateful windowed-sinc resampler for packetized live capture.
+///
+/// Unlike repeatedly calling Resampler::resample() for each device packet,
+/// this preserves the fractional source position and filter history across
+/// packet boundaries. That guarantees long-run sample conservation and avoids
+/// a small clock drift that otherwise breaks timestamp-aligned AEC.
+class StreamingResampler {
+public:
+    StreamingResampler(int from_rate, int to_rate);
+
+    /// Append one source packet and return every output sample whose filter
+    /// has enough future context. A small filter-delay tail remains buffered.
+    std::vector<float> process(const float* input, size_t input_length);
+
+    /// Emit the buffered tail using edge extension. Call once when capture
+    /// ends; subsequent process() calls require reset().
+    std::vector<float> flush();
+
+    /// Discard filter and fractional-rate state after a capture discontinuity.
+    void reset();
+
+    int input_sample_rate() const { return from_rate_; }
+    int output_sample_rate() const { return to_rate_; }
+    uint64_t total_input_samples() const { return total_input_samples_; }
+    uint64_t total_output_samples() const { return total_output_samples_; }
+
+private:
+    std::vector<float> produce(bool finishing);
+    uint64_t target_output_count() const;
+    void advance_source_position();
+    void prune_input();
+
+    int from_rate_ = 0;
+    int to_rate_ = 0;
+    Resampler::KernelTable kernel_{};
+    std::vector<float> input_;
+    uint64_t input_base_sample_ = 0;
+    uint64_t total_input_samples_ = 0;
+    uint64_t total_output_samples_ = 0;
+    uint64_t next_source_sample_ = 0;
+    uint64_t next_source_fraction_ = 0;
+    bool flushed_ = false;
 };
 
 }  // namespace speech_core

--- a/include/speech_core/interfaces.h
+++ b/include/speech_core/interfaces.h
@@ -43,6 +43,46 @@ struct PartialResult {
     float confidence = 0.0f;
 };
 
+/// One paragraph-local segment emitted by a joint transcription/diarization
+/// model. `speaker` is activity-routing metadata scoped to this result only;
+/// callers must never persist it as a person identity.
+struct DiarizedTranscriptionSegment {
+    float start_time = 0.0f;
+    float end_time = 0.0f;
+    std::string speaker;
+    std::string text;
+};
+
+/// Structured output from a joint transcription/diarization pass.
+struct DiarizedTranscriptionResult {
+    /// Plain lexical transcript assembled from `segments` when structured
+    /// activity was valid. If the model emitted usable but unstructured text,
+    /// this remains visible here while `segments` stays empty.
+    std::string text;
+    std::vector<DiarizedTranscriptionSegment> segments;
+    /// Original model output retained for application-side fail-closed
+    /// validation. It must not be presented directly to users.
+    std::string raw_text;
+};
+
+/// Joint paragraph-final transcription and speaker-activity interface.
+///
+/// Unlike `DiarizerInterface`, implementations produce text and paragraph-
+/// local activity in one authoritative pass. Speaker tokens never identify a
+/// person and must be reconciled by a separate identity encoder.
+class TranscribeDiarizeInterface {
+public:
+    virtual ~TranscribeDiarizeInterface() = default;
+
+    virtual DiarizedTranscriptionResult transcribe_diarized(
+        const float* audio, size_t length, int sample_rate) = 0;
+
+    virtual int input_sample_rate() const = 0;
+
+    /// Cancel any in-progress generation. Thread-safe when supported.
+    virtual void cancel() {}
+};
+
 class STTInterface {
 public:
     virtual ~STTInterface() = default;
@@ -270,6 +310,38 @@ public:
     virtual void reset() = 0;
 };
 
+/// Frame-synchronous acoustic echo cancellation used by passive recorders.
+///
+/// Unlike EchoCancellerInterface's conversational playback queue, this seam
+/// requires the caller to supply microphone and independently captured
+/// playback-reference frames for the exact same timestamp range. It supports
+/// bounded batch delay acquisition before any cleaned microphone PCM is
+/// published.
+class FrameEchoCancellerInterface {
+public:
+    virtual ~FrameEchoCancellerInterface() = default;
+
+    virtual int input_sample_rate() const = 0;
+    virtual size_t frame_size() const = 0;
+
+    virtual void process_frame(
+        const float* microphone,
+        const float* reference,
+        float* output) = 0;
+
+    /// Estimate bulk playback delay from an equal-length synchronized clip.
+    /// A false return means no confident delay was acquired; processing may
+    /// still continue with the implementation's safe zero/current delay.
+    virtual bool prime_delay(
+        const float* microphone,
+        const float* reference,
+        size_t sample_count) = 0;
+
+    virtual int current_delay_samples() const { return 0; }
+    virtual float delay_confidence() const { return 0.0f; }
+    virtual void reset() = 0;
+};
+
 // ---------------------------------------------------------------------------
 // Diarization — speaker segmentation, embedding, and clustering
 // ---------------------------------------------------------------------------
@@ -328,6 +400,14 @@ public:
     /// Embed an audio span into a speaker vector.
     virtual std::vector<float> embed(
         const float* audio, size_t length, int sample_rate) = 0;
+
+    /// Optional strict short-utterance retrieval probe. Implementations that
+    /// support it return an embedding for their documented minimum duration.
+    /// Callers must never create or update an identity from this result alone.
+    virtual std::vector<float> embed_short_utterance(
+        const float* /*audio*/, size_t /*length*/, int /*sample_rate*/) {
+        return {};
+    }
 
     /// Output embedding dimensionality.
     virtual int embedding_dim() const = 0;

--- a/include/speech_core/models/moss_prompt_processor.h
+++ b/include/speech_core/models/moss_prompt_processor.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+struct MossPreparedPrompt {
+    std::vector<int64_t> input_ids;
+    std::size_t audio_placeholder_count = 0;
+    int64_t eos_token_id = 151645;
+};
+
+/// Published MOSS chat prompt and audio-placeholder expansion.
+///
+/// The text instruction and its token ids are pinned to the source revision
+/// named by the portable model bundle. Keeping the already-tokenized fixed
+/// prompt here avoids embedding a full BPE encoder in native inference; model
+/// output still uses the bundle's vocabulary for decoding.
+class MossPromptProcessor {
+public:
+    static constexpr int64_t kAudioTokenId = 151671;
+    static constexpr int64_t kEosTokenId = 151645;
+    static constexpr double kAudioTokensPerSecond = 12.5;
+    static constexpr int kTimeMarkerEverySeconds = 5;
+
+    static MossPreparedPrompt prepare(std::size_t audio_token_count);
+    static std::vector<int64_t> make_audio_span(
+        std::size_t audio_token_count);
+};
+
+/// Qwen byte-level output decoder for the MOSS bundle's `vocab.json`.
+class MossTokenizerDecoder {
+public:
+    explicit MossTokenizerDecoder(const std::string& vocab_json_path);
+
+    /// Decode generated ids exactly as the Qwen tokenizer's byte decoder.
+    /// Added control ids are absent from vocab.json and are skipped.
+    std::string decode(const std::vector<int64_t>& ids) const;
+
+    std::size_t vocab_size() const { return tokens_by_id_.size(); }
+
+private:
+    std::vector<std::string> tokens_by_id_;
+    int inverse_byte_map_[512] = {};
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/moss_whisper_features.h
+++ b/include/speech_core/models/moss_whisper_features.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace speech_core {
+
+/// Fixed-shape Whisper log-mel input consumed by the portable MOSS audio
+/// encoder. Data is row-major `[mel_bins, time_frames]`.
+struct MossLogMelFeatures {
+    std::vector<float> data;
+    int mel_bins = 0;
+    int time_frames = 0;
+};
+
+/// Exact 400-point Whisper frontend used by MOSS-Transcribe-Diarize.
+///
+/// The ordinary speech-core FFT helper intentionally pads non-power-of-two
+/// transforms. MOSS was trained and exported with a true 400-point DFT, so
+/// this frontend uses the bundled KISS FFT implementation directly.
+class MossWhisperFeatureExtractor {
+public:
+    static constexpr int kSampleRate = 16000;
+    static constexpr int kFftSize = 400;
+    static constexpr int kHopLength = 160;
+    static constexpr int kMelBins = 80;
+    static constexpr int kChunkSamples = 480000;
+    static constexpr int kTimeFrames = 3000;
+    static constexpr int kEncoderStrideSamples = 1280;
+
+    MossWhisperFeatureExtractor();
+
+    static std::size_t audio_token_count(std::size_t sample_count);
+
+    /// Extract exactly `[80, 3000]` features from one non-empty, at-most
+    /// 30-second 16 kHz mono chunk. Short chunks are right-padded with zeroes.
+    MossLogMelFeatures extract_padded_chunk(
+        const float* audio, std::size_t length) const;
+
+private:
+    std::vector<float> hann_window_;
+    /// Row-major `[mel_bins, fft_bins]`.
+    std::vector<float> mel_filterbank_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_localvqe_echo_canceller.h
+++ b/include/speech_core/models/onnx_localvqe_echo_canceller.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace speech_core {
+
+/// Portable LocalVQE v1.4-AEC hybrid runtime.
+///
+/// The ONNX graph is only the recurrent neural residual mask. This class also
+/// owns the exact released delay estimator, adaptive filter/controller,
+/// 512/256 sqrt-Hann codec, and overlap-add state required around that graph.
+class OnnxLocalVQEEchoCanceller final
+    : public EchoCancellerInterface,
+      public FrameEchoCancellerInterface {
+public:
+    static constexpr int kSampleRate = 16000;
+    static constexpr std::size_t kFrameSize = 256;
+    static constexpr std::size_t kFftSize = 512;
+    static constexpr std::size_t kAlgorithmicLatencySamples = kFrameSize;
+
+    struct Config {
+        bool hardware_acceleration = true;
+        int intra_threads = 0;
+        bool enable_prealignment = true;
+    };
+
+    struct Profile {
+        double adaptive_filter_ms = 0.0;
+        double neural_mask_ms = 0.0;
+        double total_ms = 0.0;
+    };
+
+    explicit OnnxLocalVQEEchoCanceller(
+        const std::string& bundle_directory);
+    OnnxLocalVQEEchoCanceller(
+        const std::string& bundle_directory, const Config& config);
+    ~OnnxLocalVQEEchoCanceller() override;
+
+    OnnxLocalVQEEchoCanceller(
+        const OnnxLocalVQEEchoCanceller&) = delete;
+    OnnxLocalVQEEchoCanceller& operator=(
+        const OnnxLocalVQEEchoCanceller&) = delete;
+
+    /// Process one synchronized 16 ms microphone/reference pair.
+    ///
+    /// The caller owns timestamp alignment. Both frames must represent the
+    /// same capture interval; a gap in either stream requires reset().
+    void process_frame(
+        const float* microphone,
+        const float* reference,
+        float* output) override;
+
+    /// Estimate and freeze bulk playback delay from one synchronized clip.
+    /// The clip must contain the same number of microphone/reference samples.
+    bool prime_delay(
+        const float* microphone,
+        const float* reference,
+        std::size_t sample_count) override;
+
+    int current_delay_samples() const override;
+    float delay_confidence() const override;
+    Profile last_profile() const;
+
+    /// EchoCancellerInterface compatibility. feed_reference() queues exact
+    /// 16 kHz reference samples; cancel_echo() consumes the same number and
+    /// rejects underrun or non-256-aligned calls instead of passing raw audio.
+    void feed_reference(
+        const float* samples, std::size_t length) override;
+    void cancel_echo(
+        const float* input, std::size_t length, float* output) override;
+    int input_sample_rate() const override { return kSampleRate; }
+    std::size_t frame_size() const override { return kFrameSize; }
+    void reset() override;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_moss_transcribe_diarize.h
+++ b/include/speech_core/models/onnx_moss_transcribe_diarize.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/models/moss_prompt_processor.h"
+#include "speech_core/models/moss_whisper_features.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+namespace speech_core {
+
+/// Portable MOSS-Transcribe-Diarize runtime for the validated two-graph ONNX
+/// bundle published by speech-models.
+class OnnxMossTranscribeDiarize final
+    : public TranscribeDiarizeInterface {
+public:
+    struct Config {
+        int max_new_tokens = 512;
+        int audio_intra_threads = 0;
+        int decoder_intra_threads = 0;
+        bool audio_hardware_acceleration = true;
+        bool decoder_hardware_acceleration = false;
+    };
+
+    struct Profile {
+        double total_ms = 0.0;
+        double feature_ms = 0.0;
+        double audio_encoder_ms = 0.0;
+        double decoder_prefill_ms = 0.0;
+        double decoder_generate_ms = 0.0;
+        int prompt_tokens = 0;
+        int generated_tokens = 0;
+        int audio_chunks = 0;
+    };
+
+    explicit OnnxMossTranscribeDiarize(
+        const std::string& bundle_directory);
+    OnnxMossTranscribeDiarize(
+        const std::string& bundle_directory, const Config& config);
+    ~OnnxMossTranscribeDiarize() override;
+
+    OnnxMossTranscribeDiarize(
+        const OnnxMossTranscribeDiarize&) = delete;
+    OnnxMossTranscribeDiarize& operator=(
+        const OnnxMossTranscribeDiarize&) = delete;
+
+    DiarizedTranscriptionResult transcribe_diarized(
+        const float* audio, std::size_t length, int sample_rate) override;
+
+    int input_sample_rate() const override {
+        return MossWhisperFeatureExtractor::kSampleRate;
+    }
+
+    void cancel() override;
+    Profile last_profile() const;
+
+private:
+    void validate_bundle(const std::string& bundle_directory) const;
+    void validate_graph_contracts();
+
+    const OrtApi* api_ = nullptr;
+    OrtSession* audio_encoder_ = nullptr;
+    OrtSession* decoder_ = nullptr;
+    Config config_;
+    MossWhisperFeatureExtractor feature_extractor_;
+    MossTokenizerDecoder tokenizer_;
+    ONNXTensorElementDataType audio_type_ =
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    ONNXTensorElementDataType decoder_type_ =
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    std::atomic<bool> cancel_requested_{false};
+    mutable std::mutex inference_mutex_;
+    mutable std::mutex profile_mutex_;
+    Profile last_profile_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/onnx_redimnet_speaker_embedding.h
+++ b/include/speech_core/models/onnx_redimnet_speaker_embedding.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// ReDimNet2-B6 speaker-identity embeddings from the portable ONNX export.
+///
+/// This is the identity layer used after MOSS activity routing. It is not a
+/// diarizer and its vectors must not be treated as authentication.
+class OnnxReDimNetSpeakerEmbedding final : public EmbeddingInterface {
+public:
+    static constexpr int kSampleRate = 16000;
+    static constexpr std::size_t kInputSamples = 96000;
+    static constexpr std::size_t kMinimumSamples = 32000;
+    static constexpr std::size_t kMinimumShortSamples = 9600;
+    static constexpr int kEmbeddingDimension = 192;
+
+    explicit OnnxReDimNetSpeakerEmbedding(
+        const std::string& model_path, bool hardware_acceleration = true);
+    ~OnnxReDimNetSpeakerEmbedding() override;
+
+    OnnxReDimNetSpeakerEmbedding(
+        const OnnxReDimNetSpeakerEmbedding&) = delete;
+    OnnxReDimNetSpeakerEmbedding& operator=(
+        const OnnxReDimNetSpeakerEmbedding&) = delete;
+
+    std::vector<float> embed(
+        const float* audio, std::size_t length, int sample_rate) override;
+
+    /// Conservative 0.6-to-2-second retrieval probe. Do not use its result to
+    /// create, enroll, or update an identity.
+    std::vector<float> embed_short_utterance(
+        const float* audio, std::size_t length, int sample_rate) override;
+
+    int embedding_dim() const override { return kEmbeddingDimension; }
+    int input_sample_rate() const override { return kSampleRate; }
+
+    static std::vector<float> prepare_audio(
+        const float* samples, std::size_t length,
+        std::size_t minimum_samples = kMinimumSamples);
+
+private:
+    std::vector<float> embed_with_minimum(
+        const float* audio, std::size_t length, int sample_rate,
+        std::size_t minimum_samples);
+    void validate_contract();
+
+    const OrtApi* api_ = nullptr;
+    OrtSession* session_ = nullptr;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/pipeline/meeting_transcription_track.h
+++ b/include/speech_core/pipeline/meeting_transcription_track.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// One authoritative paragraph block from a source-local meeting track.
+struct MeetingTranscriptBlock {
+    std::int64_t start_time_ns = 0;
+    std::int64_t end_time_ns = 0;
+    std::string text;
+    /// MOSS activity label scoped to this one inference result. Empty means
+    /// attribution abstained or this is the microphone track.
+    std::string activity_label;
+    /// Clean, non-overlapped source-local evidence for an identity encoder.
+    /// Empty when the turn is mixed, overlapping, or unalignable.
+    std::vector<float> identity_audio;
+};
+
+enum class MeetingTrackEventType {
+    Preview,
+    Revision,
+    Error,
+};
+
+struct MeetingTrackEvent {
+    MeetingTrackEventType type = MeetingTrackEventType::Preview;
+    /// Full revisable Nemotron caption for Preview; empty clears it.
+    std::string preview_text;
+    /// Revision replaces source-local blocks intersecting this interval.
+    std::int64_t replace_start_time_ns = 0;
+    std::int64_t replace_end_time_ns = 0;
+    std::vector<MeetingTranscriptBlock> blocks;
+    bool paragraph_final = false;
+    double final_asr_ms = 0.0;
+    std::string error;
+};
+
+/// Source-local fixed meeting pipeline:
+/// Silero VAD -> Nemotron previews -> MOSS paragraph-final text/activity.
+///
+/// Construct one instance per captured source. PCM, VAD state, preview state,
+/// paragraph state, and timestamps never cross instances. The MOSS model may
+/// be shared; its implementation is responsible for serializing inference.
+class MeetingTranscriptionTrack {
+public:
+    struct Config {
+        int sample_rate = 16000;
+        float vad_onset = 0.50f;
+        float vad_offset = 0.35f;
+        float minimum_speech_seconds = 0.20f;
+        float silence_close_seconds = 0.55f;
+        float pre_roll_seconds = 0.20f;
+        float post_roll_seconds = 0.20f;
+        float activity_recovery_context_seconds = 4.0f;
+        float microphone_short_agreement_seconds = 0.40f;
+        float continuous_update_seconds = 10.0f;
+        float maximum_window_seconds = 20.0f;
+        /// Microphone keeps MOSS text/timing but discards activity labels and
+        /// gates sub-400 ms results on independent preview agreement.
+        bool microphone = false;
+    };
+
+    using EventCallback = std::function<void(const MeetingTrackEvent&)>;
+
+    MeetingTranscriptionTrack(
+        STTInterface& preview,
+        TranscribeDiarizeInterface& final_model,
+        VADInterface& vad,
+        Config config,
+        EventCallback callback);
+    ~MeetingTranscriptionTrack();
+
+    MeetingTranscriptionTrack(
+        const MeetingTranscriptionTrack&) = delete;
+    MeetingTranscriptionTrack& operator=(
+        const MeetingTranscriptionTrack&) = delete;
+
+    /// Push 16 kHz mono PCM and the capture time of its first sample.
+    /// `discontinuity` resets all source-local state before accepting the
+    /// block. Callers should then fail the enclosing required track if that
+    /// policy is stricter than a reset.
+    void push_audio(
+        const float* samples,
+        std::size_t length,
+        std::int64_t start_time_ns,
+        bool discontinuity = false);
+
+    /// Close an open paragraph, publish its final MOSS result, and wait until
+    /// all source-local inference is complete.
+    void finish();
+
+    /// Discard revisable work and reset VAD/ASR state without publishing it.
+    void cancel();
+
+    /// Wait until every already queued final inference has completed.
+    void wait_idle();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/pipeline/recording_speaker_identity.h
+++ b/include/speech_core/pipeline/recording_speaker_identity.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+#include "speech_core/pipeline/meeting_transcription_track.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+struct StoredSpeakerIdentityProfile {
+    std::string name;
+    std::vector<float> embedding;
+    std::size_t sample_count = 1;
+};
+
+struct SpeakerIdentityBackfill {
+    std::int64_t start_time_ns = 0;
+    std::int64_t end_time_ns = 0;
+    std::string text;
+    std::string speaker;
+};
+
+struct SpeakerIdentityResolution {
+    /// One optional recording/global identity per input block.
+    std::vector<std::optional<std::string>> speakers;
+    /// Exact earlier short-fragment ranges that supplied newly resolved
+    /// recording-local evidence. Callers must also require text compatibility.
+    std::vector<SpeakerIdentityBackfill> backfills;
+};
+
+/// Precision-first ReDimNet identity layer for MOSS paragraph-local activity.
+///
+/// MOSS S01... labels are accepted only as within-result different-speaker
+/// constraints and never escape this class. Long clean evidence may match or
+/// create a recording identity. A 0.6-to-2-second probe can only retrieve an
+/// existing profile/session identity. Unsupported or ambiguous evidence
+/// remains unlabelled.
+class RecordingSpeakerIdentity {
+public:
+    struct Config {
+        int sample_rate = 16000;
+        float minimum_long_seconds = 2.0f;
+        float minimum_short_seconds = 0.60f;
+        float match_threshold = 0.55f;
+        float novelty_threshold = 0.45f;
+        float ambiguity_margin = 0.08f;
+        float global_short_threshold = 0.85f;
+        float global_short_margin = 0.20f;
+        float recording_short_threshold = 0.70f;
+        float recording_short_margin = 0.18f;
+        float gallery_bootstrap_threshold = 0.60f;
+        float gallery_support_threshold = 0.35f;
+        float gallery_support_margin = 0.10f;
+        std::size_t gallery_minimum_fragments = 3;
+        std::size_t maximum_session_speakers = 12;
+        std::size_t maximum_gallery_candidates = 12;
+        std::size_t maximum_gallery_fragments = 8;
+    };
+
+    explicit RecordingSpeakerIdentity(
+        EmbeddingInterface& embedder);
+    RecordingSpeakerIdentity(
+        EmbeddingInterface& embedder,
+        Config config);
+    ~RecordingSpeakerIdentity();
+
+    RecordingSpeakerIdentity(
+        const RecordingSpeakerIdentity&) = delete;
+    RecordingSpeakerIdentity& operator=(
+        const RecordingSpeakerIdentity&) = delete;
+
+    void set_profiles(
+        std::vector<StoredSpeakerIdentityProfile> profiles);
+    const std::vector<StoredSpeakerIdentityProfile>& profiles() const {
+        return profiles_;
+    }
+
+    void begin_recording();
+
+    SpeakerIdentityResolution resolve(
+        const std::vector<MeetingTranscriptBlock>& blocks);
+
+    /// Promote/rename an established recording identity as a durable profile.
+    /// Returns false when the recording label is unknown.
+    bool promote_recording_identity(
+        const std::string& label,
+        const std::string& name);
+
+    void upsert_profile(
+        const std::string& name,
+        const std::vector<float>& embedding,
+        std::size_t sample_count = 1);
+    bool delete_profile(const std::string& name);
+    bool has_profile(const std::string& name) const;
+
+private:
+    struct SessionVoice;
+    struct GalleryCandidate;
+    struct GroupEvidence;
+
+    std::optional<std::string> resolve_long(
+        const std::vector<float>& embedding,
+        const std::vector<std::string>& claimed);
+    std::optional<std::string> resolve_short(
+        const std::vector<float>& embedding,
+        const std::vector<std::string>& claimed) const;
+    void add_gallery_evidence(
+        const GroupEvidence& group,
+        const std::vector<float>& embedding,
+        const std::vector<std::string>& claimed,
+        SpeakerIdentityResolution& resolution,
+        std::size_t group_index);
+
+    EmbeddingInterface& embedder_;
+    Config config_;
+    std::vector<StoredSpeakerIdentityProfile> profiles_;
+    std::vector<SessionVoice> session_voices_;
+    std::vector<GalleryCandidate> gallery_;
+    std::uint64_t paragraph_sequence_ = 0;
+    std::uint64_t gallery_tick_ = 0;
+    std::size_t next_session_label_ = 1;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/pipeline/timestamped_echo_cancellation_stream.h
+++ b/include/speech_core/pipeline/timestamped_echo_cancellation_stream.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// One timestamp-aligned frame published after mandatory echo cancellation.
+///
+/// The three buffers always describe the same capture interval and retain only
+/// `sample_count` real samples; the internal model-only padding is not exposed.
+struct EchoCancelledFrame {
+    std::int64_t start_time_ns = 0;
+    std::size_t sample_count = 0;
+    bool discontinuity = false;
+    std::vector<float> raw_microphone;
+    std::vector<float> playback_reference;
+    std::vector<float> cleaned_microphone;
+};
+
+struct EchoCancellationPrimingEvent {
+    std::int64_t start_time_ns = 0;
+    std::int64_t end_time_ns = 0;
+    std::string reason;
+    int delay_samples = 0;
+    float delay_confidence = 0.0f;
+};
+
+/// Timestamp-aligns independently captured microphone and playback PCM before
+/// sending still-separate frames through a FrameEchoCancellerInterface.
+///
+/// Capture callbacks only copy bounded timestamped segments. A private worker
+/// performs model inference and publishes cleaned microphone frames. Missing
+/// timestamps, backwards clocks, buffer overrun, or model failures stop this
+/// stream; raw microphone PCM is never emitted as a fallback.
+class TimestampedEchoCancellationStream {
+public:
+    struct Config {
+        int sample_rate = 16000;
+        std::size_t frame_size = 256;
+        std::size_t capacity_samples = 16000 * 30;
+        std::int64_t reference_wait_ns = 100000000;
+        std::int64_t clock_skew_tolerance_ns = 10000000;
+        std::int64_t timestamp_discontinuity_ns = 100000000;
+        std::size_t playback_priming_samples = 16000 * 2;
+        std::size_t playback_repriming_silence_samples = 16000 * 2;
+        float playback_activation_rms = 0.001f;
+        /// Must use the same monotonic epoch as input start_time_ns.
+        std::function<std::int64_t()> current_time_ns;
+    };
+
+    using OutputCallback =
+        std::function<void(const EchoCancelledFrame&)>;
+    using FailureCallback =
+        std::function<void(const std::string&)>;
+    using PrimingCallback =
+        std::function<void(const EchoCancellationPrimingEvent&)>;
+
+    TimestampedEchoCancellationStream(
+        FrameEchoCancellerInterface& canceller,
+        Config config,
+        OutputCallback output,
+        FailureCallback failure = {},
+        PrimingCallback priming = {});
+    ~TimestampedEchoCancellationStream();
+
+    TimestampedEchoCancellationStream(
+        const TimestampedEchoCancellationStream&) = delete;
+    TimestampedEchoCancellationStream& operator=(
+        const TimestampedEchoCancellationStream&) = delete;
+
+    void push_microphone(
+        const float* samples,
+        std::size_t count,
+        std::int64_t start_time_ns,
+        bool discontinuity = false);
+
+    void push_reference(
+        const float* samples,
+        std::size_t count,
+        std::int64_t start_time_ns,
+        bool discontinuity = false);
+
+    /// Mark both capture sources stopped, drain the final partial model frame,
+    /// and wait for all already-captured microphone PCM to be published.
+    /// Throws the fail-closed reason if synchronization or inference failed.
+    void finish();
+
+    /// Discard queued audio and stop without publishing a trailing frame.
+    void cancel();
+
+    std::optional<std::string> failure() const;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/transcription/moss_transcript_parser.h
+++ b/include/speech_core/transcription/moss_transcript_parser.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "speech_core/interfaces.h"
+
+namespace speech_core {
+
+/// Parse MOSS's compact `[start][Sxx]text[end]` wire format.
+///
+/// Malformed or backwards segments are ignored. If no valid structured
+/// segment exists, `plain_text` preserves the trimmed raw output so the caller
+/// can apply source-specific fail-closed policy.
+DiarizedTranscriptionResult parse_moss_transcript(const std::string& raw_text);
+
+/// Consume control tokens accidentally repeated inside an otherwise valid
+/// MOSS segment. Spoken words and punctuation are preserved.
+std::string sanitize_moss_segment_text(const std::string& text);
+
+/// True when text contains a MOSS timestamp or speaker control token.
+bool contains_moss_wire_marker(const std::string& text);
+
+}  // namespace speech_core

--- a/scripts/download_models.ps1
+++ b/scripts/download_models.ps1
@@ -1,6 +1,9 @@
 param(
     [Parameter(Position = 0)]
-    [string]$OutputDirectory
+    [string]$OutputDirectory,
+
+    [ValidateSet("default", "stenograf")]
+    [string]$ModelSet = "default"
 )
 
 Set-StrictMode -Version Latest
@@ -24,7 +27,7 @@ $outputRoot = [System.IO.Path]::GetFullPath($OutputDirectory)
 $voicesDirectory = Join-Path $outputRoot "voices"
 New-Item -ItemType Directory -Force -Path $voicesDirectory | Out-Null
 
-$files = @(
+$defaultFiles = @(
     "Silero-VAD-v5-ONNX/silero-vad.onnx",
     "Parakeet-TDT-0.6B-ONNX/parakeet-encoder-int8.onnx",
     "Parakeet-TDT-0.6B-ONNX/parakeet-decoder-joint-int8.onnx",
@@ -51,11 +54,44 @@ $files = @(
     "DeepFilterNet3-ONNX/deepfilter.onnx"
 )
 
+$stenografFiles = @(
+    "Silero-VAD-v5-ONNX/silero-vad.onnx",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/encoder.onnx",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/decoder.onnx",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/decoder.onnx.data",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/joint.onnx",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/joint.onnx.data",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/vocab.json",
+    "Nemotron-3.5-ASR-Streaming-Multilingual-0.6B-ONNX-INT8/languages.json",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/audio_encoder.onnx",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/decoder.onnx",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/config.json",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/processor_config.json",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/preprocessor_config.json",
+    "MOSS-Transcribe-Diarize-0.9B-ONNX-FP16/vocab.json",
+    "ReDimNet2-B6-ONNX-FP32/ReDimNet2B6.onnx",
+    "ReDimNet2-B6-ONNX-FP32/config.json",
+    "LocalVQE-v1.4-AEC-200K-ONNX-FP32/LocalVQEAECResidualMask.onnx",
+    "LocalVQE-v1.4-AEC-200K-ONNX-FP32/LocalVQEAECFrontend.json",
+    "LocalVQE-v1.4-AEC-200K-ONNX-FP32/config.json"
+)
+
+$files = if ($ModelSet -eq "stenograf") {
+    $stenografFiles
+} else {
+    $defaultFiles
+}
+
 foreach ($entry in $files) {
     $slash = $entry.IndexOf('/')
     $repository = $entry.Substring(0, $slash)
     $relativePath = $entry.Substring($slash + 1)
-    if ($relativePath.StartsWith("voices/")) {
+    if ($ModelSet -eq "stenograf") {
+        # Keep each application model in its repository directory. Nemotron
+        # external-data references and common config/vocab filenames require
+        # this layout.
+        $destination = Join-Path (Join-Path $outputRoot $repository) ($relativePath.Replace('/', '\'))
+    } elseif ($relativePath.StartsWith("voices/")) {
         $destination = Join-Path $outputRoot ($relativePath.Replace('/', '\'))
     } else {
         $destination = Join-Path $outputRoot ([System.IO.Path]::GetFileName($relativePath))
@@ -91,5 +127,5 @@ foreach ($entry in $files) {
 }
 
 Write-Host ""
-Write-Host "Models downloaded to: $outputRoot"
+Write-Host "$ModelSet models downloaded to: $outputRoot"
 Write-Host "Start the server with: speech-server.exe --model-dir `"$outputRoot`""

--- a/src/audio/resampler.cpp
+++ b/src/audio/resampler.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <stdexcept>
 
 namespace speech_core {
 
@@ -115,6 +117,166 @@ std::vector<float> Resampler::resample(
 void Resampler::clear_cache() {
     std::lock_guard<std::mutex> lock(cache_mutex_);
     cache_.clear();
+}
+
+StreamingResampler::StreamingResampler(int from_rate, int to_rate)
+    : from_rate_(from_rate), to_rate_(to_rate) {
+    if (from_rate <= 0 || to_rate <= 0) {
+        throw std::invalid_argument(
+            "Streaming resampler rates must be positive");
+    }
+    if (from_rate != to_rate) {
+        // Keep an owned copy so Resampler::clear_cache() cannot invalidate a
+        // live packetized stream.
+        kernel_ = Resampler::get_kernel(from_rate, to_rate);
+    }
+}
+
+std::vector<float> StreamingResampler::process(
+    const float* input, size_t input_length) {
+    if (!input && input_length != 0) {
+        throw std::invalid_argument(
+            "Streaming resampler input must not be null");
+    }
+    if (flushed_) {
+        throw std::logic_error(
+            "Streaming resampler must be reset after flush");
+    }
+    if (input_length == 0) return {};
+    for (size_t index = 0; index < input_length; ++index) {
+        if (!std::isfinite(input[index])) {
+            throw std::invalid_argument(
+                "Streaming resampler input contains NaN or infinity");
+        }
+    }
+    if (total_input_samples_
+        > std::numeric_limits<uint64_t>::max() - input_length) {
+        throw std::overflow_error(
+            "Streaming resampler input sample counter overflowed");
+    }
+    input_.insert(input_.end(), input, input + input_length);
+    total_input_samples_ += static_cast<uint64_t>(input_length);
+    return produce(false);
+}
+
+std::vector<float> StreamingResampler::flush() {
+    if (flushed_) return {};
+    flushed_ = true;
+    return produce(true);
+}
+
+void StreamingResampler::reset() {
+    input_.clear();
+    input_base_sample_ = 0;
+    total_input_samples_ = 0;
+    total_output_samples_ = 0;
+    next_source_sample_ = 0;
+    next_source_fraction_ = 0;
+    flushed_ = false;
+}
+
+uint64_t StreamingResampler::target_output_count() const {
+    // floor(total_input_samples * to_rate / from_rate), written without a
+    // potentially overflowing multiplication so multi-day captures remain
+    // exact on MSVC as well as compilers with 128-bit integers.
+    const uint64_t from = static_cast<uint64_t>(from_rate_);
+    const uint64_t to = static_cast<uint64_t>(to_rate_);
+    const uint64_t whole = total_input_samples_ / from;
+    const uint64_t remainder = total_input_samples_ % from;
+    if (whole > std::numeric_limits<uint64_t>::max() / to) {
+        throw std::overflow_error(
+            "Streaming resampler output sample counter overflowed");
+    }
+    return whole * to + remainder * to / from;
+}
+
+void StreamingResampler::advance_source_position() {
+    next_source_fraction_ += static_cast<uint64_t>(from_rate_);
+    next_source_sample_ +=
+        next_source_fraction_ / static_cast<uint64_t>(to_rate_);
+    next_source_fraction_ %= static_cast<uint64_t>(to_rate_);
+}
+
+std::vector<float> StreamingResampler::produce(bool finishing) {
+    if (from_rate_ == to_rate_) {
+        const size_t offset = static_cast<size_t>(
+            total_output_samples_ - input_base_sample_);
+        if (offset > input_.size()) {
+            throw std::logic_error(
+                "Streaming resampler identity state is inconsistent");
+        }
+        std::vector<float> output(
+            input_.begin() + static_cast<std::ptrdiff_t>(offset),
+            input_.end());
+        total_output_samples_ += output.size();
+        input_.clear();
+        input_base_sample_ = total_input_samples_;
+        next_source_sample_ = total_input_samples_;
+        return output;
+    }
+
+    std::vector<float> output;
+    const uint64_t final_count = target_output_count();
+    while (total_output_samples_ < final_count) {
+        if (!finishing
+            && next_source_sample_
+                + static_cast<uint64_t>(kernel_.half_width)
+                >= total_input_samples_) {
+            break;
+        }
+        const uint64_t phase_numerator =
+            next_source_fraction_
+            * static_cast<uint64_t>(Resampler::kTablePhases);
+        int phase = static_cast<int>(
+            phase_numerator / static_cast<uint64_t>(to_rate_));
+        phase = std::min(phase, Resampler::kTablePhases - 1);
+        const float* taps =
+            &kernel_.table[static_cast<size_t>(phase) * kernel_.taps];
+        float sum = 0.0f;
+        for (int tap = -kernel_.half_width;
+             tap <= kernel_.half_width; ++tap) {
+            int64_t absolute =
+                static_cast<int64_t>(next_source_sample_) + tap;
+            absolute = std::max<int64_t>(0, absolute);
+            absolute = std::min<int64_t>(
+                absolute,
+                static_cast<int64_t>(total_input_samples_) - 1);
+            if (absolute < static_cast<int64_t>(input_base_sample_)) {
+                throw std::logic_error(
+                    "Streaming resampler discarded required filter history");
+            }
+            const uint64_t relative =
+                static_cast<uint64_t>(absolute)
+                - input_base_sample_;
+            if (relative >= input_.size()) {
+                throw std::logic_error(
+                    "Streaming resampler is missing required future input");
+            }
+            sum += input_[static_cast<size_t>(relative)]
+                * taps[tap + kernel_.half_width];
+        }
+        output.push_back(sum);
+        ++total_output_samples_;
+        advance_source_position();
+    }
+    prune_input();
+    return output;
+}
+
+void StreamingResampler::prune_input() {
+    if (input_.empty() || from_rate_ == to_rate_) return;
+    const uint64_t history = static_cast<uint64_t>(kernel_.half_width);
+    const uint64_t keep_from =
+        next_source_sample_ > history
+        ? next_source_sample_ - history : 0;
+    if (keep_from <= input_base_sample_) return;
+    const uint64_t requested = keep_from - input_base_sample_;
+    const size_t remove = static_cast<size_t>(
+        std::min<uint64_t>(requested, input_.size()));
+    input_.erase(
+        input_.begin(),
+        input_.begin() + static_cast<std::ptrdiff_t>(remove));
+    input_base_sample_ += remove;
 }
 
 }  // namespace speech_core

--- a/src/models/localvqe/localvqe_aec_frontend.cpp
+++ b/src/models/localvqe/localvqe_aec_frontend.cpp
@@ -1,0 +1,857 @@
+// LocalVQE v1.4 adaptive echo-cancellation front end.
+//
+// Derived from localai-org/LocalVQE's ggml/daf_frontend.cpp (Apache-2.0).
+// The Core ML residual model was trained behind this exact controller and
+// partitioned-block Kalman filter; replacing it with a generic subtractor
+// materially changes the neural model's inputs.
+
+#include "localvqe_aec_frontend.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <new>
+#include <vector>
+
+namespace {
+
+constexpr int kBlock = 128;
+constexpr int kPartitions = 128;
+constexpr int kFFT = 256;
+constexpr int kBins = 129;
+constexpr int kIterations = 2;
+constexpr float kDecay = 0.999f;
+constexpr float kInitialCovariance = 1000.0f;
+
+constexpr int kGCCWindow = 16384;
+constexpr int kGCCHop = 8000;
+constexpr int kGCCFFT = 32768;
+constexpr int kGCCMaxLag = 16384;
+constexpr float kGCCGateDB = 26.0f;
+constexpr float kGCCConfidenceThreshold = 8.0f;
+constexpr int64_t kLockAfter = 56000;
+constexpr size_t kControllerWeightCount = 2742;
+constexpr double kPi = 3.14159265358979323846264338327950288;
+
+void fftInPlace(std::vector<float>& real, std::vector<float>& imag, bool inverse) {
+    const size_t count = real.size();
+    for (size_t index = 1, reversed = 0; index < count; ++index) {
+        size_t bit = count >> 1;
+        for (; reversed & bit; bit >>= 1) {
+            reversed ^= bit;
+        }
+        reversed ^= bit;
+        if (index < reversed) {
+            std::swap(real[index], real[reversed]);
+            std::swap(imag[index], imag[reversed]);
+        }
+    }
+
+    for (size_t length = 2; length <= count; length <<= 1) {
+        const double angle = (inverse ? 2.0 : -2.0) * kPi
+            / static_cast<double>(length);
+        const double rootReal = std::cos(angle);
+        const double rootImag = std::sin(angle);
+        for (size_t offset = 0; offset < count; offset += length) {
+            double currentReal = 1.0;
+            double currentImag = 0.0;
+            for (size_t index = 0; index < length / 2; ++index) {
+                const float upperReal = real[offset + index];
+                const float upperImag = imag[offset + index];
+                const size_t lower = offset + index + length / 2;
+                const float lowerReal = static_cast<float>(
+                    real[lower] * currentReal - imag[lower] * currentImag);
+                const float lowerImag = static_cast<float>(
+                    real[lower] * currentImag + imag[lower] * currentReal);
+                real[offset + index] = upperReal + lowerReal;
+                imag[offset + index] = upperImag + lowerImag;
+                real[lower] = upperReal - lowerReal;
+                imag[lower] = upperImag - lowerImag;
+
+                const double nextReal = currentReal * rootReal
+                    - currentImag * rootImag;
+                currentImag = currentReal * rootImag + currentImag * rootReal;
+                currentReal = nextReal;
+            }
+        }
+    }
+
+    if (inverse) {
+        const float scale = 1.0f / static_cast<float>(count);
+        for (size_t index = 0; index < count; ++index) {
+            real[index] *= scale;
+            imag[index] *= scale;
+        }
+    }
+}
+
+void realFFT(const float *input, int count, float *real, float *imag) {
+    // These transforms run several times per 8 ms adaptive-filter block.
+    // Reuse thread-local capacity instead of allocating on the audio path.
+    static thread_local std::vector<float> workReal;
+    static thread_local std::vector<float> workImag;
+    workReal.assign(input, input + count);
+    workImag.assign(static_cast<size_t>(count), 0.0f);
+    fftInPlace(workReal, workImag, false);
+    for (int bin = 0; bin <= count / 2; ++bin) {
+        real[bin] = workReal[bin];
+        imag[bin] = workImag[bin];
+    }
+}
+
+void inverseRealFFT(
+    const float *binReal,
+    const float *binImag,
+    int count,
+    float *output
+) {
+    static thread_local std::vector<float> real;
+    static thread_local std::vector<float> imag;
+    real.assign(static_cast<size_t>(count), 0.0f);
+    imag.assign(static_cast<size_t>(count), 0.0f);
+    for (int bin = 0; bin <= count / 2; ++bin) {
+        real[bin] = binReal[bin];
+        imag[bin] = binImag[bin];
+    }
+    for (int bin = 1; bin < count / 2; ++bin) {
+        real[count - bin] = binReal[bin];
+        imag[count - bin] = -binImag[bin];
+    }
+    fftInPlace(real, imag, true);
+    std::copy(real.begin(), real.end(), output);
+}
+
+void gruCell(
+    const float *input,
+    int inputSize,
+    float *hidden,
+    int hiddenSize,
+    const std::vector<float>& inputWeights,
+    const std::vector<float>& hiddenWeights,
+    const std::vector<float>& inputBias,
+    const std::vector<float>& hiddenBias,
+    std::vector<float>& inputGates,
+    std::vector<float>& hiddenGates
+) {
+    for (int gate = 0; gate < 3 * hiddenSize; ++gate) {
+        float inputSum = inputBias[gate];
+        const float *inputRow = inputWeights.data()
+            + static_cast<size_t>(gate) * inputSize;
+        for (int index = 0; index < inputSize; ++index) {
+            inputSum += inputRow[index] * input[index];
+        }
+        inputGates[gate] = inputSum;
+
+        float hiddenSum = hiddenBias[gate];
+        const float *hiddenRow = hiddenWeights.data()
+            + static_cast<size_t>(gate) * hiddenSize;
+        for (int index = 0; index < hiddenSize; ++index) {
+            hiddenSum += hiddenRow[index] * hidden[index];
+        }
+        hiddenGates[gate] = hiddenSum;
+    }
+
+    for (int index = 0; index < hiddenSize; ++index) {
+        const float reset = 1.0f / (1.0f + std::exp(
+            -(inputGates[index] + hiddenGates[index])));
+        const float update = 1.0f / (1.0f + std::exp(
+            -(inputGates[hiddenSize + index]
+              + hiddenGates[hiddenSize + index])));
+        const float candidate = std::tanh(
+            inputGates[2 * hiddenSize + index]
+            + reset * hiddenGates[2 * hiddenSize + index]);
+        hidden[index] = (1.0f - update) * candidate + update * hidden[index];
+    }
+}
+
+void normalizeFeatures(
+    const float *input,
+    float *output,
+    const std::vector<float>& weight,
+    const std::vector<float>& bias,
+    int count
+) {
+    float mean = 0.0f;
+    for (int index = 0; index < 6; ++index) {
+        mean += input[index];
+    }
+    mean /= 6.0f;
+    float variance = 0.0f;
+    for (int index = 0; index < 6; ++index) {
+        const float difference = input[index] - mean;
+        variance += difference * difference;
+    }
+    variance /= 6.0f;
+    const float inverse = 1.0f / std::sqrt(variance + 1e-5f);
+    for (int index = 0; index < 6; ++index) {
+        output[index] = (input[index] - mean) * inverse * weight[index]
+            + bias[index];
+    }
+    for (int index = 6; index < count; ++index) {
+        output[index] = input[index];
+    }
+}
+
+inline float safeLog10(float value) {
+    return std::log10(value + 1e-10f);
+}
+
+} // namespace
+
+struct localvqe_aec_daf {
+    bool prealignmentEnabled = true;
+
+    std::vector<float> globalNormWeight, globalNormBias;
+    std::vector<float> globalInputWeight, globalHiddenWeight;
+    std::vector<float> globalInputBias, globalHiddenBias;
+    std::vector<float> binNormWeight, binNormBias;
+    std::vector<float> binInputWeight, binHiddenWeight;
+    std::vector<float> binInputBias, binHiddenBias;
+    std::vector<float> partitionNormWeight, partitionNormBias;
+    std::vector<float> partitionInputWeight, partitionHiddenWeight;
+    std::vector<float> partitionInputBias, partitionHiddenBias;
+    std::vector<float> binHeadWeight, binHeadBias;
+    std::vector<float> partitionHeadWeight, partitionHeadBias;
+
+    std::vector<float> filterReal, filterImag;
+    std::vector<float> referenceReal, referenceImag;
+    std::vector<float> covariance;
+    std::vector<float> previousReference;
+    int constrainedPartition = 0;
+
+    std::vector<float> globalHidden;
+    std::vector<float> binHidden;
+    std::vector<float> partitionHidden;
+
+    std::vector<float> gccReal, gccImag;
+    std::vector<float> microphoneRing, referenceRing;
+    int64_t samplesSeen = 0;
+    float maximumReferenceRMS = 1e-12f;
+    float delayConfidence = 0.0f;
+    int currentDelay = 0;
+    bool delayLocked = false;
+    std::vector<float> referenceDelayLine;
+    size_t referenceDelayPosition = 0;
+
+    bool loadWeights(const float *weights, size_t count) {
+        if (weights == nullptr || count != kControllerWeightCount) {
+            return false;
+        }
+        size_t cursor = 0;
+        auto take = [&](std::vector<float>& destination, size_t size) {
+            destination.assign(weights + cursor, weights + cursor + size);
+            cursor += size;
+        };
+
+        take(globalNormWeight, 6); take(globalNormBias, 6);
+        take(globalInputWeight, 24 * 10); take(globalHiddenWeight, 24 * 8);
+        take(globalInputBias, 24); take(globalHiddenBias, 24);
+        take(binNormWeight, 6); take(binNormBias, 6);
+        take(binInputWeight, 48 * 18); take(binHiddenWeight, 48 * 16);
+        take(binInputBias, 48); take(binHiddenBias, 48);
+        take(partitionNormWeight, 2); take(partitionNormBias, 2);
+        take(partitionInputWeight, 24 * 10);
+        take(partitionHiddenWeight, 24 * 8);
+        take(partitionInputBias, 24); take(partitionHiddenBias, 24);
+        take(binHeadWeight, 16); take(binHeadBias, 1);
+        take(partitionHeadWeight, 8); take(partitionHeadBias, 1);
+        return cursor == count;
+    }
+
+    void reset() {
+        auto resetValues = [](
+            std::vector<float>& values,
+            size_t count,
+            float initialValue
+        ) {
+            if (values.size() != count) {
+                values.assign(count, initialValue);
+            } else {
+                std::fill(values.begin(), values.end(), initialValue);
+            }
+        };
+        const size_t filterCount = static_cast<size_t>(kPartitions) * kBins + 16;
+        resetValues(filterReal, filterCount, 0.0f);
+        resetValues(filterImag, filterCount, 0.0f);
+        resetValues(referenceReal, filterCount, 0.0f);
+        resetValues(referenceImag, filterCount, 0.0f);
+        resetValues(covariance, filterCount, kInitialCovariance);
+        resetValues(previousReference, kBlock, 0.0f);
+        constrainedPartition = 0;
+        resetValues(globalHidden, 8, 0.0f);
+        resetValues(binHidden, static_cast<size_t>(kBins) * 16, 0.0f);
+        resetValues(
+            partitionHidden, static_cast<size_t>(kPartitions) * 8, 0.0f);
+        resetValues(gccReal, kGCCFFT / 2 + 1, 0.0f);
+        resetValues(gccImag, kGCCFFT / 2 + 1, 0.0f);
+        resetValues(microphoneRing, kGCCWindow, 0.0f);
+        resetValues(referenceRing, kGCCWindow, 0.0f);
+        samplesSeen = 0;
+        maximumReferenceRMS = 1e-12f;
+        delayConfidence = 0.0f;
+        currentDelay = 0;
+        delayLocked = false;
+        resetValues(referenceDelayLine, kGCCMaxLag + kBlock, 0.0f);
+        referenceDelayPosition = 0;
+    }
+
+    void updateDelay() {
+        if (delayLocked) {
+            return;
+        }
+        static thread_local std::vector<float> referenceFFTReal(
+            kGCCFFT / 2 + 1);
+        static thread_local std::vector<float> referenceFFTImag(
+            kGCCFFT / 2 + 1);
+        static thread_local std::vector<float> microphoneFFTReal(
+            kGCCFFT / 2 + 1);
+        static thread_local std::vector<float> microphoneFFTImag(
+            kGCCFFT / 2 + 1);
+        static thread_local std::vector<float> padded(kGCCFFT);
+        static thread_local std::vector<float> correlation(kGCCFFT);
+
+        float rms = 0.0f;
+        for (float sample : referenceRing) {
+            rms += sample * sample;
+        }
+        rms = std::sqrt(rms / static_cast<float>(kGCCWindow));
+        maximumReferenceRMS = std::max(maximumReferenceRMS, rms);
+        const bool retain = rms > maximumReferenceRMS
+            * std::pow(10.0f, -kGCCGateDB / 20.0f);
+        if (retain) {
+            std::copy(referenceRing.begin(), referenceRing.end(), padded.begin());
+            std::fill(padded.begin() + kGCCWindow, padded.end(), 0.0f);
+            realFFT(
+                padded.data(), kGCCFFT,
+                referenceFFTReal.data(), referenceFFTImag.data());
+            std::copy(microphoneRing.begin(), microphoneRing.end(), padded.begin());
+            std::fill(padded.begin() + kGCCWindow, padded.end(), 0.0f);
+            realFFT(
+                padded.data(), kGCCFFT,
+                microphoneFFTReal.data(), microphoneFFTImag.data());
+            for (int bin = 0; bin <= kGCCFFT / 2; ++bin) {
+                const float crossReal = microphoneFFTReal[bin]
+                        * referenceFFTReal[bin]
+                    + microphoneFFTImag[bin] * referenceFFTImag[bin];
+                const float crossImag = microphoneFFTImag[bin]
+                        * referenceFFTReal[bin]
+                    - microphoneFFTReal[bin] * referenceFFTImag[bin];
+                const float magnitude = std::sqrt(
+                    crossReal * crossReal + crossImag * crossImag) + 1e-9f;
+                gccReal[bin] += crossReal / magnitude;
+                gccImag[bin] += crossImag / magnitude;
+            }
+        }
+
+        inverseRealFFT(gccReal.data(), gccImag.data(), kGCCFFT, correlation.data());
+        int bestLag = 0;
+        float peak = correlation[0];
+        float absoluteSum = 0.0f;
+        for (int lag = 0; lag < kGCCMaxLag; ++lag) {
+            if (correlation[lag] > peak) {
+                peak = correlation[lag];
+                bestLag = lag;
+            }
+            absoluteSum += std::abs(correlation[lag]);
+        }
+        delayConfidence = peak
+            / (absoluteSum / static_cast<float>(kGCCMaxLag) + 1e-12f);
+        currentDelay = delayConfidence > kGCCConfidenceThreshold
+            ? std::max(0, bestLag - kBlock) / kBlock * kBlock
+            : 0;
+        if (delayConfidence > kGCCConfidenceThreshold
+            && samplesSeen >= kLockAfter) {
+            delayLocked = true;
+        }
+    }
+
+    void processBlock(
+        const float *microphone,
+        const float *reference,
+        float *residual
+    ) {
+        // One block is only 8 ms. Keep its scratch storage off the allocator
+        // after the first call, matching the reference implementation while
+        // preserving independent state in each frontend instance.
+        static thread_local std::vector<float> fftInput(kFFT);
+        static thread_local std::vector<float> currentReferenceReal(kBins);
+        static thread_local std::vector<float> currentReferenceImag(kBins);
+        static thread_local std::vector<float> echoReal(kBins);
+        static thread_local std::vector<float> echoImag(kBins);
+        static thread_local std::vector<float> timeBuffer(kFFT);
+        static thread_local std::vector<float> errorReal(kBins);
+        static thread_local std::vector<float> errorImag(kBins);
+        static thread_local std::vector<float> microphoneReal(kBins);
+        static thread_local std::vector<float> microphoneImag(kBins);
+        static thread_local std::vector<float> referencePower(kBins);
+        static thread_local std::vector<float> normalizedFeatures(18);
+        static thread_local std::vector<float> globalFeatures(10);
+        static thread_local std::vector<float> inputGates(48);
+        static thread_local std::vector<float> hiddenGates(48);
+        static thread_local std::vector<float> binGain(kBins);
+        static thread_local std::vector<float> partitionGain(kPartitions);
+        static thread_local std::vector<float> stepSize(
+            static_cast<size_t>(kPartitions) * kBins);
+        static thread_local std::vector<float> meanCovariance(kBins);
+        static thread_local std::vector<float> features(
+            static_cast<size_t>(kBins) * 10);
+
+        std::fill(echoReal.begin(), echoReal.end(), 0.0f);
+        std::fill(echoImag.begin(), echoImag.end(), 0.0f);
+        std::fill(referencePower.begin(), referencePower.end(), 0.0f);
+        std::fill(meanCovariance.begin(), meanCovariance.end(), 0.0f);
+        std::fill(globalFeatures.begin(), globalFeatures.end(), 0.0f);
+
+        std::copy(previousReference.begin(), previousReference.end(), fftInput.begin());
+        std::copy(reference, reference + kBlock, fftInput.begin() + kBlock);
+        std::copy(reference, reference + kBlock, previousReference.begin());
+        realFFT(
+            fftInput.data(), kFFT,
+            currentReferenceReal.data(), currentReferenceImag.data());
+
+        std::memmove(
+            referenceReal.data() + kBins,
+            referenceReal.data(),
+            static_cast<size_t>(kPartitions - 1) * kBins * sizeof(float));
+        std::memmove(
+            referenceImag.data() + kBins,
+            referenceImag.data(),
+            static_cast<size_t>(kPartitions - 1) * kBins * sizeof(float));
+        std::copy(
+            currentReferenceReal.begin(), currentReferenceReal.end(),
+            referenceReal.begin());
+        std::copy(
+            currentReferenceImag.begin(), currentReferenceImag.end(),
+            referenceImag.begin());
+
+        for (int partition = 0; partition < kPartitions; ++partition) {
+            const size_t base = static_cast<size_t>(partition) * kBins;
+            for (int bin = 0; bin < kBins; ++bin) {
+                const size_t index = base + bin;
+                echoReal[bin] += filterReal[index] * referenceReal[index]
+                    - filterImag[index] * referenceImag[index];
+                echoImag[bin] += filterReal[index] * referenceImag[index]
+                    + filterImag[index] * referenceReal[index];
+            }
+        }
+        inverseRealFFT(echoReal.data(), echoImag.data(), kFFT, timeBuffer.data());
+        for (int index = 0; index < kBlock; ++index) {
+            residual[index] = microphone[index] - timeBuffer[kBlock + index];
+        }
+
+        std::fill(fftInput.begin(), fftInput.begin() + kBlock, 0.0f);
+        std::copy(residual, residual + kBlock, fftInput.begin() + kBlock);
+        realFFT(fftInput.data(), kFFT, errorReal.data(), errorImag.data());
+        std::copy(microphone, microphone + kBlock, fftInput.begin() + kBlock);
+        realFFT(
+            fftInput.data(), kFFT,
+            microphoneReal.data(), microphoneImag.data());
+
+        for (int partition = 0; partition < kPartitions; ++partition) {
+            const size_t base = static_cast<size_t>(partition) * kBins;
+            for (int bin = 0; bin < kBins; ++bin) {
+                const float real = referenceReal[base + bin];
+                const float imag = referenceImag[base + bin];
+                referencePower[bin] += real * real + imag * imag;
+                meanCovariance[bin] += covariance[base + bin];
+            }
+        }
+        for (int bin = 0; bin < kBins; ++bin) {
+            meanCovariance[bin] /= static_cast<float>(kPartitions);
+            const float referenceMagnitude = std::sqrt(
+                currentReferenceReal[bin] * currentReferenceReal[bin]
+                + currentReferenceImag[bin] * currentReferenceImag[bin]);
+            const float errorMagnitude = std::sqrt(
+                errorReal[bin] * errorReal[bin]
+                + errorImag[bin] * errorImag[bin]);
+            const float echoMagnitude = std::sqrt(
+                echoReal[bin] * echoReal[bin]
+                + echoImag[bin] * echoImag[bin]);
+            const float microphoneMagnitude = std::sqrt(
+                microphoneReal[bin] * microphoneReal[bin]
+                + microphoneImag[bin] * microphoneImag[bin]);
+            float *feature = features.data() + static_cast<size_t>(bin) * 10;
+            feature[0] = safeLog10(referenceMagnitude * referenceMagnitude);
+            feature[1] = safeLog10(referencePower[bin]);
+            feature[2] = safeLog10(microphoneMagnitude * microphoneMagnitude);
+            feature[3] = safeLog10(errorMagnitude * errorMagnitude);
+            feature[4] = safeLog10(echoMagnitude * echoMagnitude);
+            feature[5] = safeLog10(meanCovariance[bin]);
+            constexpr float epsilon = 1e-9f;
+            feature[6] = (errorReal[bin] * microphoneReal[bin]
+                          + errorImag[bin] * microphoneImag[bin])
+                / (errorMagnitude * microphoneMagnitude + epsilon);
+            feature[7] = (microphoneReal[bin] * echoReal[bin]
+                          + microphoneImag[bin] * echoImag[bin])
+                / (microphoneMagnitude * echoMagnitude + epsilon);
+            feature[8] = (errorReal[bin] * echoReal[bin]
+                          + errorImag[bin] * echoImag[bin])
+                / (errorMagnitude * echoMagnitude + epsilon);
+            feature[9] = (currentReferenceReal[bin] * microphoneReal[bin]
+                          + currentReferenceImag[bin] * microphoneImag[bin])
+                / (referenceMagnitude * microphoneMagnitude + epsilon);
+            for (int index = 0; index < 10; ++index) {
+                globalFeatures[index] += feature[index];
+            }
+        }
+
+        for (float& value : globalFeatures) {
+            value /= static_cast<float>(kBins);
+        }
+        normalizeFeatures(
+            globalFeatures.data(), normalizedFeatures.data(),
+            globalNormWeight, globalNormBias, 10);
+        gruCell(
+            normalizedFeatures.data(), 10, globalHidden.data(), 8,
+            globalInputWeight, globalHiddenWeight,
+            globalInputBias, globalHiddenBias,
+            inputGates, hiddenGates);
+
+        for (int bin = 0; bin < kBins; ++bin) {
+            normalizeFeatures(
+                features.data() + static_cast<size_t>(bin) * 10,
+                normalizedFeatures.data(), binNormWeight, binNormBias, 10);
+            std::copy(
+                globalHidden.begin(), globalHidden.end(),
+                normalizedFeatures.begin() + 10);
+            gruCell(
+                normalizedFeatures.data(), 18,
+                binHidden.data() + static_cast<size_t>(bin) * 16, 16,
+                binInputWeight, binHiddenWeight, binInputBias, binHiddenBias,
+                inputGates, hiddenGates);
+            float logit = binHeadBias[0];
+            for (int index = 0; index < 16; ++index) {
+                logit += binHeadWeight[index]
+                    * binHidden[static_cast<size_t>(bin) * 16 + index];
+            }
+            binGain[bin] = 2.0f / (1.0f + std::exp(-logit));
+        }
+
+        for (int partition = 0; partition < kPartitions; ++partition) {
+            const size_t base = static_cast<size_t>(partition) * kBins;
+            float filterPower = 0.0f;
+            float covarianceMean = 0.0f;
+            for (int bin = 0; bin < kBins; ++bin) {
+                filterPower += filterReal[base + bin] * filterReal[base + bin]
+                    + filterImag[base + bin] * filterImag[base + bin];
+                covarianceMean += covariance[base + bin];
+            }
+            float pair[2] = {
+                safeLog10(filterPower / kBins),
+                safeLog10(covarianceMean / kBins),
+            };
+            const float mean = 0.5f * (pair[0] + pair[1]);
+            const float variance = 0.5f
+                * ((pair[0] - mean) * (pair[0] - mean)
+                   + (pair[1] - mean) * (pair[1] - mean));
+            const float inverse = 1.0f / std::sqrt(variance + 1e-5f);
+            float partitionInput[10];
+            partitionInput[0] = (pair[0] - mean) * inverse
+                    * partitionNormWeight[0]
+                + partitionNormBias[0];
+            partitionInput[1] = (pair[1] - mean) * inverse
+                    * partitionNormWeight[1]
+                + partitionNormBias[1];
+            std::copy(
+                globalHidden.begin(), globalHidden.end(), partitionInput + 2);
+            gruCell(
+                partitionInput, 10,
+                partitionHidden.data() + static_cast<size_t>(partition) * 8, 8,
+                partitionInputWeight, partitionHiddenWeight,
+                partitionInputBias, partitionHiddenBias,
+                inputGates, hiddenGates);
+            float logit = partitionHeadBias[0];
+            for (int index = 0; index < 8; ++index) {
+                logit += partitionHeadWeight[index]
+                    * partitionHidden[static_cast<size_t>(partition) * 8 + index];
+            }
+            partitionGain[partition] = 2.0f / (1.0f + std::exp(-logit));
+        }
+
+        const float squaredDecay = kDecay * kDecay;
+        for (int partition = 0; partition < kPartitions; ++partition) {
+            const size_t base = static_cast<size_t>(partition) * kBins;
+            for (int bin = 0; bin < kBins; ++bin) {
+                const size_t index = base + bin;
+                const float errorPower = (
+                    errorReal[bin] * errorReal[bin]
+                    + errorImag[bin] * errorImag[bin]) / kPartitions;
+                const float posterior = 0.5f * covariance[index]
+                        * referencePower[bin]
+                    + errorPower;
+                float update = covariance[index] / (posterior + 1e-10f);
+                update *= binGain[bin] * partitionGain[partition];
+                const float normalizedUpdate = update * referencePower[bin];
+                if (normalizedUpdate > 2.0f) {
+                    update *= 2.0f / normalizedUpdate;
+                }
+                const float factor = std::max(
+                    1.0f - 0.5f * update * referencePower[bin], 0.0f);
+                covariance[index] = std::max(
+                    squaredDecay * factor * covariance[index]
+                    + (1.0f - squaredDecay)
+                        * (filterReal[index] * filterReal[index]
+                           + filterImag[index] * filterImag[index]),
+                    1e-12f);
+                stepSize[index] = update;
+            }
+        }
+
+        static thread_local std::vector<float> refreshedErrorReal(kBins);
+        static thread_local std::vector<float> refreshedErrorImag(kBins);
+        for (int iteration = 0; iteration < kIterations; ++iteration) {
+            const float *activeErrorReal = errorReal.data();
+            const float *activeErrorImag = errorImag.data();
+            if (iteration > 0) {
+                std::fill(echoReal.begin(), echoReal.end(), 0.0f);
+                std::fill(echoImag.begin(), echoImag.end(), 0.0f);
+                for (int partition = 0; partition < kPartitions; ++partition) {
+                    const size_t base = static_cast<size_t>(partition) * kBins;
+                    for (int bin = 0; bin < kBins; ++bin) {
+                        const size_t index = base + bin;
+                        echoReal[bin] += filterReal[index] * referenceReal[index]
+                            - filterImag[index] * referenceImag[index];
+                        echoImag[bin] += filterReal[index] * referenceImag[index]
+                            + filterImag[index] * referenceReal[index];
+                    }
+                }
+                inverseRealFFT(
+                    echoReal.data(), echoImag.data(), kFFT, timeBuffer.data());
+                std::fill(fftInput.begin(), fftInput.begin() + kBlock, 0.0f);
+                for (int index = 0; index < kBlock; ++index) {
+                    fftInput[kBlock + index] = microphone[index]
+                        - timeBuffer[kBlock + index];
+                }
+                realFFT(
+                    fftInput.data(), kFFT,
+                    refreshedErrorReal.data(), refreshedErrorImag.data());
+                activeErrorReal = refreshedErrorReal.data();
+                activeErrorImag = refreshedErrorImag.data();
+            }
+            for (int partition = 0; partition < kPartitions; ++partition) {
+                const size_t base = static_cast<size_t>(partition) * kBins;
+                for (int bin = 0; bin < kBins; ++bin) {
+                    const size_t index = base + bin;
+                    filterReal[index] += stepSize[index]
+                        * (activeErrorReal[bin] * referenceReal[index]
+                           + activeErrorImag[bin] * referenceImag[index]);
+                    filterImag[index] += stepSize[index]
+                        * (activeErrorImag[bin] * referenceReal[index]
+                           - activeErrorReal[bin] * referenceImag[index]);
+                }
+            }
+        }
+
+        const size_t constrainedBase = static_cast<size_t>(constrainedPartition)
+            * kBins;
+        inverseRealFFT(
+            filterReal.data() + constrainedBase,
+            filterImag.data() + constrainedBase,
+            kFFT,
+            timeBuffer.data());
+        std::fill(timeBuffer.begin() + kBlock, timeBuffer.end(), 0.0f);
+        realFFT(
+            timeBuffer.data(), kFFT,
+            filterReal.data() + constrainedBase,
+            filterImag.data() + constrainedBase);
+        constrainedPartition = (constrainedPartition + 1) % kPartitions;
+    }
+
+    void process(
+        const float *microphone,
+        const float *reference,
+        size_t sampleCount,
+        float *residual,
+        float *echoEstimate
+    ) {
+        const int delayLineCount = static_cast<int>(referenceDelayLine.size());
+        for (size_t offset = 0; offset < sampleCount; offset += kBlock) {
+            std::memmove(
+                microphoneRing.data(), microphoneRing.data() + kBlock,
+                (kGCCWindow - kBlock) * sizeof(float));
+            std::memcpy(
+                microphoneRing.data() + kGCCWindow - kBlock,
+                microphone + offset,
+                kBlock * sizeof(float));
+            std::memmove(
+                referenceRing.data(), referenceRing.data() + kBlock,
+                (kGCCWindow - kBlock) * sizeof(float));
+            std::memcpy(
+                referenceRing.data() + kGCCWindow - kBlock,
+                reference + offset,
+                kBlock * sizeof(float));
+            for (int index = 0; index < kBlock; ++index) {
+                referenceDelayLine[(referenceDelayPosition + index)
+                    % delayLineCount] = reference[offset + index];
+            }
+            samplesSeen += kBlock;
+            if (prealignmentEnabled && samplesSeen >= kGCCWindow
+                && ((samplesSeen - kGCCWindow) % kGCCHop) < kBlock) {
+                updateDelay();
+            }
+
+            float shiftedReference[kBlock];
+            for (int index = 0; index < kBlock; ++index) {
+                const int64_t delayedIndex = static_cast<int64_t>(
+                    referenceDelayPosition) + index - currentDelay;
+                const int64_t sourcePosition = samplesSeen - kBlock + index;
+                const int wrapped = static_cast<int>(
+                    (delayedIndex % delayLineCount + delayLineCount)
+                    % delayLineCount);
+                shiftedReference[index] = sourcePosition >= currentDelay
+                    ? referenceDelayLine[wrapped]
+                    : 0.0f;
+            }
+            referenceDelayPosition = (referenceDelayPosition + kBlock)
+                % delayLineCount;
+            processBlock(
+                microphone + offset, shiftedReference, residual + offset);
+        }
+        for (size_t index = 0; index < sampleCount; ++index) {
+            echoEstimate[index] = microphone[index] - residual[index];
+        }
+    }
+
+    void primeDelay(
+        const float *microphone,
+        const float *reference,
+        size_t sampleCount
+    ) {
+        reset();
+        int bestDelay = 0;
+        float bestConfidence = 0.0f;
+        for (size_t offset = 0; offset + kBlock <= sampleCount;
+             offset += kBlock) {
+            std::memmove(
+                microphoneRing.data(), microphoneRing.data() + kBlock,
+                (kGCCWindow - kBlock) * sizeof(float));
+            std::memcpy(
+                microphoneRing.data() + kGCCWindow - kBlock,
+                microphone + offset,
+                kBlock * sizeof(float));
+            std::memmove(
+                referenceRing.data(), referenceRing.data() + kBlock,
+                (kGCCWindow - kBlock) * sizeof(float));
+            std::memcpy(
+                referenceRing.data() + kGCCWindow - kBlock,
+                reference + offset,
+                kBlock * sizeof(float));
+            samplesSeen += kBlock;
+            if (samplesSeen >= kGCCWindow
+                && ((samplesSeen - kGCCWindow) % kGCCHop) < kBlock) {
+                updateDelay();
+                delayLocked = false;
+                if (delayConfidence > bestConfidence) {
+                    bestConfidence = delayConfidence;
+                    bestDelay = currentDelay;
+                }
+            }
+        }
+        reset();
+        if (bestConfidence > kGCCConfidenceThreshold) {
+            currentDelay = bestDelay;
+            delayConfidence = bestConfidence;
+            delayLocked = true;
+        }
+    }
+};
+
+size_t localvqe_aec_daf_weight_count(void) {
+    return kControllerWeightCount;
+}
+
+localvqe_aec_daf *localvqe_aec_daf_create(
+    const float *weights,
+    size_t count
+) {
+    auto *frontend = new (std::nothrow) localvqe_aec_daf();
+    if (frontend == nullptr) {
+        return nullptr;
+    }
+    try {
+        if (!frontend->loadWeights(weights, count)) {
+            delete frontend;
+            return nullptr;
+        }
+        frontend->reset();
+        return frontend;
+    } catch (...) {
+        delete frontend;
+        return nullptr;
+    }
+}
+
+void localvqe_aec_daf_destroy(localvqe_aec_daf *frontend) {
+    delete frontend;
+}
+
+void localvqe_aec_daf_reset(localvqe_aec_daf *frontend) {
+    if (frontend != nullptr) {
+        try {
+            frontend->reset();
+        } catch (...) {
+            // Reset normally only fills storage allocated at creation. Never
+            // allow an allocation failure to cross the C ABI into Swift.
+        }
+    }
+}
+
+void localvqe_aec_daf_set_prealignment(
+    localvqe_aec_daf *frontend,
+    bool enabled
+) {
+    if (frontend != nullptr) {
+        frontend->prealignmentEnabled = enabled;
+    }
+}
+
+bool localvqe_aec_daf_prime_delay(
+    localvqe_aec_daf *frontend,
+    const float *microphone,
+    const float *reference,
+    size_t sample_count
+) {
+    if (frontend == nullptr || microphone == nullptr || reference == nullptr) {
+        return false;
+    }
+    try {
+        frontend->primeDelay(microphone, reference, sample_count);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool localvqe_aec_daf_process(
+    localvqe_aec_daf *frontend,
+    const float *microphone,
+    const float *reference,
+    size_t sample_count,
+    float *residual,
+    float *echo_estimate
+) {
+    if (frontend == nullptr || microphone == nullptr || reference == nullptr
+        || residual == nullptr || echo_estimate == nullptr
+        || sample_count == 0 || sample_count % kBlock != 0) {
+        return false;
+    }
+    try {
+        frontend->process(
+            microphone, reference, sample_count, residual, echo_estimate);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+int32_t localvqe_aec_daf_current_delay_samples(
+    const localvqe_aec_daf *frontend
+) {
+    return frontend == nullptr ? 0 : frontend->currentDelay;
+}
+
+float localvqe_aec_daf_delay_confidence(
+    const localvqe_aec_daf *frontend
+) {
+    return frontend == nullptr ? 0.0f : frontend->delayConfidence;
+}

--- a/src/models/localvqe/localvqe_aec_frontend.h
+++ b/src/models/localvqe/localvqe_aec_frontend.h
@@ -1,0 +1,63 @@
+#ifndef LOCALVQE_AEC_FRONTEND_H
+#define LOCALVQE_AEC_FRONTEND_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque state for the LocalVQE v1.4 adaptive echo-cancellation front end.
+typedef struct localvqe_aec_daf localvqe_aec_daf;
+
+/// Number of Float32 controller weights expected by `localvqe_aec_daf_create`.
+size_t localvqe_aec_daf_weight_count(void);
+
+/// Create the front end from the flattened 2,742-parameter controller.
+/// Returns NULL when the pointer is NULL or the count is invalid.
+localvqe_aec_daf *localvqe_aec_daf_create(
+    const float *weights,
+    size_t count
+);
+
+void localvqe_aec_daf_destroy(localvqe_aec_daf *frontend);
+void localvqe_aec_daf_reset(localvqe_aec_daf *frontend);
+void localvqe_aec_daf_set_prealignment(
+    localvqe_aec_daf *frontend,
+    bool enabled
+);
+
+/// Estimate and freeze bulk reference delay from a complete synchronized clip.
+bool localvqe_aec_daf_prime_delay(
+    localvqe_aec_daf *frontend,
+    const float *microphone,
+    const float *reference,
+    size_t sample_count
+);
+
+/// Process a sample count divisible by 128. `residual` and `echo_estimate`
+/// must each have room for `sample_count` Float32 values.
+bool localvqe_aec_daf_process(
+    localvqe_aec_daf *frontend,
+    const float *microphone,
+    const float *reference,
+    size_t sample_count,
+    float *residual,
+    float *echo_estimate
+);
+
+int32_t localvqe_aec_daf_current_delay_samples(
+    const localvqe_aec_daf *frontend
+);
+
+float localvqe_aec_daf_delay_confidence(
+    const localvqe_aec_daf *frontend
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/models/localvqe/onnx_localvqe_echo_canceller.cpp
+++ b/src/models/localvqe/onnx_localvqe_echo_canceller.cpp
@@ -1,0 +1,877 @@
+#include "speech_core/models/onnx_localvqe_echo_canceller.h"
+
+#include "localvqe_aec_frontend.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include "nlohmann/json.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace speech_core {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+namespace fs = std::filesystem;
+
+constexpr double kPi = 3.14159265358979323846264338327950288;
+constexpr std::size_t kSpectrumBins = 256;
+constexpr std::size_t kControllerWeights = 2742;
+
+const std::array<const char*, 9> kInputNames = {
+    "mic_spectrum",
+    "reference_spectrum",
+    "conv_state",
+    "align_key_state",
+    "align_reference_state",
+    "align_smooth_state",
+    "s4_real_state",
+    "s4_imag_state",
+    "ccm_state",
+};
+
+const std::array<const char*, 8> kOutputNames = {
+    "enhanced_spectrum",
+    "next_conv_state",
+    "next_align_key_state",
+    "next_align_reference_state",
+    "next_align_smooth_state",
+    "next_s4_real_state",
+    "next_s4_imag_state",
+    "next_ccm_state",
+};
+
+const std::array<std::vector<int64_t>, 7> kStateShapes = {
+    std::vector<int64_t>{1, 75936},
+    std::vector<int64_t>{1, 16, 15, 64},
+    std::vector<int64_t>{1, 20, 15, 64},
+    std::vector<int64_t>{1, 16, 4, 16},
+    std::vector<int64_t>{1, 80},
+    std::vector<int64_t>{1, 80},
+    std::vector<int64_t>{1, 2, 2, 256},
+};
+
+double elapsed_ms(const Clock::time_point& started) {
+    return std::chrono::duration<double, std::milli>(
+        Clock::now() - started).count();
+}
+
+std::size_t element_count(const std::vector<int64_t>& shape) {
+    std::size_t count = 1;
+    for (const int64_t dimension : shape) {
+        if (dimension <= 0) {
+            throw std::runtime_error(
+                "LocalVQE state shape must be fully resolved");
+        }
+        const auto value = static_cast<std::size_t>(dimension);
+        if (count > std::numeric_limits<std::size_t>::max() / value) {
+            throw std::overflow_error("LocalVQE state tensor is too large");
+        }
+        count *= value;
+    }
+    return count;
+}
+
+struct OrtValueHandle {
+    const OrtApi* api = nullptr;
+    OrtValue* value = nullptr;
+
+    OrtValueHandle() = default;
+    OrtValueHandle(const OrtApi* api_value, OrtValue* value_value)
+        : api(api_value), value(value_value) {}
+    ~OrtValueHandle() {
+        if (api && value) api->ReleaseValue(value);
+    }
+    OrtValueHandle(const OrtValueHandle&) = delete;
+    OrtValueHandle& operator=(const OrtValueHandle&) = delete;
+    OrtValueHandle(OrtValueHandle&& other) noexcept
+        : api(other.api), value(other.value) {
+        other.value = nullptr;
+    }
+    OrtValueHandle& operator=(OrtValueHandle&& other) noexcept {
+        if (this != &other) {
+            if (api && value) api->ReleaseValue(value);
+            api = other.api;
+            value = other.value;
+            other.value = nullptr;
+        }
+        return *this;
+    }
+    OrtValue* get() const { return value; }
+};
+
+struct OrtStringHandle {
+    const OrtApi* api = nullptr;
+    OrtAllocator* allocator = nullptr;
+    char* value = nullptr;
+    ~OrtStringHandle() {
+        if (api && allocator && value) {
+            OrtStatus* status = api->AllocatorFree(allocator, value);
+            if (status) api->ReleaseStatus(status);
+        }
+    }
+};
+
+struct TensorInfo {
+    ONNXTensorElementDataType type =
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    std::vector<int64_t> shape;
+};
+
+TensorInfo tensor_info(
+    const OrtApi* api, OrtSession* session, std::size_t index,
+    bool input) {
+    OrtTypeInfo* raw = nullptr;
+    if (input) {
+        ort_check(api, api->SessionGetInputTypeInfo(session, index, &raw));
+    } else {
+        ort_check(api, api->SessionGetOutputTypeInfo(session, index, &raw));
+    }
+    const OrtTensorTypeAndShapeInfo* tensor = nullptr;
+    OrtStatus* cast_status = api->CastTypeInfoToTensorInfo(raw, &tensor);
+    if (cast_status || !tensor) {
+        if (cast_status) api->ReleaseStatus(cast_status);
+        api->ReleaseTypeInfo(raw);
+        throw std::runtime_error("LocalVQE graph I/O must be tensors");
+    }
+    TensorInfo output;
+    ort_check(api, api->GetTensorElementType(tensor, &output.type));
+    std::size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(tensor, &rank));
+    output.shape.resize(rank);
+    ort_check(api, api->GetDimensions(
+        tensor, output.shape.data(), output.shape.size()));
+    api->ReleaseTypeInfo(raw);
+    return output;
+}
+
+TensorInfo value_info(const OrtApi* api, OrtValue* value) {
+    OrtTensorTypeAndShapeInfo* raw = nullptr;
+    ort_check(api, api->GetTensorTypeAndShape(value, &raw));
+    TensorInfo output;
+    ort_check(api, api->GetTensorElementType(raw, &output.type));
+    std::size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(raw, &rank));
+    output.shape.resize(rank);
+    ort_check(api, api->GetDimensions(
+        raw, output.shape.data(), output.shape.size()));
+    api->ReleaseTensorTypeAndShapeInfo(raw);
+    return output;
+}
+
+std::vector<std::string> session_names(
+    const OrtApi* api, OrtSession* session, bool input) {
+    OrtAllocator* allocator = nullptr;
+    ort_check(api, api->GetAllocatorWithDefaultOptions(&allocator));
+    std::size_t count = 0;
+    if (input) {
+        ort_check(api, api->SessionGetInputCount(session, &count));
+    } else {
+        ort_check(api, api->SessionGetOutputCount(session, &count));
+    }
+    std::vector<std::string> names;
+    names.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        OrtStringHandle name{api, allocator, nullptr};
+        if (input) {
+            ort_check(api, api->SessionGetInputName(
+                session, index, allocator, &name.value));
+        } else {
+            ort_check(api, api->SessionGetOutputName(
+                session, index, allocator, &name.value));
+        }
+        names.emplace_back(name.value);
+    }
+    return names;
+}
+
+void validate_shape(
+    const TensorInfo& info,
+    const std::vector<int64_t>& expected,
+    const char* label,
+    bool allow_symbolic) {
+    if (info.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+        || info.shape.size() != expected.size()) {
+        throw std::runtime_error(
+            std::string("LocalVQE ") + label
+            + " has an incompatible tensor contract");
+    }
+    for (std::size_t index = 0; index < expected.size(); ++index) {
+        if (info.shape[index] == expected[index]) continue;
+        if (allow_symbolic && info.shape[index] < 0) continue;
+        throw std::runtime_error(
+            std::string("LocalVQE ") + label
+            + " has an incompatible shape");
+    }
+}
+
+OrtValueHandle make_tensor(
+    const OrtApi* api,
+    OrtMemoryInfo* memory,
+    std::vector<float>& values,
+    const std::vector<int64_t>& shape) {
+    if (values.size() != element_count(shape)) {
+        throw std::runtime_error(
+            "LocalVQE host tensor does not match its declared shape");
+    }
+    OrtValue* output = nullptr;
+    ort_check(api, api->CreateTensorWithDataAsOrtValue(
+        memory,
+        values.data(),
+        values.size() * sizeof(float),
+        shape.data(),
+        shape.size(),
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,
+        &output));
+    return OrtValueHandle(api, output);
+}
+
+std::vector<float> copy_float_tensor(
+    const OrtApi* api,
+    OrtValue* value,
+    const std::vector<int64_t>& expected,
+    const char* label) {
+    const TensorInfo info = value_info(api, value);
+    validate_shape(info, expected, label, false);
+    float* data = nullptr;
+    ort_check(api, api->GetTensorMutableData(
+        value, reinterpret_cast<void**>(&data)));
+    return std::vector<float>(
+        data, data + static_cast<std::ptrdiff_t>(element_count(expected)));
+}
+
+void fft_in_place(
+    std::vector<float>& real,
+    std::vector<float>& imaginary,
+    bool inverse) {
+    const std::size_t count = real.size();
+    for (std::size_t index = 1, reversed = 0;
+         index < count; ++index) {
+        std::size_t bit = count >> 1;
+        for (; reversed & bit; bit >>= 1) reversed ^= bit;
+        reversed ^= bit;
+        if (index < reversed) {
+            std::swap(real[index], real[reversed]);
+            std::swap(imaginary[index], imaginary[reversed]);
+        }
+    }
+    for (std::size_t length = 2; length <= count; length <<= 1) {
+        const double angle =
+            (inverse ? 2.0 : -2.0) * kPi / static_cast<double>(length);
+        const double root_real = std::cos(angle);
+        const double root_imaginary = std::sin(angle);
+        for (std::size_t offset = 0; offset < count; offset += length) {
+            double current_real = 1.0;
+            double current_imaginary = 0.0;
+            for (std::size_t index = 0; index < length / 2; ++index) {
+                const float upper_real = real[offset + index];
+                const float upper_imaginary = imaginary[offset + index];
+                const std::size_t lower =
+                    offset + index + length / 2;
+                const float lower_real = static_cast<float>(
+                    real[lower] * current_real
+                    - imaginary[lower] * current_imaginary);
+                const float lower_imaginary = static_cast<float>(
+                    real[lower] * current_imaginary
+                    + imaginary[lower] * current_real);
+                real[offset + index] = upper_real + lower_real;
+                imaginary[offset + index] =
+                    upper_imaginary + lower_imaginary;
+                real[lower] = upper_real - lower_real;
+                imaginary[lower] =
+                    upper_imaginary - lower_imaginary;
+                const double next_real =
+                    current_real * root_real
+                    - current_imaginary * root_imaginary;
+                current_imaginary =
+                    current_real * root_imaginary
+                    + current_imaginary * root_real;
+                current_real = next_real;
+            }
+        }
+    }
+    if (inverse) {
+        const float scale = 1.0f / static_cast<float>(count);
+        for (std::size_t index = 0; index < count; ++index) {
+            real[index] *= scale;
+            imaginary[index] *= scale;
+        }
+    }
+}
+
+class LocalVQECodec {
+public:
+    explicit LocalVQECodec(std::vector<float> window)
+        : window_(std::move(window)) {
+        if (window_.size() != OnnxLocalVQEEchoCanceller::kFftSize
+            || !std::all_of(
+                window_.begin(), window_.end(),
+                [](float value) { return std::isfinite(value); })) {
+            throw std::runtime_error(
+                "LocalVQE analysis window is invalid");
+        }
+        reset();
+    }
+
+    void reset() {
+        microphone_history_.fill(0.0f);
+        reference_history_.fill(0.0f);
+        overlap_.fill(0.0f);
+    }
+
+    void analyze(
+        const float* residual,
+        const float* echo_estimate,
+        std::vector<float>& microphone,
+        std::vector<float>& reference) {
+        analyze_one(
+            residual, microphone_history_, microphone);
+        analyze_one(
+            echo_estimate, reference_history_, reference);
+    }
+
+    void synthesize(
+        const std::vector<float>& spectrum,
+        float* output) {
+        if (spectrum.size() != kSpectrumBins * 2) {
+            throw std::runtime_error(
+                "LocalVQE enhanced spectrum has the wrong size");
+        }
+        std::vector<float> real(
+            OnnxLocalVQEEchoCanceller::kFftSize, 0.0f);
+        std::vector<float> imaginary(
+            OnnxLocalVQEEchoCanceller::kFftSize, 0.0f);
+        for (std::size_t bin = 1; bin < kSpectrumBins; ++bin) {
+            real[bin] = spectrum[bin - 1];
+            imaginary[bin] =
+                spectrum[kSpectrumBins + bin - 1];
+            real[OnnxLocalVQEEchoCanceller::kFftSize - bin] =
+                real[bin];
+            imaginary[OnnxLocalVQEEchoCanceller::kFftSize - bin] =
+                -imaginary[bin];
+        }
+        real[kSpectrumBins] = 2.0f * spectrum[kSpectrumBins - 1];
+        fft_in_place(real, imaginary, true);
+        for (std::size_t index = 0;
+             index < OnnxLocalVQEEchoCanceller::kFftSize; ++index) {
+            overlap_[index] += real[index] * window_[index];
+        }
+        std::copy_n(
+            overlap_.begin(),
+            OnnxLocalVQEEchoCanceller::kFrameSize,
+            output);
+        std::move(
+            overlap_.begin()
+                + OnnxLocalVQEEchoCanceller::kFrameSize,
+            overlap_.end(),
+            overlap_.begin());
+        std::fill(
+            overlap_.begin()
+                + OnnxLocalVQEEchoCanceller::kFrameSize,
+            overlap_.end(),
+            0.0f);
+    }
+
+private:
+    void analyze_one(
+        const float* frame,
+        std::array<float, OnnxLocalVQEEchoCanceller::kFrameSize>&
+            history,
+        std::vector<float>& output) {
+        std::vector<float> real(
+            OnnxLocalVQEEchoCanceller::kFftSize, 0.0f);
+        std::vector<float> imaginary(
+            OnnxLocalVQEEchoCanceller::kFftSize, 0.0f);
+        std::copy(history.begin(), history.end(), real.begin());
+        std::copy_n(
+            frame,
+            OnnxLocalVQEEchoCanceller::kFrameSize,
+            real.begin() + OnnxLocalVQEEchoCanceller::kFrameSize);
+        std::copy_n(
+            frame,
+            OnnxLocalVQEEchoCanceller::kFrameSize,
+            history.begin());
+        for (std::size_t index = 0;
+             index < OnnxLocalVQEEchoCanceller::kFftSize; ++index) {
+            real[index] *= window_[index];
+        }
+        fft_in_place(real, imaginary, false);
+        output.assign(kSpectrumBins * 2, 0.0f);
+        for (std::size_t bin = 0; bin < kSpectrumBins; ++bin) {
+            output[bin] = real[bin + 1];
+            output[kSpectrumBins + bin] = imaginary[bin + 1];
+        }
+    }
+
+    std::vector<float> window_;
+    std::array<float, OnnxLocalVQEEchoCanceller::kFrameSize>
+        microphone_history_{};
+    std::array<float, OnnxLocalVQEEchoCanceller::kFrameSize>
+        reference_history_{};
+    std::array<float, OnnxLocalVQEEchoCanceller::kFftSize> overlap_{};
+};
+
+nlohmann::json read_json(const fs::path& path) {
+    std::ifstream stream(path);
+    if (!stream) {
+        throw std::runtime_error(
+            "Could not read LocalVQE bundle file " + path.string());
+    }
+    nlohmann::json value;
+    stream >> value;
+    return value;
+}
+
+std::vector<float> read_finite_array(
+    const nlohmann::json& value,
+    const char* key,
+    std::size_t expected_count) {
+    const auto found = value.find(key);
+    if (found == value.end() || !found->is_array()
+        || found->size() != expected_count) {
+        throw std::runtime_error(
+            std::string("LocalVQE frontend has invalid ") + key);
+    }
+    std::vector<float> output;
+    output.reserve(expected_count);
+    for (const auto& element : *found) {
+        if (!element.is_number()) {
+            throw std::runtime_error(
+                std::string("LocalVQE frontend has non-numeric ") + key);
+        }
+        const float number = element.get<float>();
+        if (!std::isfinite(number)) {
+            throw std::runtime_error(
+                std::string("LocalVQE frontend has non-finite ") + key);
+        }
+        output.push_back(number);
+    }
+    return output;
+}
+
+}  // namespace
+
+class OnnxLocalVQEEchoCanceller::Impl {
+public:
+    Impl(const std::string& bundle_directory, const Config& config)
+        : config_(config) {
+        if (config.intra_threads < 0) {
+            throw std::invalid_argument(
+                "LocalVQE intra_threads must be non-negative");
+        }
+        const fs::path bundle(bundle_directory);
+        const fs::path model_path =
+            bundle / "LocalVQEAECResidualMask.onnx";
+        const fs::path frontend_path =
+            bundle / "LocalVQEAECFrontend.json";
+        const fs::path config_path = bundle / "config.json";
+        if (!fs::is_regular_file(model_path)
+            || !fs::is_regular_file(frontend_path)
+            || !fs::is_regular_file(config_path)) {
+            throw std::runtime_error(
+                "LocalVQE ONNX bundle is incomplete");
+        }
+
+        const nlohmann::json metadata = read_json(config_path);
+        if (metadata.value("model_type", std::string{})
+                != "localvqe-v1.4-aec-onnx"
+            || metadata.value("source_run_id", std::string{})
+                != "v1.4.r005"
+            || metadata.value("source_gguf_sha256", std::string{})
+                != "b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
+            || metadata.value("sample_rate", 0) != kSampleRate
+            || metadata.value("fft_size", 0)
+                != static_cast<int>(kFftSize)
+            || metadata.value("hop_size", 0)
+                != static_cast<int>(kFrameSize)
+            || metadata.value("precision", std::string{}) != "float32") {
+            throw std::runtime_error(
+                "LocalVQE bundle metadata does not match v1.4-AEC");
+        }
+
+        const nlohmann::json frontend = read_json(frontend_path);
+        if (frontend.value("format_version", 0) != 1
+            || frontend.value("source_run_id", std::string{})
+                != "v1.4.r005"
+            || frontend.value("sample_rate", 0) != kSampleRate
+            || frontend.value("fft_size", 0)
+                != static_cast<int>(kFftSize)
+            || frontend.value("hop_size", 0)
+                != static_cast<int>(kFrameSize)
+            || frontend.value("daf_block_size", 0) != 128
+            || frontend.value("daf_partitions", 0) != 128
+            || frontend.value("daf_iterations", 0) != 2) {
+            throw std::runtime_error(
+                "LocalVQE frontend metadata is incompatible");
+        }
+        std::vector<float> controller = read_finite_array(
+            frontend, "controller_weights", kControllerWeights);
+        std::vector<float> window = read_finite_array(
+            frontend, "analysis_window", kFftSize);
+        frontend_ = localvqe_aec_daf_create(
+            controller.data(), controller.size());
+        if (!frontend_) {
+            throw std::runtime_error(
+                "Could not initialize LocalVQE adaptive frontend");
+        }
+        localvqe_aec_daf_set_prealignment(
+            frontend_, config.enable_prealignment);
+        codec_ = std::make_unique<LocalVQECodec>(std::move(window));
+
+        auto& engine = OnnxEngine::get();
+        api_ = engine.api();
+        try {
+            session_ = engine.load(
+                model_path.string(),
+                config.hardware_acceleration,
+                false,
+                config.intra_threads);
+            validate_graph();
+            reset_model_state();
+        } catch (...) {
+            if (session_ && api_) api_->ReleaseSession(session_);
+            session_ = nullptr;
+            localvqe_aec_daf_destroy(frontend_);
+            frontend_ = nullptr;
+            throw;
+        }
+    }
+
+    ~Impl() {
+        if (session_ && api_) api_->ReleaseSession(session_);
+        if (frontend_) localvqe_aec_daf_destroy(frontend_);
+    }
+
+    void process_frame(
+        const float* microphone,
+        const float* reference,
+        float* output) {
+        if (!microphone || !reference || !output) {
+            throw std::invalid_argument(
+                "LocalVQE frame pointers must not be null");
+        }
+        for (std::size_t index = 0; index < kFrameSize; ++index) {
+            if (!std::isfinite(microphone[index])
+                || !std::isfinite(reference[index])) {
+                throw std::invalid_argument(
+                    "LocalVQE input contains NaN or infinity");
+            }
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        process_frame_locked(microphone, reference, output);
+    }
+
+    bool prime_delay(
+        const float* microphone,
+        const float* reference,
+        std::size_t sample_count) {
+        if ((!microphone || !reference) && sample_count != 0) {
+            throw std::invalid_argument(
+                "LocalVQE delay-prime pointers must not be null");
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        return localvqe_aec_daf_prime_delay(
+            frontend_, microphone, reference, sample_count);
+    }
+
+    int current_delay_samples() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return static_cast<int>(
+            localvqe_aec_daf_current_delay_samples(frontend_));
+    }
+
+    float delay_confidence() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return localvqe_aec_daf_delay_confidence(frontend_);
+    }
+
+    Profile last_profile() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return profile_;
+    }
+
+    void feed_reference(
+        const float* samples,
+        std::size_t length) {
+        if (!samples && length != 0) {
+            throw std::invalid_argument(
+                "LocalVQE reference pointer must not be null");
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (reference_queue_.size() + length
+            > kSampleRate * 10u) {
+            throw std::runtime_error(
+                "LocalVQE reference queue exceeded ten seconds");
+        }
+        for (std::size_t index = 0; index < length; ++index) {
+            if (!std::isfinite(samples[index])) {
+                throw std::invalid_argument(
+                    "LocalVQE reference contains NaN or infinity");
+            }
+            reference_queue_.push_back(samples[index]);
+        }
+    }
+
+    void cancel_echo(
+        const float* input,
+        std::size_t length,
+        float* output) {
+        if ((!input || !output) && length != 0) {
+            throw std::invalid_argument(
+                "LocalVQE audio pointers must not be null");
+        }
+        if (length % kFrameSize != 0) {
+            throw std::invalid_argument(
+                "LocalVQE cancel_echo requires complete 256-sample frames");
+        }
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (reference_queue_.size() < length) {
+            throw std::runtime_error(
+                "LocalVQE reference underrun; raw microphone was not passed");
+        }
+        std::array<float, kFrameSize> reference{};
+        for (std::size_t offset = 0; offset < length;
+             offset += kFrameSize) {
+            for (std::size_t index = 0; index < kFrameSize; ++index) {
+                reference[index] = reference_queue_.front();
+                reference_queue_.pop_front();
+            }
+            process_frame_locked(
+                input + offset, reference.data(), output + offset);
+        }
+    }
+
+    void reset() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        localvqe_aec_daf_reset(frontend_);
+        localvqe_aec_daf_set_prealignment(
+            frontend_, config_.enable_prealignment);
+        codec_->reset();
+        reset_model_state();
+        reference_queue_.clear();
+        profile_ = {};
+    }
+
+private:
+    void validate_graph() {
+        const std::vector<std::string> actual_inputs =
+            session_names(api_, session_, true);
+        const std::vector<std::string> actual_outputs =
+            session_names(api_, session_, false);
+        if (actual_inputs != std::vector<std::string>(
+                kInputNames.begin(), kInputNames.end())
+            || actual_outputs != std::vector<std::string>(
+                kOutputNames.begin(), kOutputNames.end())) {
+            throw std::runtime_error(
+                "LocalVQE ONNX graph signature is incompatible");
+        }
+        validate_shape(
+            tensor_info(api_, session_, 0, true),
+            {1, 2, 1, 256}, "mic_spectrum", false);
+        validate_shape(
+            tensor_info(api_, session_, 1, true),
+            {1, 2, 1, 256}, "reference_spectrum", false);
+        for (std::size_t index = 0; index < kStateShapes.size(); ++index) {
+            validate_shape(
+                tensor_info(api_, session_, index + 2, true),
+                kStateShapes[index], kInputNames[index + 2], false);
+        }
+        validate_shape(
+            tensor_info(api_, session_, 0, false),
+            {1, 2, 1, 256}, "enhanced_spectrum", true);
+        for (std::size_t index = 0; index < kStateShapes.size(); ++index) {
+            validate_shape(
+                tensor_info(api_, session_, index + 1, false),
+                kStateShapes[index], kOutputNames[index + 1], true);
+        }
+    }
+
+    void reset_model_state() {
+        states_.clear();
+        states_.reserve(kStateShapes.size());
+        for (const auto& shape : kStateShapes) {
+            states_.emplace_back(element_count(shape), 0.0f);
+        }
+    }
+
+    void process_frame_locked(
+        const float* microphone,
+        const float* reference,
+        float* output) {
+        const auto total_started = Clock::now();
+        std::array<float, kFrameSize> residual{};
+        std::array<float, kFrameSize> echo_estimate{};
+        const auto adaptive_started = Clock::now();
+        if (!localvqe_aec_daf_process(
+                frontend_,
+                microphone,
+                reference,
+                kFrameSize,
+                residual.data(),
+                echo_estimate.data())) {
+            throw std::runtime_error(
+                "LocalVQE adaptive frontend rejected a synchronized frame");
+        }
+        const double adaptive_ms = elapsed_ms(adaptive_started);
+
+        std::vector<float> microphone_spectrum;
+        std::vector<float> reference_spectrum;
+        codec_->analyze(
+            residual.data(),
+            echo_estimate.data(),
+            microphone_spectrum,
+            reference_spectrum);
+        OrtMemoryInfo* raw_memory = nullptr;
+        ort_check(api_, api_->CreateCpuMemoryInfo(
+            OrtArenaAllocator, OrtMemTypeDefault, &raw_memory));
+        struct MemoryGuard {
+            const OrtApi* api;
+            OrtMemoryInfo* memory;
+            ~MemoryGuard() {
+                if (api && memory) api->ReleaseMemoryInfo(memory);
+            }
+        } memory{api_, raw_memory};
+
+        std::vector<OrtValueHandle> inputs;
+        inputs.reserve(kInputNames.size());
+        inputs.emplace_back(make_tensor(
+            api_, raw_memory, microphone_spectrum, {1, 2, 1, 256}));
+        inputs.emplace_back(make_tensor(
+            api_, raw_memory, reference_spectrum, {1, 2, 1, 256}));
+        for (std::size_t index = 0; index < states_.size(); ++index) {
+            inputs.emplace_back(make_tensor(
+                api_, raw_memory, states_[index], kStateShapes[index]));
+        }
+        std::array<OrtValue*, kInputNames.size()> raw_inputs{};
+        for (std::size_t index = 0; index < inputs.size(); ++index) {
+            raw_inputs[index] = inputs[index].get();
+        }
+        std::array<OrtValue*, kOutputNames.size()> raw_outputs{};
+        const auto neural_started = Clock::now();
+        ort_check(api_, api_->Run(
+            session_,
+            nullptr,
+            kInputNames.data(),
+            raw_inputs.data(),
+            raw_inputs.size(),
+            kOutputNames.data(),
+            kOutputNames.size(),
+            raw_outputs.data()));
+        std::vector<OrtValueHandle> outputs;
+        outputs.reserve(raw_outputs.size());
+        for (OrtValue* value : raw_outputs) {
+            outputs.emplace_back(api_, value);
+        }
+        std::vector<float> enhanced = copy_float_tensor(
+            api_, outputs[0].get(), {1, 2, 1, 256},
+            "enhanced_spectrum output");
+        std::vector<std::vector<float>> next_states;
+        next_states.reserve(kStateShapes.size());
+        for (std::size_t index = 0; index < kStateShapes.size(); ++index) {
+            next_states.emplace_back(copy_float_tensor(
+                api_,
+                outputs[index + 1].get(),
+                kStateShapes[index],
+                kOutputNames[index + 1]));
+        }
+        const double neural_ms = elapsed_ms(neural_started);
+        if (!std::all_of(
+                enhanced.begin(), enhanced.end(),
+                [](float value) { return std::isfinite(value); })) {
+            throw std::runtime_error(
+                "LocalVQE neural mask produced NaN or infinity");
+        }
+        codec_->synthesize(enhanced, output);
+        if (!std::all_of(
+                output, output + kFrameSize,
+                [](float value) { return std::isfinite(value); })) {
+            throw std::runtime_error(
+                "LocalVQE synthesis produced NaN or infinity");
+        }
+        states_.swap(next_states);
+        profile_ = {
+            adaptive_ms,
+            neural_ms,
+            elapsed_ms(total_started),
+        };
+    }
+
+    Config config_;
+    const OrtApi* api_ = nullptr;
+    OrtSession* session_ = nullptr;
+    localvqe_aec_daf* frontend_ = nullptr;
+    std::unique_ptr<LocalVQECodec> codec_;
+    std::vector<std::vector<float>> states_;
+    std::deque<float> reference_queue_;
+    mutable std::mutex mutex_;
+    Profile profile_;
+};
+
+OnnxLocalVQEEchoCanceller::OnnxLocalVQEEchoCanceller(
+    const std::string& bundle_directory)
+    : OnnxLocalVQEEchoCanceller(bundle_directory, Config{}) {}
+
+OnnxLocalVQEEchoCanceller::OnnxLocalVQEEchoCanceller(
+    const std::string& bundle_directory,
+    const Config& config)
+    : impl_(std::make_unique<Impl>(bundle_directory, config)) {}
+
+OnnxLocalVQEEchoCanceller::~OnnxLocalVQEEchoCanceller() = default;
+
+void OnnxLocalVQEEchoCanceller::process_frame(
+    const float* microphone,
+    const float* reference,
+    float* output) {
+    impl_->process_frame(microphone, reference, output);
+}
+
+bool OnnxLocalVQEEchoCanceller::prime_delay(
+    const float* microphone,
+    const float* reference,
+    std::size_t sample_count) {
+    return impl_->prime_delay(microphone, reference, sample_count);
+}
+
+int OnnxLocalVQEEchoCanceller::current_delay_samples() const {
+    return impl_->current_delay_samples();
+}
+
+float OnnxLocalVQEEchoCanceller::delay_confidence() const {
+    return impl_->delay_confidence();
+}
+
+OnnxLocalVQEEchoCanceller::Profile
+OnnxLocalVQEEchoCanceller::last_profile() const {
+    return impl_->last_profile();
+}
+
+void OnnxLocalVQEEchoCanceller::feed_reference(
+    const float* samples,
+    std::size_t length) {
+    impl_->feed_reference(samples, length);
+}
+
+void OnnxLocalVQEEchoCanceller::cancel_echo(
+    const float* input,
+    std::size_t length,
+    float* output) {
+    impl_->cancel_echo(input, length, output);
+}
+
+void OnnxLocalVQEEchoCanceller::reset() {
+    impl_->reset();
+}
+
+}  // namespace speech_core

--- a/src/models/moss/moss_prompt_processor.cpp
+++ b/src/models/moss/moss_prompt_processor.cpp
@@ -1,0 +1,206 @@
+#include "speech_core/models/moss_prompt_processor.h"
+
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace speech_core {
+namespace {
+
+constexpr std::array<int64_t, 15> kPromptPrefix = {
+    151644, 8948, 198, 2610, 525, 264, 10950, 17847, 13, 151645,
+    198, 151644, 872, 198, 151669,
+};
+
+constexpr std::array<int64_t, 71> kPromptSuffix = {
+    151670, 198, 14880, 44063, 111268, 46670, 61443, 17714, 108704,
+    3837, 73157, 104383, 58362, 23031, 71618, 26606, 20450, 111420,
+    33108, 104283, 17340, 72640, 9909, 58, 50, 15, 16, 60, 5373, 58,
+    50, 15, 17, 60, 5373, 58, 50, 15, 18, 60, 1940, 7552, 111749,
+    3837, 110644, 17714, 110019, 105761, 43815, 90395, 18493, 37474,
+    100072, 111066, 80565, 20450, 111420, 3837, 23031, 104542, 117932,
+    75882, 37474, 105761, 101121, 1773, 151645, 198, 151644, 77091, 198,
+};
+
+std::string trim_ascii(std::string value) {
+    auto not_space = [](unsigned char character) {
+        return !std::isspace(character);
+    };
+    const auto first = std::find_if(value.begin(), value.end(), not_space);
+    const auto last = std::find_if(
+        value.rbegin(), value.rend(), not_space).base();
+    if (first >= last) return {};
+    return std::string(first, last);
+}
+
+void append_utf8_codepoint(
+    const std::string& value, std::size_t& offset, uint32_t& codepoint) {
+    const unsigned char first =
+        static_cast<unsigned char>(value[offset++]);
+    if ((first & 0x80u) == 0) {
+        codepoint = first;
+        return;
+    }
+    int continuation_count = 0;
+    if ((first & 0xe0u) == 0xc0u) {
+        codepoint = first & 0x1fu;
+        continuation_count = 1;
+    } else if ((first & 0xf0u) == 0xe0u) {
+        codepoint = first & 0x0fu;
+        continuation_count = 2;
+    } else if ((first & 0xf8u) == 0xf0u) {
+        codepoint = first & 0x07u;
+        continuation_count = 3;
+    } else {
+        codepoint = first;
+        return;
+    }
+    if (offset + static_cast<std::size_t>(continuation_count)
+            > value.size()) {
+        codepoint = first;
+        return;
+    }
+    for (int index = 0; index < continuation_count; ++index) {
+        const unsigned char next =
+            static_cast<unsigned char>(value[offset++]);
+        if ((next & 0xc0u) != 0x80u) {
+            codepoint = first;
+            return;
+        }
+        codepoint = (codepoint << 6u) | (next & 0x3fu);
+    }
+}
+
+}  // namespace
+
+std::vector<int64_t> MossPromptProcessor::make_audio_span(
+    std::size_t audio_token_count) {
+    if (audio_token_count == 0) return {};
+
+    const int tokens_per_marker = static_cast<int>(
+        kAudioTokensPerSecond
+        * static_cast<double>(kTimeMarkerEverySeconds));
+    const double duration =
+        static_cast<double>(audio_token_count) / kAudioTokensPerSecond;
+
+    std::vector<int64_t> output;
+    output.reserve(audio_token_count + 16);
+    std::size_t consumed = 0;
+    for (int seconds = kTimeMarkerEverySeconds;
+         seconds <= static_cast<int>(duration);
+         seconds += kTimeMarkerEverySeconds) {
+        const std::size_t position = static_cast<std::size_t>(
+            (seconds / kTimeMarkerEverySeconds) * tokens_per_marker);
+        if (position > consumed) {
+            output.insert(
+                output.end(), position - consumed, kAudioTokenId);
+            consumed = position;
+        }
+        for (const char digit : std::to_string(seconds)) {
+            output.push_back(15 + static_cast<int64_t>(digit - '0'));
+        }
+    }
+    if (audio_token_count > consumed) {
+        output.insert(
+            output.end(), audio_token_count - consumed, kAudioTokenId);
+    }
+    return output;
+}
+
+MossPreparedPrompt MossPromptProcessor::prepare(
+    std::size_t audio_token_count) {
+    if (audio_token_count == 0) {
+        throw std::invalid_argument(
+            "MOSS prompt requires at least one audio token");
+    }
+    const std::vector<int64_t> audio_span =
+        make_audio_span(audio_token_count);
+
+    MossPreparedPrompt result;
+    result.eos_token_id = kEosTokenId;
+    result.audio_placeholder_count = static_cast<std::size_t>(
+        std::count(audio_span.begin(), audio_span.end(), kAudioTokenId));
+    result.input_ids.reserve(
+        kPromptPrefix.size() + audio_span.size() + kPromptSuffix.size());
+    result.input_ids.insert(
+        result.input_ids.end(), kPromptPrefix.begin(), kPromptPrefix.end());
+    result.input_ids.insert(
+        result.input_ids.end(), audio_span.begin(), audio_span.end());
+    result.input_ids.insert(
+        result.input_ids.end(), kPromptSuffix.begin(), kPromptSuffix.end());
+    return result;
+}
+
+MossTokenizerDecoder::MossTokenizerDecoder(
+    const std::string& vocab_json_path) {
+    const std::string text = json::read_file(vocab_json_path);
+    if (text.empty()) {
+        throw std::runtime_error(
+            "Unable to read MOSS vocabulary: " + vocab_json_path);
+    }
+    const auto vocabulary = json::parse_vocab_index(text);
+    if (vocabulary.empty()) {
+        throw std::runtime_error(
+            "MOSS vocabulary contains no usable tokens: "
+            + vocab_json_path);
+    }
+
+    int maximum_id = -1;
+    for (const auto& entry : vocabulary) {
+        maximum_id = std::max(maximum_id, entry.second);
+    }
+    tokens_by_id_.resize(static_cast<std::size_t>(maximum_id + 1));
+    for (const auto& entry : vocabulary) {
+        if (entry.second >= 0) {
+            tokens_by_id_[static_cast<std::size_t>(entry.second)] =
+                entry.first;
+        }
+    }
+
+    std::fill(
+        std::begin(inverse_byte_map_), std::end(inverse_byte_map_), -1);
+    bool direct[256] = {};
+    for (int value = static_cast<int>('!');
+         value <= static_cast<int>('~'); ++value) {
+        direct[value] = true;
+    }
+    for (int value = 0xa1; value <= 0xac; ++value) direct[value] = true;
+    for (int value = 0xae; value <= 0xff; ++value) direct[value] = true;
+    int replacement = 0;
+    for (int byte = 0; byte < 256; ++byte) {
+        const int codepoint = direct[byte] ? byte : 256 + replacement++;
+        inverse_byte_map_[codepoint] = byte;
+    }
+}
+
+std::string MossTokenizerDecoder::decode(
+    const std::vector<int64_t>& ids) const {
+    std::string output;
+    for (const int64_t id : ids) {
+        if (id < 0 || static_cast<std::size_t>(id) >= tokens_by_id_.size()) {
+            continue;
+        }
+        const std::string& token =
+            tokens_by_id_[static_cast<std::size_t>(id)];
+        std::size_t offset = 0;
+        while (offset < token.size()) {
+            uint32_t codepoint = 0;
+            const std::size_t previous = offset;
+            append_utf8_codepoint(token, offset, codepoint);
+            if (codepoint < 512 && inverse_byte_map_[codepoint] >= 0) {
+                output.push_back(static_cast<char>(
+                    inverse_byte_map_[codepoint]));
+            } else {
+                output.append(token, previous, offset - previous);
+            }
+        }
+    }
+    return trim_ascii(std::move(output));
+}
+
+}  // namespace speech_core

--- a/src/models/moss/moss_whisper_features.cpp
+++ b/src/models/moss/moss_whisper_features.cpp
@@ -1,0 +1,192 @@
+#include "speech_core/models/moss_whisper_features.h"
+
+#include <kiss_fftr.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace speech_core {
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+struct KissFftrDeleter {
+    void operator()(kiss_fftr_state* value) const {
+        if (value) kiss_fftr_free(value);
+    }
+};
+
+using KissFftrPlan = std::unique_ptr<kiss_fftr_state, KissFftrDeleter>;
+
+double hertz_to_slaney_mel(double hertz) {
+    constexpr double kMinimumLogHertz = 1000.0;
+    constexpr double kMinimumLogMel = 15.0;
+    const double log_step = 27.0 / std::log(6.4);
+    if (hertz < kMinimumLogHertz) return 3.0 * hertz / 200.0;
+    return kMinimumLogMel
+        + std::log(hertz / kMinimumLogHertz) * log_step;
+}
+
+double slaney_mel_to_hertz(double mel) {
+    constexpr double kMinimumLogHertz = 1000.0;
+    constexpr double kMinimumLogMel = 15.0;
+    const double log_step = 27.0 / std::log(6.4);
+    if (mel < kMinimumLogMel) return 200.0 * mel / 3.0;
+    return kMinimumLogHertz
+        * std::exp((mel - kMinimumLogMel) / log_step);
+}
+
+}  // namespace
+
+MossWhisperFeatureExtractor::MossWhisperFeatureExtractor() {
+    hann_window_.resize(kFftSize);
+    for (int index = 0; index < kFftSize; ++index) {
+        hann_window_[static_cast<std::size_t>(index)] = static_cast<float>(
+            0.5 * (1.0 - std::cos(
+                2.0 * kPi * static_cast<double>(index)
+                / static_cast<double>(kFftSize))));
+    }
+
+    constexpr int kFrequencyBins = kFftSize / 2 + 1;
+    std::vector<double> points(kMelBins + 2);
+    const double mel_minimum = hertz_to_slaney_mel(0.0);
+    const double mel_maximum =
+        hertz_to_slaney_mel(static_cast<double>(kSampleRate) / 2.0);
+    for (int index = 0; index < kMelBins + 2; ++index) {
+        const double mel = mel_minimum
+            + static_cast<double>(index) * (mel_maximum - mel_minimum)
+                / static_cast<double>(kMelBins + 1);
+        points[static_cast<std::size_t>(index)] =
+            slaney_mel_to_hertz(mel);
+    }
+
+    mel_filterbank_.assign(
+        static_cast<std::size_t>(kMelBins * kFrequencyBins), 0.0f);
+    for (int mel = 0; mel < kMelBins; ++mel) {
+        const double left = points[static_cast<std::size_t>(mel)];
+        const double center = points[static_cast<std::size_t>(mel + 1)];
+        const double right = points[static_cast<std::size_t>(mel + 2)];
+        const double slaney = 2.0 / (right - left);
+        for (int bin = 0; bin < kFrequencyBins; ++bin) {
+            const double hertz =
+                static_cast<double>(bin * kSampleRate) / kFftSize;
+            const double rising = (hertz - left) / (center - left);
+            const double falling = (right - hertz) / (right - center);
+            const double triangle =
+                std::max(0.0, std::min(rising, falling));
+            mel_filterbank_[
+                static_cast<std::size_t>(mel * kFrequencyBins + bin)] =
+                static_cast<float>(triangle * slaney);
+        }
+    }
+}
+
+std::size_t MossWhisperFeatureExtractor::audio_token_count(
+    std::size_t sample_count) {
+    if (sample_count == 0) return 0;
+    return (sample_count - 1)
+        / static_cast<std::size_t>(kEncoderStrideSamples) + 1;
+}
+
+MossLogMelFeatures MossWhisperFeatureExtractor::extract_padded_chunk(
+    const float* audio, std::size_t length) const {
+    if (!audio || length == 0) {
+        throw std::invalid_argument("MOSS audio chunk is empty");
+    }
+    if (length > static_cast<std::size_t>(kChunkSamples)) {
+        throw std::invalid_argument(
+            "MOSS audio chunk exceeds the 30-second encoder input");
+    }
+
+    std::vector<float> fixed_audio(
+        static_cast<std::size_t>(kChunkSamples), 0.0f);
+    std::copy_n(audio, length, fixed_audio.begin());
+
+    constexpr int kPad = kFftSize / 2;
+    std::vector<float> centered(
+        fixed_audio.size() + static_cast<std::size_t>(2 * kPad), 0.0f);
+    for (int index = 0; index < kPad; ++index) {
+        centered[static_cast<std::size_t>(index)] =
+            fixed_audio[static_cast<std::size_t>(kPad - index)];
+    }
+    std::copy(
+        fixed_audio.begin(), fixed_audio.end(),
+        centered.begin() + kPad);
+    for (int index = 0; index < kPad; ++index) {
+        centered[
+            static_cast<std::size_t>(kPad + kChunkSamples + index)] =
+            fixed_audio[
+                static_cast<std::size_t>(kChunkSamples - 2 - index)];
+    }
+
+    KissFftrPlan plan(
+        kiss_fftr_alloc(kFftSize, /*inverse_fft=*/0, nullptr, nullptr));
+    if (!plan) {
+        throw std::runtime_error("MOSS KISS FFT plan allocation failed");
+    }
+
+    constexpr int kFrequencyBins = kFftSize / 2 + 1;
+    std::vector<float> frame(static_cast<std::size_t>(kFftSize));
+    std::vector<kiss_fft_cpx> spectrum(
+        static_cast<std::size_t>(kFrequencyBins));
+    std::vector<float> power(static_cast<std::size_t>(kFrequencyBins));
+    std::vector<float> mel_by_frame(
+        static_cast<std::size_t>(kTimeFrames * kMelBins));
+
+    for (int time = 0; time < kTimeFrames; ++time) {
+        const std::size_t start =
+            static_cast<std::size_t>(time * kHopLength);
+        for (int index = 0; index < kFftSize; ++index) {
+            frame[static_cast<std::size_t>(index)] =
+                centered[start + static_cast<std::size_t>(index)]
+                * hann_window_[static_cast<std::size_t>(index)];
+        }
+        kiss_fftr(plan.get(), frame.data(), spectrum.data());
+        for (int bin = 0; bin < kFrequencyBins; ++bin) {
+            const auto& value = spectrum[static_cast<std::size_t>(bin)];
+            power[static_cast<std::size_t>(bin)] =
+                value.r * value.r + value.i * value.i;
+        }
+        for (int mel = 0; mel < kMelBins; ++mel) {
+            const float* filter = mel_filterbank_.data()
+                + static_cast<std::size_t>(mel * kFrequencyBins);
+            double sum = 0.0;
+            for (int bin = 0; bin < kFrequencyBins; ++bin) {
+                sum += static_cast<double>(
+                    power[static_cast<std::size_t>(bin)])
+                    * static_cast<double>(filter[bin]);
+            }
+            mel_by_frame[
+                static_cast<std::size_t>(time * kMelBins + mel)] =
+                static_cast<float>(std::max(sum, 1e-10));
+        }
+    }
+
+    float peak = -std::numeric_limits<float>::infinity();
+    for (float& value : mel_by_frame) {
+        value = std::log10(value);
+        peak = std::max(peak, value);
+    }
+    const float floor = peak - 8.0f;
+
+    MossLogMelFeatures result;
+    result.mel_bins = kMelBins;
+    result.time_frames = kTimeFrames;
+    result.data.resize(static_cast<std::size_t>(kMelBins * kTimeFrames));
+    for (int time = 0; time < kTimeFrames; ++time) {
+        for (int mel = 0; mel < kMelBins; ++mel) {
+            const float value = mel_by_frame[
+                static_cast<std::size_t>(time * kMelBins + mel)];
+            result.data[
+                static_cast<std::size_t>(mel * kTimeFrames + time)] =
+                (std::max(value, floor) + 4.0f) * 0.25f;
+        }
+    }
+    return result;
+}
+
+}  // namespace speech_core

--- a/src/models/moss/onnx_moss_transcribe_diarize.cpp
+++ b/src/models/moss/onnx_moss_transcribe_diarize.cpp
@@ -1,0 +1,950 @@
+#include "speech_core/models/onnx_moss_transcribe_diarize.h"
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_engine.h"
+#include "speech_core/transcription/moss_transcript_parser.h"
+#include "speech_core/util/json.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace speech_core {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+namespace fs = std::filesystem;
+
+constexpr int64_t kDecoderLayers = 28;
+constexpr int64_t kDecoderKvHeads = 8;
+constexpr int64_t kDecoderHeadDim = 128;
+constexpr int64_t kDecoderHidden = 1024;
+constexpr int64_t kDecoderVocabulary = 151936;
+
+double milliseconds_since(const Clock::time_point& started) {
+    return std::chrono::duration<double, std::milli>(
+        Clock::now() - started).count();
+}
+
+struct OrtValueHandle {
+    const OrtApi* api = nullptr;
+    OrtValue* value = nullptr;
+
+    OrtValueHandle() = default;
+    OrtValueHandle(const OrtApi* api_value, OrtValue* ort_value)
+        : api(api_value), value(ort_value) {}
+    ~OrtValueHandle() {
+        if (value && api) api->ReleaseValue(value);
+    }
+    OrtValueHandle(const OrtValueHandle&) = delete;
+    OrtValueHandle& operator=(const OrtValueHandle&) = delete;
+    OrtValueHandle(OrtValueHandle&& other) noexcept
+        : api(other.api), value(other.value) {
+        other.value = nullptr;
+    }
+    OrtValueHandle& operator=(OrtValueHandle&& other) noexcept {
+        if (this != &other) {
+            if (value && api) api->ReleaseValue(value);
+            api = other.api;
+            value = other.value;
+            other.value = nullptr;
+        }
+        return *this;
+    }
+    OrtValue* get() const { return value; }
+};
+
+struct OrtStringHandle {
+    const OrtApi* api = nullptr;
+    OrtAllocator* allocator = nullptr;
+    char* value = nullptr;
+    ~OrtStringHandle() {
+        if (value && api && allocator) {
+            OrtStatus* status = api->AllocatorFree(allocator, value);
+            if (status) api->ReleaseStatus(status);
+        }
+    }
+};
+
+struct TensorInfo {
+    ONNXTensorElementDataType type =
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    std::vector<int64_t> shape;
+};
+
+std::size_t checked_element_count(const std::vector<int64_t>& shape) {
+    std::size_t count = 1;
+    for (const int64_t dimension : shape) {
+        if (dimension < 0) {
+            throw std::runtime_error(
+                "MOSS runtime received an unresolved tensor shape");
+        }
+        if (dimension == 0) return 0;
+        const std::size_t value = static_cast<std::size_t>(dimension);
+        if (count > std::numeric_limits<std::size_t>::max() / value) {
+            throw std::overflow_error("MOSS tensor is too large");
+        }
+        count *= value;
+    }
+    return count;
+}
+
+std::size_t element_size(ONNXTensorElementDataType type) {
+    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) return 2;
+    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) return 4;
+    throw std::runtime_error("MOSS graph must use Float16 or Float32 I/O");
+}
+
+uint16_t float_to_half(float value) {
+    uint32_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint32_t sign = (bits >> 16u) & 0x8000u;
+    int exponent = static_cast<int>((bits >> 23u) & 0xffu) - 127 + 15;
+    uint32_t mantissa = bits & 0x7fffffu;
+    if (exponent <= 0) {
+        if (exponent < -10) return static_cast<uint16_t>(sign);
+        mantissa = (mantissa | 0x800000u)
+            >> static_cast<unsigned>(1 - exponent);
+        if (mantissa & 0x1000u) mantissa += 0x2000u;
+        return static_cast<uint16_t>(sign | (mantissa >> 13u));
+    }
+    if (exponent >= 31) {
+        return static_cast<uint16_t>(
+            sign | (mantissa ? 0x7e00u : 0x7c00u));
+    }
+    if (mantissa & 0x1000u) {
+        mantissa += 0x2000u;
+        if (mantissa & 0x800000u) {
+            mantissa = 0;
+            ++exponent;
+            if (exponent >= 31) {
+                return static_cast<uint16_t>(sign | 0x7c00u);
+            }
+        }
+    }
+    return static_cast<uint16_t>(
+        sign | (static_cast<uint32_t>(exponent) << 10u)
+        | (mantissa >> 13u));
+}
+
+float half_to_float(uint16_t value) {
+    const uint32_t sign =
+        static_cast<uint32_t>(value & 0x8000u) << 16u;
+    int exponent = static_cast<int>((value >> 10u) & 0x1fu);
+    uint32_t mantissa = value & 0x3ffu;
+    uint32_t bits = 0;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            bits = sign;
+        } else {
+            exponent = 1;
+            while ((mantissa & 0x400u) == 0) {
+                mantissa <<= 1u;
+                --exponent;
+            }
+            mantissa &= 0x3ffu;
+            bits = sign
+                | (static_cast<uint32_t>(exponent + 127 - 15) << 23u)
+                | (mantissa << 13u);
+        }
+    } else if (exponent == 31) {
+        bits = sign | 0x7f800000u | (mantissa << 13u);
+    } else {
+        bits = sign
+            | (static_cast<uint32_t>(exponent + 127 - 15) << 23u)
+            | (mantissa << 13u);
+    }
+    float output = 0.0f;
+    std::memcpy(&output, &bits, sizeof(output));
+    return output;
+}
+
+void write_float(
+    std::vector<uint8_t>& storage, std::size_t index, float value,
+    ONNXTensorElementDataType type) {
+    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+        const uint16_t converted = float_to_half(value);
+        std::memcpy(
+            storage.data() + index * sizeof(converted),
+            &converted, sizeof(converted));
+    } else if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        std::memcpy(
+            storage.data() + index * sizeof(value), &value, sizeof(value));
+    } else {
+        throw std::runtime_error("Unsupported MOSS floating-point type");
+    }
+}
+
+float read_float(
+    const void* data, std::size_t index, ONNXTensorElementDataType type) {
+    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+        uint16_t value = 0;
+        std::memcpy(
+            &value,
+            static_cast<const uint8_t*>(data) + index * sizeof(value),
+            sizeof(value));
+        return half_to_float(value);
+    }
+    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        float value = 0.0f;
+        std::memcpy(
+            &value,
+            static_cast<const uint8_t*>(data) + index * sizeof(value),
+            sizeof(value));
+        return value;
+    }
+    throw std::runtime_error("Unsupported MOSS floating-point type");
+}
+
+OrtValueHandle make_raw_tensor(
+    const OrtApi* api, OrtMemoryInfo* memory, void* data,
+    std::size_t byte_count, const std::vector<int64_t>& shape,
+    ONNXTensorElementDataType type) {
+    OrtValue* value = nullptr;
+    ort_check(api, api->CreateTensorWithDataAsOrtValue(
+        memory, data, byte_count, shape.data(), shape.size(), type, &value));
+    return OrtValueHandle(api, value);
+}
+
+template <typename T>
+OrtValueHandle make_typed_tensor(
+    const OrtApi* api, OrtMemoryInfo* memory, std::vector<T>& data,
+    const std::vector<int64_t>& shape, ONNXTensorElementDataType type) {
+    return make_raw_tensor(
+        api, memory, data.data(), data.size() * sizeof(T), shape, type);
+}
+
+TensorInfo value_info(const OrtApi* api, OrtValue* value) {
+    OrtTensorTypeAndShapeInfo* raw = nullptr;
+    ort_check(api, api->GetTensorTypeAndShape(value, &raw));
+    TensorInfo output;
+    ort_check(api, api->GetTensorElementType(raw, &output.type));
+    std::size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(raw, &rank));
+    output.shape.resize(rank);
+    ort_check(api, api->GetDimensions(raw, output.shape.data(), rank));
+    api->ReleaseTensorTypeAndShapeInfo(raw);
+    return output;
+}
+
+TensorInfo session_tensor_info(
+    const OrtApi* api, OrtSession* session, std::size_t index,
+    bool input) {
+    OrtTypeInfo* raw = nullptr;
+    if (input) {
+        ort_check(api, api->SessionGetInputTypeInfo(session, index, &raw));
+    } else {
+        ort_check(api, api->SessionGetOutputTypeInfo(session, index, &raw));
+    }
+    const OrtTensorTypeAndShapeInfo* tensor = nullptr;
+    OrtStatus* status = api->CastTypeInfoToTensorInfo(raw, &tensor);
+    if (status || !tensor) {
+        if (status) api->ReleaseStatus(status);
+        api->ReleaseTypeInfo(raw);
+        throw std::runtime_error("MOSS graph I/O must be tensors");
+    }
+    TensorInfo output;
+    ort_check(api, api->GetTensorElementType(tensor, &output.type));
+    std::size_t rank = 0;
+    ort_check(api, api->GetDimensionsCount(tensor, &rank));
+    output.shape.resize(rank);
+    ort_check(api, api->GetDimensions(tensor, output.shape.data(), rank));
+    api->ReleaseTypeInfo(raw);
+    return output;
+}
+
+std::vector<std::string> session_names(
+    const OrtApi* api, OrtSession* session, bool input) {
+    OrtAllocator* allocator = nullptr;
+    ort_check(api, api->GetAllocatorWithDefaultOptions(&allocator));
+    std::size_t count = 0;
+    if (input) {
+        ort_check(api, api->SessionGetInputCount(session, &count));
+    } else {
+        ort_check(api, api->SessionGetOutputCount(session, &count));
+    }
+    std::vector<std::string> names;
+    names.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        OrtStringHandle name{api, allocator, nullptr};
+        if (input) {
+            ort_check(api, api->SessionGetInputName(
+                session, index, allocator, &name.value));
+        } else {
+            ort_check(api, api->SessionGetOutputName(
+                session, index, allocator, &name.value));
+        }
+        names.emplace_back(name.value);
+    }
+    return names;
+}
+
+void require_names(
+    const std::vector<std::string>& actual,
+    const std::vector<std::string>& expected,
+    const char* label) {
+    if (actual != expected) {
+        throw std::runtime_error(
+            std::string("Incompatible MOSS ") + label + " graph signature");
+    }
+}
+
+std::vector<uint8_t> copy_tensor_bytes(
+    const OrtApi* api, OrtValue* value,
+    ONNXTensorElementDataType expected_type) {
+    const TensorInfo info = value_info(api, value);
+    if (info.type != expected_type) {
+        throw std::runtime_error("MOSS graph returned an unexpected type");
+    }
+    const std::size_t bytes =
+        checked_element_count(info.shape) * element_size(info.type);
+    void* data = nullptr;
+    ort_check(api, api->GetTensorMutableData(value, &data));
+    std::vector<uint8_t> output(bytes);
+    if (bytes > 0) std::memcpy(output.data(), data, bytes);
+    return output;
+}
+
+int64_t cache_sequence_length(
+    const TensorInfo& info, std::size_t expected_delta = 0) {
+    if (info.shape.size() != 5
+        || info.shape[0] != kDecoderLayers
+        || info.shape[1] != 1
+        || info.shape[2] != kDecoderKvHeads
+        || info.shape[4] != kDecoderHeadDim
+        || info.shape[3] < 0
+        || (expected_delta > 0
+            && info.shape[3] != static_cast<int64_t>(expected_delta))) {
+        throw std::runtime_error(
+            "MOSS decoder returned an incompatible K/V cache");
+    }
+    return info.shape[3];
+}
+
+std::vector<uint8_t> append_cache(
+    const std::vector<uint8_t>& past, int64_t past_length,
+    const std::vector<uint8_t>& delta, int64_t delta_length,
+    std::size_t scalar_size) {
+    const int64_t next_length = past_length + delta_length;
+    const std::size_t head_width =
+        static_cast<std::size_t>(kDecoderHeadDim) * scalar_size;
+    const std::size_t past_head_bytes =
+        static_cast<std::size_t>(past_length) * head_width;
+    const std::size_t delta_head_bytes =
+        static_cast<std::size_t>(delta_length) * head_width;
+    const std::size_t next_head_bytes =
+        static_cast<std::size_t>(next_length) * head_width;
+    const std::size_t head_count =
+        static_cast<std::size_t>(kDecoderLayers * kDecoderKvHeads);
+    std::vector<uint8_t> output(head_count * next_head_bytes);
+    for (std::size_t head = 0; head < head_count; ++head) {
+        uint8_t* destination = output.data() + head * next_head_bytes;
+        if (past_head_bytes > 0) {
+            std::memcpy(
+                destination, past.data() + head * past_head_bytes,
+                past_head_bytes);
+        }
+        if (delta_head_bytes > 0) {
+            std::memcpy(
+                destination + past_head_bytes,
+                delta.data() + head * delta_head_bytes,
+                delta_head_bytes);
+        }
+    }
+    return output;
+}
+
+int64_t argmax_logits(
+    const OrtApi* api, OrtValue* logits,
+    ONNXTensorElementDataType expected_type) {
+    const TensorInfo info = value_info(api, logits);
+    if (info.type != expected_type || info.shape.size() != 3
+        || info.shape[0] != 1 || info.shape[1] != 1
+        || info.shape[2] != kDecoderVocabulary) {
+        throw std::runtime_error(
+            "MOSS decoder returned incompatible logits");
+    }
+    void* data = nullptr;
+    ort_check(api, api->GetTensorMutableData(logits, &data));
+    int64_t best_index = 0;
+    float best_value = -std::numeric_limits<float>::infinity();
+    for (int64_t index = 0; index < kDecoderVocabulary; ++index) {
+        const float value = read_float(
+            data, static_cast<std::size_t>(index), expected_type);
+        if (!std::isnan(value) && value > best_value) {
+            best_value = value;
+            best_index = index;
+        }
+    }
+    return best_index;
+}
+
+void validate_expected_shape(
+    const TensorInfo& info, const std::vector<int64_t>& expected,
+    const char* label) {
+    if (info.shape.size() != expected.size()) {
+        throw std::runtime_error(
+            std::string("MOSS ") + label + " has an incompatible rank");
+    }
+    for (std::size_t index = 0; index < expected.size(); ++index) {
+        // ORT reports symbolic graph dimensions as -1. Accept those at load
+        // time and validate every resolved runtime tensor below; the exported
+        // decoder leaves even semantically fixed batch/head dimensions
+        // symbolic on a few outputs.
+        if (expected[index] >= 0 && info.shape[index] >= 0
+            && info.shape[index] != expected[index]) {
+            throw std::runtime_error(
+                std::string("MOSS ") + label
+                + " has an incompatible shape");
+        }
+    }
+}
+
+}  // namespace
+
+OnnxMossTranscribeDiarize::OnnxMossTranscribeDiarize(
+    const std::string& bundle_directory)
+    : OnnxMossTranscribeDiarize(bundle_directory, Config{}) {}
+
+OnnxMossTranscribeDiarize::OnnxMossTranscribeDiarize(
+    const std::string& bundle_directory, const Config& config)
+    : config_(config),
+      tokenizer_((fs::path(bundle_directory) / "vocab.json").string()) {
+    if (config_.max_new_tokens <= 0) {
+        throw std::invalid_argument(
+            "MOSS max_new_tokens must be positive");
+    }
+    validate_bundle(bundle_directory);
+
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    const fs::path bundle(bundle_directory);
+    audio_encoder_ = engine.load(
+        (bundle / "audio_encoder.onnx").string(),
+        config_.audio_hardware_acceleration, false,
+        config_.audio_intra_threads);
+    try {
+        decoder_ = engine.load(
+            (bundle / "decoder.onnx").string(),
+            config_.decoder_hardware_acceleration, false,
+            config_.decoder_intra_threads);
+        validate_graph_contracts();
+    } catch (...) {
+        if (decoder_) api_->ReleaseSession(decoder_);
+        decoder_ = nullptr;
+        if (audio_encoder_) api_->ReleaseSession(audio_encoder_);
+        audio_encoder_ = nullptr;
+        throw;
+    }
+}
+
+OnnxMossTranscribeDiarize::~OnnxMossTranscribeDiarize() {
+    if (decoder_) api_->ReleaseSession(decoder_);
+    if (audio_encoder_) api_->ReleaseSession(audio_encoder_);
+}
+
+void OnnxMossTranscribeDiarize::validate_bundle(
+    const std::string& bundle_directory) const {
+    const fs::path bundle(bundle_directory);
+    const std::array<const char*, 6> required = {
+        "audio_encoder.onnx",
+        "decoder.onnx",
+        "config.json",
+        "processor_config.json",
+        "preprocessor_config.json",
+        "vocab.json",
+    };
+    for (const char* name : required) {
+        if (!fs::is_regular_file(bundle / name)) {
+            throw std::runtime_error(
+                std::string("MOSS bundle is missing ") + name);
+        }
+    }
+
+    const auto config = json::parse_flat_object(
+        json::read_file((bundle / "config.json").string()));
+    const auto model_type = config.find("model_type");
+    const auto source_revision = config.find("source_revision");
+    if (model_type == config.end()
+        || model_type->second != "moss-transcribe-diarize-onnx"
+        || source_revision == config.end()
+        || source_revision->second
+            != "e6d68cdfcddbdad1a7e8454f0cb859cad76e2502") {
+        throw std::runtime_error(
+            "MOSS bundle metadata does not match the supported export");
+    }
+
+    const auto processor = json::parse_flat_object(
+        json::read_file((bundle / "processor_config.json").string()));
+    const auto preprocessor = json::parse_flat_object(
+        json::read_file((bundle / "preprocessor_config.json").string()));
+    auto require_value = [](const json::Dict& values, const char* key,
+                            const char* expected, const char* label) {
+        const auto found = values.find(key);
+        if (found == values.end() || found->second != expected) {
+            throw std::runtime_error(
+                std::string("MOSS ") + label
+                + " has an incompatible " + key);
+        }
+    };
+    require_value(
+        processor, "audio_tokens_per_second", "12.5",
+        "processor_config.json");
+    require_value(
+        processor, "audio_merge_size", "4", "processor_config.json");
+    require_value(
+        processor, "time_marker_every_seconds", "5",
+        "processor_config.json");
+    require_value(
+        processor, "enable_time_marker", "true",
+        "processor_config.json");
+    require_value(
+        preprocessor, "feature_size", "80", "preprocessor_config.json");
+    require_value(
+        preprocessor, "hop_length", "160", "preprocessor_config.json");
+    require_value(
+        preprocessor, "n_fft", "400", "preprocessor_config.json");
+    require_value(
+        preprocessor, "n_samples", "480000",
+        "preprocessor_config.json");
+    require_value(
+        preprocessor, "nb_max_frames", "3000",
+        "preprocessor_config.json");
+    require_value(
+        preprocessor, "sampling_rate", "16000",
+        "preprocessor_config.json");
+}
+
+void OnnxMossTranscribeDiarize::validate_graph_contracts() {
+    require_names(
+        session_names(api_, audio_encoder_, true),
+        {"input_features"}, "audio-encoder input");
+    require_names(
+        session_names(api_, audio_encoder_, false),
+        {"audio_embeds"}, "audio-encoder output");
+    require_names(
+        session_names(api_, decoder_, true),
+        {
+            "input_ids", "input_embeds", "input_embed_mask",
+            "position_ids", "attention_mask", "past_keys", "past_values",
+        },
+        "decoder input");
+    require_names(
+        session_names(api_, decoder_, false),
+        {"logits", "new_keys", "new_values"}, "decoder output");
+
+    const TensorInfo audio_input =
+        session_tensor_info(api_, audio_encoder_, 0, true);
+    const TensorInfo audio_output =
+        session_tensor_info(api_, audio_encoder_, 0, false);
+    validate_expected_shape(
+        audio_input, {1, 80, 3000}, "audio input");
+    validate_expected_shape(
+        audio_output, {1, 375, 1024}, "audio output");
+    if (audio_input.type != audio_output.type
+        || (audio_input.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16
+            && audio_input.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)) {
+        throw std::runtime_error(
+            "MOSS audio graph has incompatible numeric I/O");
+    }
+    audio_type_ = audio_input.type;
+
+    const TensorInfo input_ids =
+        session_tensor_info(api_, decoder_, 0, true);
+    const TensorInfo input_embeds =
+        session_tensor_info(api_, decoder_, 1, true);
+    const TensorInfo embed_mask =
+        session_tensor_info(api_, decoder_, 2, true);
+    const TensorInfo position_ids =
+        session_tensor_info(api_, decoder_, 3, true);
+    const TensorInfo attention =
+        session_tensor_info(api_, decoder_, 4, true);
+    const TensorInfo past_keys =
+        session_tensor_info(api_, decoder_, 5, true);
+    const TensorInfo past_values =
+        session_tensor_info(api_, decoder_, 6, true);
+    const TensorInfo logits =
+        session_tensor_info(api_, decoder_, 0, false);
+    const TensorInfo new_keys =
+        session_tensor_info(api_, decoder_, 1, false);
+    const TensorInfo new_values =
+        session_tensor_info(api_, decoder_, 2, false);
+
+    if (input_ids.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64
+        || position_ids.type != ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64) {
+        throw std::runtime_error(
+            "MOSS decoder token inputs must be Int64");
+    }
+    decoder_type_ = input_embeds.type;
+    if ((decoder_type_ != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16
+         && decoder_type_ != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT)
+        || embed_mask.type != decoder_type_
+        || attention.type != decoder_type_
+        || past_keys.type != decoder_type_
+        || past_values.type != decoder_type_
+        || logits.type != decoder_type_
+        || new_keys.type != decoder_type_
+        || new_values.type != decoder_type_
+        || audio_type_ != decoder_type_) {
+        throw std::runtime_error(
+            "MOSS graphs do not share one supported numeric type");
+    }
+    validate_expected_shape(input_ids, {1, -1}, "decoder input_ids");
+    validate_expected_shape(
+        input_embeds, {1, -1, kDecoderHidden},
+        "decoder input_embeds");
+    validate_expected_shape(
+        embed_mask, {1, -1, 1}, "decoder input_embed_mask");
+    validate_expected_shape(position_ids, {-1}, "decoder position_ids");
+    validate_expected_shape(
+        attention, {1, 1, -1, -1}, "decoder attention_mask");
+    validate_expected_shape(
+        past_keys,
+        {kDecoderLayers, 1, kDecoderKvHeads, -1, kDecoderHeadDim},
+        "decoder past_keys");
+    validate_expected_shape(
+        past_values,
+        {kDecoderLayers, 1, kDecoderKvHeads, -1, kDecoderHeadDim},
+        "decoder past_values");
+    validate_expected_shape(
+        logits, {1, 1, kDecoderVocabulary}, "decoder logits");
+    validate_expected_shape(
+        new_keys,
+        {kDecoderLayers, 1, kDecoderKvHeads, -1, kDecoderHeadDim},
+        "decoder new_keys");
+    validate_expected_shape(
+        new_values,
+        {kDecoderLayers, 1, kDecoderKvHeads, -1, kDecoderHeadDim},
+        "decoder new_values");
+}
+
+void OnnxMossTranscribeDiarize::cancel() {
+    cancel_requested_.store(true, std::memory_order_release);
+}
+
+OnnxMossTranscribeDiarize::Profile
+OnnxMossTranscribeDiarize::last_profile() const {
+    std::lock_guard<std::mutex> lock(profile_mutex_);
+    return last_profile_;
+}
+
+DiarizedTranscriptionResult
+OnnxMossTranscribeDiarize::transcribe_diarized(
+    const float* audio, std::size_t length, int sample_rate) {
+    if (!audio && length > 0) {
+        throw std::invalid_argument("MOSS audio buffer is null");
+    }
+    if (length == 0) return {};
+    if (sample_rate <= 0) {
+        throw std::invalid_argument("MOSS sample rate must be positive");
+    }
+
+    std::lock_guard<std::mutex> inference_lock(inference_mutex_);
+    cancel_requested_.store(false, std::memory_order_release);
+    Profile profile;
+    const auto total_started = Clock::now();
+
+    std::vector<float> resampled;
+    if (sample_rate != input_sample_rate()) {
+        resampled = Resampler::resample(
+            audio, length, sample_rate, input_sample_rate());
+        audio = resampled.data();
+        length = resampled.size();
+    }
+    if (length == 0) return {};
+
+    auto* memory = OnnxEngine::get().cpu_memory();
+    const std::size_t scalar_size = element_size(audio_type_);
+    std::vector<uint8_t> audio_embeddings;
+    std::size_t total_audio_tokens = 0;
+    const auto feature_started = Clock::now();
+    std::vector<MossLogMelFeatures> chunk_features;
+    std::vector<std::size_t> chunk_token_counts;
+    for (std::size_t offset = 0; offset < length;
+         offset += static_cast<std::size_t>(
+             MossWhisperFeatureExtractor::kChunkSamples)) {
+        const std::size_t chunk_length = std::min(
+            length - offset,
+            static_cast<std::size_t>(
+                MossWhisperFeatureExtractor::kChunkSamples));
+        chunk_features.push_back(
+            feature_extractor_.extract_padded_chunk(
+                audio + offset, chunk_length));
+        const std::size_t tokens =
+            MossWhisperFeatureExtractor::audio_token_count(chunk_length);
+        chunk_token_counts.push_back(tokens);
+        total_audio_tokens += tokens;
+    }
+    profile.feature_ms = milliseconds_since(feature_started);
+    profile.audio_chunks = static_cast<int>(chunk_features.size());
+    audio_embeddings.reserve(
+        total_audio_tokens * static_cast<std::size_t>(kDecoderHidden)
+        * scalar_size);
+
+    const auto audio_started = Clock::now();
+    const char* audio_input_names[] = {"input_features"};
+    const char* audio_output_names[] = {"audio_embeds"};
+    for (std::size_t chunk = 0; chunk < chunk_features.size(); ++chunk) {
+        if (cancel_requested_.load(std::memory_order_acquire)) return {};
+        const auto& features = chunk_features[chunk];
+        std::vector<uint8_t> feature_storage(
+            features.data.size() * scalar_size);
+        for (std::size_t index = 0; index < features.data.size(); ++index) {
+            write_float(
+                feature_storage, index, features.data[index], audio_type_);
+        }
+        const std::vector<int64_t> feature_shape = {1, 80, 3000};
+        auto feature_tensor = make_raw_tensor(
+            api_, memory, feature_storage.data(), feature_storage.size(),
+            feature_shape, audio_type_);
+        OrtValue* inputs[] = {feature_tensor.get()};
+        OrtValue* outputs[] = {nullptr};
+        ort_check(api_, api_->Run(
+            audio_encoder_, nullptr, audio_input_names, inputs, 1,
+            audio_output_names, 1, outputs));
+        OrtValueHandle output(api_, outputs[0]);
+        const TensorInfo output_info = value_info(api_, output.get());
+        validate_expected_shape(
+            output_info, {1, 375, 1024}, "audio output");
+        if (output_info.type != audio_type_) {
+            throw std::runtime_error(
+                "MOSS audio encoder changed numeric type");
+        }
+        void* output_data = nullptr;
+        ort_check(api_, api_->GetTensorMutableData(
+            output.get(), &output_data));
+        const std::size_t bytes = chunk_token_counts[chunk]
+            * static_cast<std::size_t>(kDecoderHidden) * scalar_size;
+        const auto* begin = static_cast<const uint8_t*>(output_data);
+        audio_embeddings.insert(
+            audio_embeddings.end(), begin, begin + bytes);
+    }
+    profile.audio_encoder_ms = milliseconds_since(audio_started);
+
+    MossPreparedPrompt prompt =
+        MossPromptProcessor::prepare(total_audio_tokens);
+    if (prompt.audio_placeholder_count != total_audio_tokens) {
+        throw std::runtime_error(
+            "MOSS prompt/audio placeholder count mismatch");
+    }
+    profile.prompt_tokens = static_cast<int>(prompt.input_ids.size());
+
+    const std::size_t prompt_tokens = prompt.input_ids.size();
+    std::vector<uint8_t> input_embeddings(
+        prompt_tokens * static_cast<std::size_t>(kDecoderHidden)
+        * scalar_size, 0);
+    std::vector<uint8_t> input_embed_mask(
+        prompt_tokens * scalar_size, 0);
+    std::size_t audio_index = 0;
+    for (std::size_t token = 0; token < prompt_tokens; ++token) {
+        if (prompt.input_ids[token] != MossPromptProcessor::kAudioTokenId) {
+            continue;
+        }
+        const std::size_t row_bytes =
+            static_cast<std::size_t>(kDecoderHidden) * scalar_size;
+        std::memcpy(
+            input_embeddings.data() + token * row_bytes,
+            audio_embeddings.data() + audio_index * row_bytes, row_bytes);
+        write_float(
+            input_embed_mask, token, 1.0f, decoder_type_);
+        ++audio_index;
+    }
+    if (audio_index != total_audio_tokens) {
+        throw std::runtime_error(
+            "MOSS prompt did not consume all audio embeddings");
+    }
+
+    std::vector<int64_t> positions(prompt_tokens);
+    for (std::size_t index = 0; index < prompt_tokens; ++index) {
+        positions[index] = static_cast<int64_t>(index);
+    }
+    std::vector<uint8_t> attention(
+        prompt_tokens * prompt_tokens * scalar_size);
+    for (std::size_t row = 0; row < prompt_tokens; ++row) {
+        for (std::size_t column = 0; column < prompt_tokens; ++column) {
+            write_float(
+                attention, row * prompt_tokens + column,
+                column <= row ? 0.0f : -10000.0f, decoder_type_);
+        }
+    }
+    uint8_t empty_sentinel = 0;
+    const std::vector<int64_t> ids_shape = {
+        1, static_cast<int64_t>(prompt_tokens)};
+    const std::vector<int64_t> embeds_shape = {
+        1, static_cast<int64_t>(prompt_tokens), kDecoderHidden};
+    const std::vector<int64_t> mask_shape = {
+        1, static_cast<int64_t>(prompt_tokens), 1};
+    const std::vector<int64_t> positions_shape = {
+        static_cast<int64_t>(prompt_tokens)};
+    const std::vector<int64_t> attention_shape = {
+        1, 1, static_cast<int64_t>(prompt_tokens),
+        static_cast<int64_t>(prompt_tokens)};
+    const std::vector<int64_t> empty_cache_shape = {
+        kDecoderLayers, 1, kDecoderKvHeads, 0, kDecoderHeadDim};
+
+    auto ids_tensor = make_typed_tensor(
+        api_, memory, prompt.input_ids,
+        ids_shape, ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+    auto embeds_tensor = make_raw_tensor(
+        api_, memory, input_embeddings.data(), input_embeddings.size(),
+        embeds_shape, decoder_type_);
+    auto mask_tensor = make_raw_tensor(
+        api_, memory, input_embed_mask.data(), input_embed_mask.size(),
+        mask_shape, decoder_type_);
+    auto positions_tensor = make_typed_tensor(
+        api_, memory, positions, positions_shape,
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+    auto attention_tensor = make_raw_tensor(
+        api_, memory, attention.data(), attention.size(),
+        attention_shape, decoder_type_);
+    auto past_keys_tensor = make_raw_tensor(
+        api_, memory, &empty_sentinel, 0, empty_cache_shape, decoder_type_);
+    auto past_values_tensor = make_raw_tensor(
+        api_, memory, &empty_sentinel, 0, empty_cache_shape, decoder_type_);
+
+    const char* decoder_input_names[] = {
+        "input_ids", "input_embeds", "input_embed_mask",
+        "position_ids", "attention_mask", "past_keys", "past_values",
+    };
+    const char* decoder_output_names[] = {
+        "logits", "new_keys", "new_values",
+    };
+    OrtValue* decoder_inputs[] = {
+        ids_tensor.get(), embeds_tensor.get(), mask_tensor.get(),
+        positions_tensor.get(), attention_tensor.get(),
+        past_keys_tensor.get(), past_values_tensor.get(),
+    };
+    OrtValue* decoder_outputs[] = {nullptr, nullptr, nullptr};
+    const auto prefill_started = Clock::now();
+    ort_check(api_, api_->Run(
+        decoder_, nullptr, decoder_input_names, decoder_inputs, 7,
+        decoder_output_names, 3, decoder_outputs));
+    profile.decoder_prefill_ms = milliseconds_since(prefill_started);
+    OrtValueHandle logits(api_, decoder_outputs[0]);
+    OrtValueHandle new_keys(api_, decoder_outputs[1]);
+    OrtValueHandle new_values(api_, decoder_outputs[2]);
+
+    const TensorInfo first_key_info = value_info(api_, new_keys.get());
+    const TensorInfo first_value_info = value_info(api_, new_values.get());
+    const int64_t first_key_length =
+        cache_sequence_length(first_key_info, prompt_tokens);
+    const int64_t first_value_length =
+        cache_sequence_length(first_value_info, prompt_tokens);
+    if (first_key_info.type != decoder_type_
+        || first_value_info.type != decoder_type_
+        || first_key_length != first_value_length) {
+        throw std::runtime_error(
+            "MOSS decoder prefill returned incompatible caches");
+    }
+    std::vector<uint8_t> past_keys =
+        copy_tensor_bytes(api_, new_keys.get(), decoder_type_);
+    std::vector<uint8_t> past_values =
+        copy_tensor_bytes(api_, new_values.get(), decoder_type_);
+    int64_t past_length = first_key_length;
+    int64_t next_token =
+        argmax_logits(api_, logits.get(), decoder_type_);
+    std::vector<int64_t> generated;
+    generated.reserve(static_cast<std::size_t>(config_.max_new_tokens));
+
+    const auto generate_started = Clock::now();
+    for (int step = 0; step < config_.max_new_tokens; ++step) {
+        generated.push_back(next_token);
+        if (next_token == prompt.eos_token_id) break;
+        if (cancel_requested_.load(std::memory_order_acquire)) return {};
+
+        std::vector<int64_t> token_ids = {next_token};
+        std::vector<uint8_t> zero_embed(
+            static_cast<std::size_t>(kDecoderHidden) * scalar_size, 0);
+        std::vector<uint8_t> zero_mask(scalar_size, 0);
+        std::vector<int64_t> token_position = {past_length};
+        std::vector<uint8_t> zero_attention(
+            static_cast<std::size_t>(past_length + 1) * scalar_size, 0);
+        const std::vector<int64_t> token_ids_shape = {1, 1};
+        const std::vector<int64_t> token_embed_shape = {
+            1, 1, kDecoderHidden};
+        const std::vector<int64_t> token_mask_shape = {1, 1, 1};
+        const std::vector<int64_t> token_position_shape = {1};
+        const std::vector<int64_t> token_attention_shape = {
+            1, 1, 1, past_length + 1};
+        const std::vector<int64_t> cache_shape = {
+            kDecoderLayers, 1, kDecoderKvHeads,
+            past_length, kDecoderHeadDim};
+
+        auto token_ids_tensor = make_typed_tensor(
+            api_, memory, token_ids, token_ids_shape,
+            ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+        auto zero_embed_tensor = make_raw_tensor(
+            api_, memory, zero_embed.data(), zero_embed.size(),
+            token_embed_shape, decoder_type_);
+        auto zero_mask_tensor = make_raw_tensor(
+            api_, memory, zero_mask.data(), zero_mask.size(),
+            token_mask_shape, decoder_type_);
+        auto token_position_tensor = make_typed_tensor(
+            api_, memory, token_position, token_position_shape,
+            ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64);
+        auto zero_attention_tensor = make_raw_tensor(
+            api_, memory, zero_attention.data(), zero_attention.size(),
+            token_attention_shape, decoder_type_);
+        auto past_key_tensor = make_raw_tensor(
+            api_, memory, past_keys.data(), past_keys.size(),
+            cache_shape, decoder_type_);
+        auto past_value_tensor = make_raw_tensor(
+            api_, memory, past_values.data(), past_values.size(),
+            cache_shape, decoder_type_);
+        OrtValue* step_inputs[] = {
+            token_ids_tensor.get(), zero_embed_tensor.get(),
+            zero_mask_tensor.get(), token_position_tensor.get(),
+            zero_attention_tensor.get(), past_key_tensor.get(),
+            past_value_tensor.get(),
+        };
+        OrtValue* step_outputs[] = {nullptr, nullptr, nullptr};
+        ort_check(api_, api_->Run(
+            decoder_, nullptr, decoder_input_names, step_inputs, 7,
+            decoder_output_names, 3, step_outputs));
+        OrtValueHandle step_logits(api_, step_outputs[0]);
+        OrtValueHandle step_keys(api_, step_outputs[1]);
+        OrtValueHandle step_values(api_, step_outputs[2]);
+        const TensorInfo key_info = value_info(api_, step_keys.get());
+        const TensorInfo value_info_value =
+            value_info(api_, step_values.get());
+        const int64_t key_delta = cache_sequence_length(key_info, 1);
+        const int64_t value_delta =
+            cache_sequence_length(value_info_value, 1);
+        if (key_info.type != decoder_type_
+            || value_info_value.type != decoder_type_
+            || key_delta != value_delta) {
+            throw std::runtime_error(
+                "MOSS decoder step returned incompatible caches");
+        }
+        const std::vector<uint8_t> delta_keys =
+            copy_tensor_bytes(api_, step_keys.get(), decoder_type_);
+        const std::vector<uint8_t> delta_values =
+            copy_tensor_bytes(api_, step_values.get(), decoder_type_);
+        past_keys = append_cache(
+            past_keys, past_length, delta_keys, key_delta, scalar_size);
+        past_values = append_cache(
+            past_values, past_length, delta_values, value_delta, scalar_size);
+        past_length += key_delta;
+        next_token =
+            argmax_logits(api_, step_logits.get(), decoder_type_);
+    }
+    profile.decoder_generate_ms = milliseconds_since(generate_started);
+    profile.generated_tokens = static_cast<int>(generated.size());
+    profile.total_ms = milliseconds_since(total_started);
+    {
+        std::lock_guard<std::mutex> profile_lock(profile_mutex_);
+        last_profile_ = profile;
+    }
+
+    const std::string raw_text = tokenizer_.decode(generated);
+    return parse_moss_transcript(raw_text);
+}
+
+}  // namespace speech_core

--- a/src/models/redimnet/onnx_redimnet_speaker_embedding.cpp
+++ b/src/models/redimnet/onnx_redimnet_speaker_embedding.cpp
@@ -1,0 +1,228 @@
+#include "speech_core/models/onnx_redimnet_speaker_embedding.h"
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+namespace {
+
+struct OrtValueHandle {
+    const OrtApi* api = nullptr;
+    OrtValue* value = nullptr;
+    ~OrtValueHandle() {
+        if (api && value) api->ReleaseValue(value);
+    }
+};
+
+std::vector<std::string> io_names(
+    const OrtApi* api, OrtSession* session, bool inputs) {
+    OrtAllocator* allocator = nullptr;
+    ort_check(api, api->GetAllocatorWithDefaultOptions(&allocator));
+    std::size_t count = 0;
+    if (inputs) {
+        ort_check(api, api->SessionGetInputCount(session, &count));
+    } else {
+        ort_check(api, api->SessionGetOutputCount(session, &count));
+    }
+    std::vector<std::string> result;
+    for (std::size_t index = 0; index < count; ++index) {
+        char* name = nullptr;
+        if (inputs) {
+            ort_check(api, api->SessionGetInputName(
+                session, index, allocator, &name));
+        } else {
+            ort_check(api, api->SessionGetOutputName(
+                session, index, allocator, &name));
+        }
+        result.emplace_back(name);
+        OrtStatus* status = api->AllocatorFree(allocator, name);
+        if (status) api->ReleaseStatus(status);
+    }
+    return result;
+}
+
+std::pair<std::vector<int64_t>, ONNXTensorElementDataType> tensor_contract(
+    const OrtApi* api, OrtSession* session, std::size_t index,
+    bool input) {
+    OrtTypeInfo* type_info = nullptr;
+    if (input) {
+        ort_check(api, api->SessionGetInputTypeInfo(
+            session, index, &type_info));
+    } else {
+        ort_check(api, api->SessionGetOutputTypeInfo(
+            session, index, &type_info));
+    }
+    const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+    OrtStatus* cast =
+        api->CastTypeInfoToTensorInfo(type_info, &tensor_info);
+    if (cast || !tensor_info) {
+        if (cast) api->ReleaseStatus(cast);
+        api->ReleaseTypeInfo(type_info);
+        throw std::runtime_error("ReDimNet graph I/O must be tensors");
+    }
+    ONNXTensorElementDataType type =
+        ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    std::size_t rank = 0;
+    ort_check(api, api->GetTensorElementType(tensor_info, &type));
+    ort_check(api, api->GetDimensionsCount(tensor_info, &rank));
+    std::vector<int64_t> shape(rank);
+    ort_check(api, api->GetDimensions(tensor_info, shape.data(), rank));
+    api->ReleaseTypeInfo(type_info);
+    return {std::move(shape), type};
+}
+
+}  // namespace
+
+OnnxReDimNetSpeakerEmbedding::OnnxReDimNetSpeakerEmbedding(
+    const std::string& model_path, bool hardware_acceleration) {
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    session_ = engine.load(model_path, hardware_acceleration);
+    try {
+        validate_contract();
+    } catch (...) {
+        api_->ReleaseSession(session_);
+        session_ = nullptr;
+        throw;
+    }
+}
+
+OnnxReDimNetSpeakerEmbedding::~OnnxReDimNetSpeakerEmbedding() {
+    if (session_) api_->ReleaseSession(session_);
+}
+
+void OnnxReDimNetSpeakerEmbedding::validate_contract() {
+    if (io_names(api_, session_, true) != std::vector<std::string>{"audio"}
+        || io_names(api_, session_, false)
+            != std::vector<std::string>{"embedding"}) {
+        throw std::runtime_error(
+            "ReDimNet ONNX graph has incompatible I/O names");
+    }
+    const auto input = tensor_contract(api_, session_, 0, true);
+    const auto output = tensor_contract(api_, session_, 0, false);
+    if (input.first != std::vector<int64_t>{1, 96000}
+        || output.first != std::vector<int64_t>{1, 192}
+        || input.second != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+        || output.second != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        throw std::runtime_error(
+            "ReDimNet ONNX graph has incompatible tensor shapes or types");
+    }
+}
+
+std::vector<float> OnnxReDimNetSpeakerEmbedding::prepare_audio(
+    const float* samples, std::size_t length,
+    std::size_t minimum_samples) {
+    if (!samples && length > 0) {
+        throw std::invalid_argument("ReDimNet audio buffer is null");
+    }
+    if (minimum_samples == 0) {
+        throw std::invalid_argument(
+            "ReDimNet minimum audio duration must be positive");
+    }
+    if (length < minimum_samples) {
+        throw std::invalid_argument(
+            "ReDimNet speaker identity has insufficient clean audio");
+    }
+    for (std::size_t index = 0; index < length; ++index) {
+        if (!std::isfinite(samples[index])) {
+            throw std::invalid_argument(
+                "ReDimNet audio contains a non-finite sample");
+        }
+    }
+
+    std::vector<float> prepared(kInputSamples);
+    if (length == kInputSamples) {
+        std::copy_n(samples, length, prepared.begin());
+    } else if (length > kInputSamples) {
+        const std::size_t start = (length - kInputSamples) / 2;
+        std::copy_n(samples + start, kInputSamples, prepared.begin());
+    } else {
+        for (std::size_t index = 0; index < kInputSamples; ++index) {
+            prepared[index] = samples[index % length];
+        }
+    }
+    return prepared;
+}
+
+std::vector<float> OnnxReDimNetSpeakerEmbedding::embed(
+    const float* audio, std::size_t length, int sample_rate) {
+    return embed_with_minimum(
+        audio, length, sample_rate, kMinimumSamples);
+}
+
+std::vector<float>
+OnnxReDimNetSpeakerEmbedding::embed_short_utterance(
+    const float* audio, std::size_t length, int sample_rate) {
+    return embed_with_minimum(
+        audio, length, sample_rate, kMinimumShortSamples);
+}
+
+std::vector<float> OnnxReDimNetSpeakerEmbedding::embed_with_minimum(
+    const float* audio, std::size_t length, int sample_rate,
+    std::size_t minimum_samples) {
+    if (sample_rate <= 0) {
+        throw std::invalid_argument(
+            "ReDimNet sample rate must be positive");
+    }
+    if (!audio && length > 0) {
+        throw std::invalid_argument(
+            "ReDimNet audio buffer is null");
+    }
+    if (length == 0) {
+        throw std::invalid_argument(
+            "ReDimNet speaker identity has insufficient clean audio");
+    }
+    std::vector<float> resampled;
+    if (sample_rate != kSampleRate) {
+        resampled = Resampler::resample(
+            audio, length, sample_rate, kSampleRate);
+        audio = resampled.data();
+        length = resampled.size();
+    }
+    std::vector<float> prepared =
+        prepare_audio(audio, length, minimum_samples);
+
+    const int64_t input_shape[] = {1, 96000};
+    OrtValue* input = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        OnnxEngine::get().cpu_memory(),
+        prepared.data(), prepared.size() * sizeof(float),
+        input_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &input));
+    OrtValueHandle input_handle{api_, input};
+    const char* input_names[] = {"audio"};
+    const char* output_names[] = {"embedding"};
+    OrtValue* inputs[] = {input};
+    OrtValue* outputs[] = {nullptr};
+    ort_check(api_, api_->Run(
+        session_, nullptr, input_names, inputs, 1,
+        output_names, 1, outputs));
+    OrtValueHandle output_handle{api_, outputs[0]};
+
+    float* values = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(
+        outputs[0], reinterpret_cast<void**>(&values)));
+    std::vector<float> embedding(
+        values, values + kEmbeddingDimension);
+    float squared_norm = 0.0f;
+    for (const float value : embedding) {
+        if (!std::isfinite(value)) {
+            throw std::runtime_error(
+                "ReDimNet returned a non-finite embedding");
+        }
+        squared_norm += value * value;
+    }
+    const float norm = std::sqrt(squared_norm);
+    if (!(norm > 1e-8f)) {
+        throw std::runtime_error("ReDimNet returned a zero embedding");
+    }
+    for (float& value : embedding) value /= norm;
+    return embedding;
+}
+
+}  // namespace speech_core

--- a/src/pipeline/meeting_transcription_track.cpp
+++ b/src/pipeline/meeting_transcription_track.cpp
@@ -1,0 +1,1334 @@
+#include "speech_core/pipeline/meeting_transcription_track.h"
+#include "speech_core/transcription/moss_transcript_parser.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cctype>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+namespace speech_core {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+std::size_t seconds_to_samples(float seconds, int sample_rate) {
+    if (!std::isfinite(seconds) || seconds < 0.0f || sample_rate <= 0) {
+        throw std::invalid_argument(
+            "Meeting track duration/sample rate is invalid");
+    }
+    return static_cast<std::size_t>(std::llround(
+        static_cast<double>(seconds) * sample_rate));
+}
+
+std::string trim(std::string value) {
+    const auto first = std::find_if_not(
+        value.begin(), value.end(),
+        [](unsigned char item) { return std::isspace(item); });
+    const auto last = std::find_if_not(
+        value.rbegin(), value.rend(),
+        [](unsigned char item) { return std::isspace(item); }).base();
+    if (first >= last) return {};
+    return std::string(first, last);
+}
+
+bool locale_control_at(const std::string& text, std::size_t offset) {
+    if (offset + 7 > text.size()
+        || text[offset] != '<' || text[offset + 6] != '>') {
+        return false;
+    }
+    const auto lower = [](char value) {
+        return value >= 'a' && value <= 'z';
+    };
+    const auto upper = [](char value) {
+        return value >= 'A' && value <= 'Z';
+    };
+    return lower(text[offset + 1])
+        && lower(text[offset + 2])
+        && text[offset + 3] == '-'
+        && upper(text[offset + 4])
+        && upper(text[offset + 5]);
+}
+
+std::string sanitize_preview(const std::string& text) {
+    std::string output;
+    output.reserve(text.size());
+    for (std::size_t index = 0; index < text.size();) {
+        if (locale_control_at(text, index)) {
+            index += 7;
+        } else {
+            output.push_back(text[index++]);
+        }
+    }
+    return trim(std::move(output));
+}
+
+bool has_wire_control(const std::string& text) {
+    return text.find("<|") != std::string::npos
+        || contains_moss_wire_marker(text);
+}
+
+bool decode_utf8(
+    const std::string& text,
+    std::size_t& offset,
+    std::uint32_t& codepoint) {
+    if (offset >= text.size()) return false;
+    const unsigned char first =
+        static_cast<unsigned char>(text[offset++]);
+    if (first < 0x80) {
+        codepoint = first;
+        return true;
+    }
+    int continuation_count = 0;
+    if ((first & 0xe0u) == 0xc0u) {
+        codepoint = first & 0x1fu;
+        continuation_count = 1;
+    } else if ((first & 0xf0u) == 0xe0u) {
+        codepoint = first & 0x0fu;
+        continuation_count = 2;
+    } else if ((first & 0xf8u) == 0xf0u) {
+        codepoint = first & 0x07u;
+        continuation_count = 3;
+    } else {
+        return false;
+    }
+    if (offset + static_cast<std::size_t>(continuation_count)
+        > text.size()) {
+        return false;
+    }
+    for (int index = 0; index < continuation_count; ++index) {
+        const unsigned char next =
+            static_cast<unsigned char>(text[offset++]);
+        if ((next & 0xc0u) != 0x80u) return false;
+        codepoint = (codepoint << 6u) | (next & 0x3fu);
+    }
+    return true;
+}
+
+void append_utf8(std::string& output, std::uint32_t codepoint) {
+    if (codepoint <= 0x7f) {
+        output.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7ff) {
+        output.push_back(static_cast<char>(0xc0u | (codepoint >> 6u)));
+        output.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    } else if (codepoint <= 0xffff) {
+        output.push_back(static_cast<char>(0xe0u | (codepoint >> 12u)));
+        output.push_back(static_cast<char>(
+            0x80u | ((codepoint >> 6u) & 0x3fu)));
+        output.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    } else {
+        output.push_back(static_cast<char>(0xf0u | (codepoint >> 18u)));
+        output.push_back(static_cast<char>(
+            0x80u | ((codepoint >> 12u) & 0x3fu)));
+        output.push_back(static_cast<char>(
+            0x80u | ((codepoint >> 6u) & 0x3fu)));
+        output.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    }
+}
+
+std::uint32_t simple_lower(std::uint32_t codepoint) {
+    if (codepoint >= 'A' && codepoint <= 'Z') return codepoint + 32;
+    if ((codepoint >= 0x00c0 && codepoint <= 0x00d6)
+        || (codepoint >= 0x00d8 && codepoint <= 0x00de)
+        || (codepoint >= 0x0391 && codepoint <= 0x03a1)
+        || (codepoint >= 0x03a3 && codepoint <= 0x03ab)
+        || (codepoint >= 0x0410 && codepoint <= 0x042f)) {
+        return codepoint + 32;
+    }
+    if (codepoint == 0x0401) return 0x0451;
+    return codepoint;
+}
+
+bool unicode_space(std::uint32_t codepoint) {
+    if (codepoint <= 0x7f) {
+        return std::isspace(static_cast<unsigned char>(codepoint));
+    }
+    return codepoint == 0x00a0
+        || codepoint == 0x1680
+        || (codepoint >= 0x2000 && codepoint <= 0x200a)
+        || codepoint == 0x2028
+        || codepoint == 0x2029
+        || codepoint == 0x202f
+        || codepoint == 0x205f
+        || codepoint == 0x3000;
+}
+
+bool unicode_punctuation(std::uint32_t codepoint) {
+    if (codepoint <= 0x7f) {
+        return !std::isalnum(static_cast<unsigned char>(codepoint))
+            && !std::isspace(static_cast<unsigned char>(codepoint));
+    }
+    return (codepoint >= 0x2000 && codepoint <= 0x206f)
+        || (codepoint >= 0x2e00 && codepoint <= 0x2e7f)
+        || (codepoint >= 0x3000 && codepoint <= 0x303f)
+        || (codepoint >= 0xfe10 && codepoint <= 0xfe1f)
+        || (codepoint >= 0xfe30 && codepoint <= 0xfe4f)
+        || (codepoint >= 0xff01 && codepoint <= 0xff0f)
+        || (codepoint >= 0xff1a && codepoint <= 0xff20)
+        || (codepoint >= 0xff3b && codepoint <= 0xff40)
+        || (codepoint >= 0xff5b && codepoint <= 0xff65)
+        || codepoint == 0x060c
+        || codepoint == 0x061b
+        || codepoint == 0x061f
+        || codepoint == 0x0964
+        || codepoint == 0x0965;
+}
+
+std::vector<std::string> normalized_tokens(const std::string& text) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::size_t offset = 0;
+    while (offset < text.size()) {
+        std::uint32_t codepoint = 0;
+        const std::size_t previous = offset;
+        if (!decode_utf8(text, offset, codepoint)) {
+            offset = previous + 1;
+            continue;
+        }
+        if (unicode_space(codepoint)) {
+            if (!token.empty()) {
+                tokens.push_back(std::move(token));
+                token.clear();
+            }
+            continue;
+        }
+        if (unicode_punctuation(codepoint)) continue;
+        append_utf8(token, simple_lower(codepoint));
+    }
+    if (!token.empty()) tokens.push_back(std::move(token));
+    return tokens;
+}
+
+bool contains_contiguous(
+    const std::vector<std::string>& text,
+    const std::vector<std::string>& sequence) {
+    if (sequence.empty() || text.size() < sequence.size()) return false;
+    for (std::size_t start = 0;
+         start + sequence.size() <= text.size(); ++start) {
+        if (std::equal(
+                sequence.begin(), sequence.end(),
+                text.begin() + static_cast<std::ptrdiff_t>(start))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool short_microphone_agrees(
+    const std::string& result,
+    const std::string& preview,
+    std::size_t index,
+    std::size_t count) {
+    const auto result_tokens = normalized_tokens(result);
+    const auto preview_tokens = normalized_tokens(preview);
+    if (result_tokens.empty() || preview_tokens.empty()) return false;
+    if (count <= 1) return result_tokens == preview_tokens;
+    if (index == 0) {
+        return preview_tokens.size() >= result_tokens.size()
+            && std::equal(
+                result_tokens.begin(), result_tokens.end(),
+                preview_tokens.begin());
+    }
+    if (index + 1 == count) {
+        return preview_tokens.size() >= result_tokens.size()
+            && std::equal(
+                result_tokens.rbegin(), result_tokens.rend(),
+                preview_tokens.rbegin());
+    }
+    return contains_contiguous(preview_tokens, result_tokens);
+}
+
+double text_similarity(
+    const std::vector<std::string>& left,
+    const std::vector<std::string>& right) {
+    if (left.empty() || right.empty()) return 0.0;
+    std::vector<std::size_t> previous(right.size() + 1, 0);
+    for (const auto& left_word : left) {
+        std::vector<std::size_t> current(
+            right.size() + 1, 0);
+        for (std::size_t index = 0;
+             index < right.size(); ++index) {
+            current[index + 1] =
+                left_word == right[index]
+                ? previous[index] + 1
+                : std::max(
+                    previous[index + 1], current[index]);
+        }
+        previous = std::move(current);
+    }
+    return static_cast<double>(previous.back())
+        / static_cast<double>(
+            std::max(left.size(), right.size()));
+}
+
+bool activity_recovery_compatible(
+    const std::string& original,
+    const std::string& recovered) {
+    return text_similarity(
+        normalized_tokens(original),
+        normalized_tokens(recovered)) >= 0.60;
+}
+
+double elapsed_ms(const Clock::time_point& started) {
+    return std::chrono::duration<double, std::milli>(
+        Clock::now() - started).count();
+}
+
+}  // namespace
+
+class MeetingTranscriptionTrack::Impl {
+public:
+    struct TimeSegment {
+        std::uint64_t first_sample = 0;
+        std::uint64_t sample_count = 0;
+        std::int64_t start_time_ns = 0;
+    };
+
+    struct Request {
+        std::uint64_t generation = 0;
+        std::uint64_t sequence = 0;
+        std::uint64_t audio_start_sample = 0;
+        std::int64_t audio_start_time_ns = 0;
+        std::uint64_t speech_start_sample = 0;
+        std::uint64_t speech_end_sample = 0;
+        std::uint64_t identity_evidence_start_sample = 0;
+        std::vector<float> audio;
+        std::vector<float> recovery_audio;
+        std::uint64_t recovery_start_sample = 0;
+        std::int64_t recovery_start_time_ns = 0;
+        std::string preview_text;
+        bool paragraph_final = false;
+    };
+
+    struct PendingActivityRecovery {
+        std::uint64_t generation = 0;
+        std::uint64_t speech_start_sample = 0;
+        std::uint64_t speech_end_sample = 0;
+        std::vector<MeetingTranscriptBlock> blocks;
+    };
+
+    Impl(
+        STTInterface& preview_value,
+        TranscribeDiarizeInterface& final_model_value,
+        VADInterface& vad_value,
+        Config config_value,
+        EventCallback callback_value)
+        : preview(preview_value),
+          final_model(final_model_value),
+          vad(vad_value),
+          config(config_value),
+          callback(std::move(callback_value)) {
+        validate_config();
+        if (!preview.supports_streaming()) {
+            throw std::invalid_argument(
+                "Meeting track preview must support streaming");
+        }
+        if (preview.input_sample_rate() != config.sample_rate
+            || final_model.input_sample_rate() != config.sample_rate
+            || vad.input_sample_rate() != config.sample_rate) {
+            throw std::invalid_argument(
+                "Meeting track models must share the configured sample rate");
+        }
+        if (vad.chunk_size() == 0) {
+            throw std::invalid_argument(
+                "Meeting track VAD chunk size must be positive");
+        }
+        worker = std::thread([this] { worker_loop(); });
+    }
+
+    ~Impl() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            stopping = true;
+            requests.clear();
+            request_cv.notify_all();
+        }
+        if (worker.joinable()) worker.join();
+    }
+
+    void push_audio(
+        const float* samples,
+        std::size_t length,
+        std::int64_t start_time_ns,
+        bool discontinuity) {
+        if ((!samples && length != 0) || start_time_ns < 0) {
+            throw std::invalid_argument(
+                "Meeting track received invalid audio metadata");
+        }
+        for (std::size_t index = 0; index < length; ++index) {
+            if (!std::isfinite(samples[index])) {
+                throw std::invalid_argument(
+                    "Meeting track audio contains NaN or infinity");
+            }
+        }
+        std::lock_guard<std::mutex> lock(mutex);
+        if (discontinuity) reset_locked(false);
+        if (length == 0) return;
+
+        const std::uint64_t first_sample = next_sample;
+        time_segments.push_back({
+            first_sample,
+            static_cast<std::uint64_t>(length),
+            start_time_ns,
+        });
+        ring.insert(ring.end(), samples, samples + length);
+        pending.insert(pending.end(), samples, samples + length);
+        next_sample += static_cast<std::uint64_t>(length);
+        process_vad_locked();
+        prune_ring_locked();
+    }
+
+    void finish() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (speech_active) close_paragraph_locked(true);
+        }
+        wait_idle();
+    }
+
+    void cancel() {
+        std::lock_guard<std::mutex> lock(mutex);
+        reset_locked(false);
+    }
+
+    void wait_idle() {
+        std::unique_lock<std::mutex> lock(mutex);
+        idle_cv.wait(lock, [this] {
+            return requests.empty() && !worker_busy;
+        });
+    }
+
+private:
+    void validate_config() const {
+        if (config.sample_rate <= 0
+            || config.vad_offset < 0.0f
+            || config.vad_onset > 1.0f
+            || config.vad_offset > config.vad_onset
+            || config.minimum_speech_seconds <= 0.0f
+            || config.silence_close_seconds <= 0.0f
+            || config.continuous_update_seconds <= 0.0f
+            || config.maximum_window_seconds
+                < config.continuous_update_seconds) {
+            throw std::invalid_argument(
+                "Meeting track configuration is invalid");
+        }
+    }
+
+    std::uint64_t pending_first_sample_locked() const {
+        return next_sample - static_cast<std::uint64_t>(pending.size());
+    }
+
+    void process_vad_locked() {
+        const std::size_t chunk = vad.chunk_size();
+        while (pending.size() >= chunk) {
+            const std::uint64_t chunk_start =
+                pending_first_sample_locked();
+            const std::uint64_t chunk_end =
+                chunk_start + static_cast<std::uint64_t>(chunk);
+            vad_processed_sample = chunk_end;
+            const float probability =
+                vad.process_chunk(pending.data(), chunk);
+            if (!std::isfinite(probability)) {
+                emit_error_locked(
+                    "Meeting track VAD returned a non-finite probability");
+                reset_locked(false);
+                return;
+            }
+
+            if (!speech_active) {
+                if (probability >= config.vad_onset) {
+                    start_paragraph_locked(chunk_start);
+                    handle_active_chunk_locked(
+                        pending.data(), chunk, chunk_end, probability);
+                }
+            } else {
+                handle_active_chunk_locked(
+                    pending.data(), chunk, chunk_end, probability);
+            }
+            pending.erase(
+                pending.begin(),
+                pending.begin() + static_cast<std::ptrdiff_t>(chunk));
+        }
+    }
+
+    void start_paragraph_locked(std::uint64_t speech_start) {
+        speech_active = true;
+        paragraph_speech_start = speech_start;
+        paragraph_last_voiced_end = speech_start;
+        paragraph_preview.clear();
+        silence_samples = 0;
+        const std::uint64_t pre_roll = seconds_to_samples(
+            config.pre_roll_seconds, config.sample_rate);
+        paragraph_audio_start = speech_start > pre_roll
+            ? speech_start - pre_roll : 0;
+        paragraph_audio_start =
+            std::max(paragraph_audio_start, ring_start_sample);
+        next_continuous_update = speech_start
+            + seconds_to_samples(
+                config.continuous_update_seconds, config.sample_rate);
+        preview.begin_stream(config.sample_rate);
+        const std::vector<float> context = audio_slice_locked(
+            paragraph_audio_start, speech_start);
+        if (!context.empty()) {
+            append_preview_locked(context.data(), context.size());
+        }
+    }
+
+    void handle_active_chunk_locked(
+        const float* samples,
+        std::size_t length,
+        std::uint64_t chunk_end,
+        float probability) {
+        append_preview_locked(samples, length);
+        if (probability >= config.vad_offset) {
+            paragraph_last_voiced_end = chunk_end;
+            silence_samples = 0;
+        } else {
+            silence_samples += length;
+        }
+
+        while (speech_active
+               && chunk_end >= next_continuous_update) {
+            queue_request_locked(
+                next_continuous_update, false, paragraph_preview);
+            next_continuous_update += seconds_to_samples(
+                config.continuous_update_seconds, config.sample_rate);
+        }
+        const std::size_t close_samples = seconds_to_samples(
+            config.silence_close_seconds, config.sample_rate);
+        if (silence_samples >= close_samples) {
+            close_paragraph_locked(false);
+        }
+    }
+
+    void append_preview_locked(
+        const float* samples, std::size_t length) {
+        try {
+            const PartialResult partial =
+                preview.push_chunk(samples, length);
+            const std::string delta = sanitize_preview(partial.text);
+            if (!delta.empty()) paragraph_preview += delta;
+            MeetingTrackEvent event;
+            event.type = MeetingTrackEventType::Preview;
+            event.preview_text = trim(paragraph_preview);
+            emit_unlocked(event);
+        } catch (const std::exception& error) {
+            emit_error_locked(
+                "Meeting track preview failed: "
+                + std::string(error.what()));
+            reset_locked(false);
+        }
+    }
+
+    void close_paragraph_locked(bool forced) {
+        if (!speech_active) return;
+        try {
+            preview.flush_stream();
+            const TranscriptionResult final_preview =
+                preview.end_stream();
+            const std::string full =
+                sanitize_preview(final_preview.text);
+            if (!full.empty()) paragraph_preview = full;
+        } catch (const std::exception& error) {
+            emit_error_locked(
+                "Meeting track preview finalization failed: "
+                + std::string(error.what()));
+            preview.cancel_stream();
+        }
+
+        const std::size_t minimum_samples = seconds_to_samples(
+            config.minimum_speech_seconds, config.sample_rate);
+        const std::uint64_t voiced =
+            paragraph_last_voiced_end > paragraph_speech_start
+            ? paragraph_last_voiced_end - paragraph_speech_start : 0;
+        if (voiced >= minimum_samples) {
+            const std::uint64_t post_roll = seconds_to_samples(
+                config.post_roll_seconds, config.sample_rate);
+            const std::uint64_t available_end =
+                forced ? next_sample : vad_processed_sample;
+            const std::uint64_t audio_end = std::min(
+                available_end,
+                paragraph_last_voiced_end + post_roll);
+            queue_request_locked(
+                audio_end, true, paragraph_preview);
+        }
+        if (paragraph_last_voiced_end > paragraph_speech_start) {
+            previous_completed_speech_start =
+                paragraph_speech_start;
+            previous_completed_speech_end =
+                paragraph_last_voiced_end;
+            has_previous_completed_speech = true;
+        }
+        MeetingTrackEvent clear;
+        clear.type = MeetingTrackEventType::Preview;
+        emit_unlocked(clear);
+        speech_active = false;
+        silence_samples = 0;
+        paragraph_preview.clear();
+        if (forced) pending.clear();
+    }
+
+    void queue_request_locked(
+        std::uint64_t requested_end,
+        bool paragraph_final,
+        const std::string& preview_text) {
+        const std::uint64_t maximum_samples = seconds_to_samples(
+            config.maximum_window_seconds, config.sample_rate);
+        const std::uint64_t window_start = requested_end > maximum_samples
+            ? requested_end - maximum_samples : 0;
+        const std::uint64_t audio_start = std::max(
+            {paragraph_audio_start, window_start, ring_start_sample});
+        const std::uint64_t speech_start = std::max(
+            paragraph_speech_start, audio_start);
+        const std::uint64_t speech_end = std::min(
+            paragraph_last_voiced_end, requested_end);
+        if (speech_end <= speech_start || requested_end <= audio_start) {
+            return;
+        }
+        Request request;
+        request.generation = generation;
+        request.sequence = ++next_sequence;
+        request.audio_start_sample = audio_start;
+        request.audio_start_time_ns =
+            time_for_sample_locked(audio_start);
+        request.speech_start_sample = speech_start;
+        request.speech_end_sample = speech_end;
+        request.audio =
+            audio_slice_locked(audio_start, requested_end);
+        request.preview_text = preview_text;
+        request.paragraph_final = paragraph_final;
+
+        if (!config.microphone
+            && has_previous_completed_speech
+            && previous_completed_speech_end <= speech_start) {
+            const std::uint64_t recovery_samples =
+                seconds_to_samples(
+                    config.activity_recovery_context_seconds,
+                    config.sample_rate);
+            const std::uint64_t maximum_start =
+                requested_end > maximum_samples
+                ? requested_end - maximum_samples : 0;
+            const std::uint64_t context_start =
+                speech_start > recovery_samples
+                ? speech_start - recovery_samples : 0;
+            request.recovery_start_sample = std::max({
+                ring_start_sample,
+                previous_completed_speech_start,
+                maximum_start,
+                context_start,
+            });
+            const std::uint64_t retained_prior =
+                std::min(
+                    previous_completed_speech_end,
+                    speech_start)
+                    > request.recovery_start_sample
+                ? std::min(
+                    previous_completed_speech_end,
+                    speech_start)
+                    - request.recovery_start_sample
+                : 0;
+            const std::uint64_t previous_length =
+                previous_completed_speech_end
+                    - previous_completed_speech_start;
+            const std::uint64_t required_prior = std::min<
+                std::uint64_t>(
+                previous_length,
+                std::max<std::uint64_t>(
+                    1,
+                    seconds_to_samples(
+                        config.pre_roll_seconds,
+                        config.sample_rate)));
+            if (retained_prior >= required_prior
+                && request.recovery_start_sample < audio_start) {
+                request.recovery_start_time_ns =
+                    time_for_sample_locked(
+                        request.recovery_start_sample);
+                request.recovery_audio = audio_slice_locked(
+                    request.recovery_start_sample,
+                    requested_end);
+            }
+        }
+
+        // Source-local requests are serialized in capture order. Earlier
+        // rolling windows carry stable transcript and identity evidence that
+        // a final latest-20-second window cannot reconstruct, so finalization
+        // must not drop them.
+        constexpr std::size_t kMaximumPendingRequests = 8;
+        if (requests.size() >= kMaximumPendingRequests) {
+            emit_error_locked(
+                "Meeting track final inference queue overran");
+            reset_locked(false);
+            return;
+        }
+        requests.push_back(std::move(request));
+        request_cv.notify_one();
+    }
+
+    std::vector<float> audio_slice_locked(
+        std::uint64_t first,
+        std::uint64_t last) const {
+        first = std::max(first, ring_start_sample);
+        last = std::min(last, next_sample);
+        if (last <= first) return {};
+        const std::size_t offset =
+            static_cast<std::size_t>(first - ring_start_sample);
+        const std::size_t count =
+            static_cast<std::size_t>(last - first);
+        if (offset > ring.size() || count > ring.size() - offset) {
+            return {};
+        }
+        return std::vector<float>(
+            ring.begin() + static_cast<std::ptrdiff_t>(offset),
+            ring.begin() + static_cast<std::ptrdiff_t>(offset + count));
+    }
+
+    std::int64_t time_for_sample_locked(
+        std::uint64_t sample) const {
+        for (const auto& segment : time_segments) {
+            if (sample >= segment.first_sample
+                && sample <= segment.first_sample
+                    + segment.sample_count) {
+                const std::uint64_t offset =
+                    sample - segment.first_sample;
+                const long double nanoseconds =
+                    static_cast<long double>(offset)
+                    * 1000000000.0L
+                    / static_cast<long double>(config.sample_rate);
+                return segment.start_time_ns
+                    + static_cast<std::int64_t>(
+                        std::llround(nanoseconds));
+            }
+        }
+        if (!time_segments.empty()) {
+            const auto& segment = time_segments.back();
+            const std::uint64_t end =
+                segment.first_sample + segment.sample_count;
+            if (sample >= end) {
+                const long double nanoseconds =
+                    static_cast<long double>(sample - segment.first_sample)
+                    * 1000000000.0L
+                    / static_cast<long double>(config.sample_rate);
+                return segment.start_time_ns
+                    + static_cast<std::int64_t>(
+                        std::llround(nanoseconds));
+            }
+        }
+        throw std::runtime_error(
+            "Meeting track could not map a sample to capture time");
+    }
+
+    void prune_ring_locked() {
+        const std::uint64_t keep_samples = seconds_to_samples(
+            config.maximum_window_seconds
+                + config.activity_recovery_context_seconds
+                + config.pre_roll_seconds + 2.0f,
+            config.sample_rate);
+        const std::uint64_t protected_start = speech_active
+            ? paragraph_audio_start
+            : (next_sample > keep_samples
+                ? next_sample - keep_samples : 0);
+        const std::uint64_t desired_start = next_sample > keep_samples
+            ? next_sample - keep_samples : 0;
+        const std::uint64_t next_start =
+            std::min(protected_start, desired_start);
+        if (next_start <= ring_start_sample) return;
+        const std::size_t remove = static_cast<std::size_t>(
+            std::min<std::uint64_t>(
+                next_start - ring_start_sample, ring.size()));
+        ring.erase(
+            ring.begin(),
+            ring.begin() + static_cast<std::ptrdiff_t>(remove));
+        ring_start_sample += remove;
+        while (!time_segments.empty()
+               && time_segments.front().first_sample
+                    + time_segments.front().sample_count
+                    < ring_start_sample) {
+            time_segments.pop_front();
+        }
+    }
+
+    void reset_locked(bool preserve_timeline) {
+        ++generation;
+        requests.clear();
+        speech_active = false;
+        silence_samples = 0;
+        paragraph_preview.clear();
+        pending.clear();
+        ring.clear();
+        ring_start_sample = next_sample;
+        time_segments.clear();
+        has_previous_completed_speech = false;
+        previous_completed_speech_start = 0;
+        previous_completed_speech_end = 0;
+        vad.reset();
+        preview.cancel_stream();
+        MeetingTrackEvent clear;
+        clear.type = MeetingTrackEventType::Preview;
+        emit_unlocked(clear);
+        if (!preserve_timeline) {
+            // Absolute sample indices remain monotonic so stale worker results
+            // cannot alias a new recording; generation is the primary guard.
+        }
+    }
+
+    void worker_loop() {
+        for (;;) {
+            Request request;
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                request_cv.wait(lock, [this] {
+                    return stopping || !requests.empty();
+                });
+                if (stopping) return;
+                request = std::move(requests.front());
+                requests.pop_front();
+                worker_busy = true;
+            }
+
+            MeetingTrackEvent event;
+            std::optional<MeetingTrackEvent>
+                following_recovery;
+            const bool may_retry_pending =
+                pending_activity_recovery
+                && pending_activity_recovery->generation
+                    == request.generation
+                && request.speech_start_sample
+                    >= pending_activity_recovery
+                        ->speech_end_sample;
+            try {
+                Request inference_request = request;
+                if (!config.microphone) {
+                    if (worker_evidence_generation
+                        != request.generation) {
+                        worker_evidence_generation =
+                            request.generation;
+                        worker_evidence_through = 0;
+                    }
+                    inference_request
+                        .identity_evidence_start_sample =
+                        std::max(
+                            request.speech_start_sample,
+                            worker_evidence_through);
+                }
+                event = run_request(inference_request);
+                if (may_retry_pending
+                    && event.type
+                        != MeetingTrackEventType::Error) {
+                    following_recovery =
+                        run_following_activity_recovery(
+                            *pending_activity_recovery,
+                            request);
+                }
+            } catch (const std::exception& error) {
+                event.type = MeetingTrackEventType::Error;
+                event.error =
+                    "Meeting track MOSS inference failed: "
+                    + std::string(error.what());
+            }
+
+            bool publish = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                publish = request.generation == generation;
+                worker_busy = false;
+                if (requests.empty()) idle_cv.notify_all();
+            }
+            if (publish
+                && (event.type != MeetingTrackEventType::Revision
+                    || !event.blocks.empty())) {
+                emit_unlocked(event);
+            } else if (publish
+                       && event.type == MeetingTrackEventType::Revision
+                       && request.paragraph_final) {
+                // A confident abstention still clears the revisable caption;
+                // it deliberately does not erase already-published blocks.
+                MeetingTrackEvent clear;
+                clear.type = MeetingTrackEventType::Preview;
+                emit_unlocked(clear);
+            }
+            if (!publish) continue;
+            if (!config.microphone
+                && event.type
+                    == MeetingTrackEventType::Revision
+                && !event.blocks.empty()) {
+                worker_evidence_through = std::max(
+                    worker_evidence_through,
+                    request.speech_end_sample);
+            }
+            if (may_retry_pending) {
+                pending_activity_recovery.reset();
+                if (following_recovery
+                    && !following_recovery->blocks.empty()) {
+                    emit_unlocked(*following_recovery);
+                }
+            } else if (pending_activity_recovery
+                       && pending_activity_recovery->generation
+                            != request.generation) {
+                pending_activity_recovery.reset();
+            }
+            if (request.paragraph_final
+                && event.type
+                    == MeetingTrackEventType::Revision
+                && !event.blocks.empty()
+                && !blocks_contain_activity(event.blocks)
+                && !config.microphone) {
+                pending_activity_recovery =
+                    PendingActivityRecovery{
+                        request.generation,
+                        request.speech_start_sample,
+                        request.speech_end_sample,
+                        event.blocks,
+                    };
+            }
+        }
+    }
+
+    MeetingTrackEvent run_request(const Request& request) {
+        const auto started = Clock::now();
+        DiarizedTranscriptionResult result =
+            final_model.transcribe_diarized(
+                request.audio.data(),
+                request.audio.size(),
+                config.sample_rate);
+        if (result.text.empty() || has_wire_control(result.text)) {
+            return revision_base(request, elapsed_ms(started));
+        }
+
+        std::vector<DiarizedTranscriptionSegment> segments =
+            result.segments;
+        if (segments.empty() && !config.microphone
+            && !request.recovery_audio.empty()) {
+            const auto recovered = final_model.transcribe_diarized(
+                request.recovery_audio.data(),
+                request.recovery_audio.size(),
+                config.sample_rate);
+            std::string current_text;
+            std::vector<DiarizedTranscriptionSegment>
+                current_segments;
+            const double current_start_seconds =
+                static_cast<double>(
+                    request.speech_start_sample
+                    - request.recovery_start_sample)
+                / config.sample_rate;
+            const double current_end_seconds =
+                static_cast<double>(
+                    request.speech_end_sample
+                    - request.recovery_start_sample)
+                / config.sample_rate;
+            for (const auto& segment : recovered.segments) {
+                if (segment.end_time <= current_start_seconds
+                    || segment.start_time >= current_end_seconds) {
+                    continue;
+                }
+                current_segments.push_back(segment);
+                if (!current_text.empty()) current_text.push_back(' ');
+                current_text += segment.text;
+            }
+            if (!current_segments.empty()
+                && activity_recovery_compatible(
+                    current_text, result.text)) {
+                const double shift = static_cast<double>(
+                    request.audio_start_sample
+                    - request.recovery_start_sample)
+                    / config.sample_rate;
+                for (auto& segment : current_segments) {
+                    segment.start_time -= static_cast<float>(shift);
+                    segment.end_time -= static_cast<float>(shift);
+                }
+                segments = std::move(current_segments);
+            }
+        }
+
+        MeetingTrackEvent event =
+            revision_base(request, elapsed_ms(started));
+        if (segments.empty()) {
+            const std::uint64_t voiced_samples =
+                request.speech_end_sample
+                    - request.speech_start_sample;
+            if (config.microphone
+                && voiced_samples < seconds_to_samples(
+                    config.microphone_short_agreement_seconds,
+                    config.sample_rate)
+                && !short_microphone_agrees(
+                    result.text, request.preview_text, 0, 1)) {
+                return event;
+            }
+            MeetingTranscriptBlock block;
+            block.start_time_ns = map_request_time(
+                request, request.speech_start_sample);
+            block.end_time_ns = map_request_time(
+                request, request.speech_end_sample);
+            block.text = trim(result.text);
+            event.blocks.push_back(std::move(block));
+            return event;
+        }
+
+        struct Candidate {
+            std::uint64_t start = 0;
+            std::uint64_t end = 0;
+            std::string speaker;
+            std::string text;
+        };
+        std::vector<Candidate> candidates;
+        for (const auto& segment : segments) {
+            const auto relative_start =
+                static_cast<std::int64_t>(std::llround(
+                    static_cast<double>(segment.start_time)
+                    * config.sample_rate));
+            const auto relative_end =
+                static_cast<std::int64_t>(std::llround(
+                    static_cast<double>(segment.end_time)
+                    * config.sample_rate));
+            const std::uint64_t start = std::clamp<std::uint64_t>(
+                relative_start > 0
+                    ? request.audio_start_sample
+                        + static_cast<std::uint64_t>(relative_start)
+                    : request.audio_start_sample,
+                request.speech_start_sample,
+                request.speech_end_sample);
+            const std::uint64_t end = std::clamp<std::uint64_t>(
+                relative_end > 0
+                    ? request.audio_start_sample
+                        + static_cast<std::uint64_t>(relative_end)
+                    : request.audio_start_sample,
+                request.speech_start_sample,
+                request.speech_end_sample);
+            const std::string text = trim(segment.text);
+            if (end > start && !text.empty()
+                && !has_wire_control(text)) {
+                candidates.push_back({
+                    start, end, segment.speaker, text,
+                });
+            }
+        }
+
+        for (std::size_t index = 0; index < candidates.size(); ++index) {
+            const auto& candidate = candidates[index];
+            if (config.microphone
+                && candidate.end - candidate.start
+                    < seconds_to_samples(
+                        config.microphone_short_agreement_seconds,
+                        config.sample_rate)
+                && !short_microphone_agrees(
+                    candidate.text,
+                    request.preview_text,
+                    index,
+                    candidates.size())) {
+                continue;
+            }
+            bool overlaps = false;
+            for (std::size_t other = 0;
+                 other < candidates.size(); ++other) {
+                if (other == index) continue;
+                overlaps = candidate.start < candidates[other].end
+                    && candidates[other].start < candidate.end;
+                if (overlaps) break;
+            }
+            MeetingTranscriptBlock block;
+            block.start_time_ns =
+                map_request_time(request, candidate.start);
+            block.end_time_ns =
+                map_request_time(request, candidate.end);
+            block.text = candidate.text;
+            if (!config.microphone) {
+                block.activity_label = candidate.speaker;
+            }
+            if (!config.microphone && !overlaps) {
+                const std::size_t first = static_cast<std::size_t>(
+                    std::max(
+                        candidate.start,
+                        request.identity_evidence_start_sample)
+                    - request.audio_start_sample);
+                const std::size_t last = static_cast<std::size_t>(
+                    candidate.end - request.audio_start_sample);
+                if (last <= request.audio.size() && last > first) {
+                    block.identity_audio.assign(
+                        request.audio.begin()
+                            + static_cast<std::ptrdiff_t>(first),
+                        request.audio.begin()
+                            + static_cast<std::ptrdiff_t>(last));
+                }
+            }
+            event.blocks.push_back(std::move(block));
+        }
+        return event;
+    }
+
+    static bool blocks_contain_activity(
+        const std::vector<MeetingTranscriptBlock>& blocks) {
+        return std::any_of(
+            blocks.begin(), blocks.end(),
+            [](const auto& block) {
+                return !trim(block.activity_label).empty();
+            });
+    }
+
+    static bool following_recovery_compatible(
+        const std::vector<MeetingTranscriptBlock>& original,
+        const std::vector<MeetingTranscriptBlock>& recovered) {
+        if (original.empty()
+            || blocks_contain_activity(original)
+            || !blocks_contain_activity(recovered)) {
+            return false;
+        }
+        std::string original_text;
+        for (const auto& block : original) {
+            if (!original_text.empty()) {
+                original_text.push_back(' ');
+            }
+            original_text += block.text;
+        }
+        std::string activity_text;
+        for (const auto& block : recovered) {
+            if (trim(block.activity_label).empty()) continue;
+            if (!activity_text.empty()) {
+                activity_text.push_back(' ');
+            }
+            activity_text += block.text;
+        }
+        const auto original_words =
+            normalized_tokens(original_text);
+        const auto activity_words =
+            normalized_tokens(activity_text);
+        if (original_words.empty()
+            || activity_words.size()
+                < original_words.size()) {
+            return false;
+        }
+        const std::vector<std::string> prefix(
+            activity_words.begin(),
+            activity_words.begin()
+                + static_cast<std::ptrdiff_t>(
+                    original_words.size()));
+        return text_similarity(
+            original_words, prefix) >= 0.80;
+    }
+
+    std::optional<MeetingTrackEvent>
+    run_following_activity_recovery(
+        const PendingActivityRecovery& pending_recovery,
+        const Request& current) {
+        if (current.recovery_audio.empty()
+            || current.recovery_start_sample
+                > pending_recovery.speech_start_sample
+            || current.speech_start_sample
+                < pending_recovery.speech_end_sample) {
+            return std::nullopt;
+        }
+        const std::uint64_t pre_roll = seconds_to_samples(
+            config.pre_roll_seconds, config.sample_rate);
+        const std::uint64_t context = seconds_to_samples(
+            config.activity_recovery_context_seconds,
+            config.sample_rate);
+        const std::uint64_t maximum = seconds_to_samples(
+            config.maximum_window_seconds,
+            config.sample_rate);
+        const std::uint64_t desired_start =
+            pending_recovery.speech_start_sample > pre_roll
+            ? pending_recovery.speech_start_sample - pre_roll
+            : 0;
+        const std::uint64_t start = std::max(
+            desired_start, current.recovery_start_sample);
+        const std::uint64_t available_end =
+            current.recovery_start_sample
+            + static_cast<std::uint64_t>(
+                current.recovery_audio.size());
+        const std::uint64_t context_end =
+            pending_recovery.speech_end_sample
+                > std::numeric_limits<std::uint64_t>::max()
+                    - context
+            ? std::numeric_limits<std::uint64_t>::max()
+            : pending_recovery.speech_end_sample + context;
+        const std::uint64_t window_end =
+            start > std::numeric_limits<std::uint64_t>::max()
+                    - maximum
+            ? std::numeric_limits<std::uint64_t>::max()
+            : start + maximum;
+        const std::uint64_t end = std::min({
+            available_end,
+            context_end,
+            window_end,
+        });
+        const std::uint64_t following_end =
+            std::min(end, current.speech_end_sample);
+        const std::uint64_t current_length =
+            current.speech_end_sample
+                - current.speech_start_sample;
+        const std::uint64_t required_following = std::min<
+            std::uint64_t>(
+            current_length,
+            std::max<std::uint64_t>(1, pre_roll));
+        if (start > pending_recovery.speech_start_sample
+            || end < pending_recovery.speech_end_sample
+            || following_end <= current.speech_start_sample
+            || following_end - current.speech_start_sample
+                < required_following) {
+            return std::nullopt;
+        }
+
+        const std::size_t first =
+            static_cast<std::size_t>(
+                start - current.recovery_start_sample);
+        const std::size_t last =
+            static_cast<std::size_t>(
+                end - current.recovery_start_sample);
+        if (last > current.recovery_audio.size()
+            || first >= last) {
+            return std::nullopt;
+        }
+        Request retry;
+        retry.generation = current.generation;
+        retry.sequence = current.sequence;
+        retry.audio_start_sample = start;
+        const long double offset_ns =
+            static_cast<long double>(
+                start - current.recovery_start_sample)
+            * 1000000000.0L
+            / static_cast<long double>(config.sample_rate);
+        retry.audio_start_time_ns =
+            current.recovery_start_time_ns
+            + static_cast<std::int64_t>(
+                std::llround(offset_ns));
+        retry.speech_start_sample =
+            pending_recovery.speech_start_sample;
+        retry.speech_end_sample =
+            pending_recovery.speech_end_sample;
+        retry.identity_evidence_start_sample =
+            pending_recovery.speech_start_sample;
+        retry.audio.assign(
+            current.recovery_audio.begin()
+                + static_cast<std::ptrdiff_t>(first),
+            current.recovery_audio.begin()
+                + static_cast<std::ptrdiff_t>(last));
+        retry.paragraph_final = true;
+
+        MeetingTrackEvent recovered = run_request(retry);
+        if (!following_recovery_compatible(
+                pending_recovery.blocks,
+                recovered.blocks)) {
+            return std::nullopt;
+        }
+        return recovered;
+    }
+
+    MeetingTrackEvent revision_base(
+        const Request& request, double final_ms) const {
+        MeetingTrackEvent event;
+        event.type = MeetingTrackEventType::Revision;
+        event.replace_start_time_ns =
+            map_request_time(request, request.speech_start_sample);
+        event.replace_end_time_ns =
+            map_request_time(request, request.speech_end_sample);
+        event.paragraph_final = request.paragraph_final;
+        event.final_asr_ms = final_ms;
+        return event;
+    }
+
+    std::int64_t map_request_time(
+        const Request& request,
+        std::uint64_t sample) const {
+        const std::uint64_t offset =
+            sample > request.audio_start_sample
+            ? sample - request.audio_start_sample : 0;
+        const long double nanoseconds =
+            static_cast<long double>(offset)
+            * 1000000000.0L
+            / static_cast<long double>(config.sample_rate);
+        return request.audio_start_time_ns
+            + static_cast<std::int64_t>(std::llround(nanoseconds));
+    }
+
+    void emit_error_locked(const std::string& text) {
+        MeetingTrackEvent event;
+        event.type = MeetingTrackEventType::Error;
+        event.error = text;
+        emit_unlocked(event);
+    }
+
+    void emit_unlocked(const MeetingTrackEvent& event) const {
+        if (callback) callback(event);
+    }
+
+    STTInterface& preview;
+    TranscribeDiarizeInterface& final_model;
+    VADInterface& vad;
+    Config config;
+    EventCallback callback;
+
+    mutable std::mutex mutex;
+    std::condition_variable request_cv;
+    std::condition_variable idle_cv;
+    std::thread worker;
+    bool stopping = false;
+    bool worker_busy = false;
+    std::deque<Request> requests;
+    std::uint64_t generation = 1;
+    std::uint64_t next_sequence = 0;
+
+    std::vector<float> ring;
+    std::uint64_t ring_start_sample = 0;
+    std::uint64_t next_sample = 0;
+    std::uint64_t vad_processed_sample = 0;
+    std::deque<TimeSegment> time_segments;
+    std::vector<float> pending;
+
+    bool speech_active = false;
+    std::uint64_t paragraph_audio_start = 0;
+    std::uint64_t paragraph_speech_start = 0;
+    std::uint64_t paragraph_last_voiced_end = 0;
+    std::uint64_t next_continuous_update = 0;
+    std::size_t silence_samples = 0;
+    std::string paragraph_preview;
+    bool has_previous_completed_speech = false;
+    std::uint64_t previous_completed_speech_start = 0;
+    std::uint64_t previous_completed_speech_end = 0;
+    std::optional<PendingActivityRecovery>
+        pending_activity_recovery;
+    std::uint64_t worker_evidence_generation = 0;
+    std::uint64_t worker_evidence_through = 0;
+};
+
+MeetingTranscriptionTrack::MeetingTranscriptionTrack(
+    STTInterface& preview,
+    TranscribeDiarizeInterface& final_model,
+    VADInterface& vad,
+    Config config,
+    EventCallback callback)
+    : impl_(std::make_unique<Impl>(
+        preview,
+        final_model,
+        vad,
+        config,
+        std::move(callback))) {}
+
+MeetingTranscriptionTrack::~MeetingTranscriptionTrack() = default;
+
+void MeetingTranscriptionTrack::push_audio(
+    const float* samples,
+    std::size_t length,
+    std::int64_t start_time_ns,
+    bool discontinuity) {
+    impl_->push_audio(
+        samples, length, start_time_ns, discontinuity);
+}
+
+void MeetingTranscriptionTrack::finish() {
+    impl_->finish();
+}
+
+void MeetingTranscriptionTrack::cancel() {
+    impl_->cancel();
+}
+
+void MeetingTranscriptionTrack::wait_idle() {
+    impl_->wait_idle();
+}
+
+}  // namespace speech_core

--- a/src/pipeline/recording_speaker_identity.cpp
+++ b/src/pipeline/recording_speaker_identity.cpp
@@ -1,0 +1,678 @@
+#include "speech_core/pipeline/recording_speaker_identity.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace speech_core {
+namespace {
+
+std::vector<float> normalized(std::vector<float> value) {
+    double squared = 0.0;
+    for (float item : value) {
+        if (!std::isfinite(item)) return {};
+        squared += static_cast<double>(item) * item;
+    }
+    const double norm = std::sqrt(squared);
+    if (!std::isfinite(norm) || norm <= 1e-8) return {};
+    for (float& item : value) {
+        item = static_cast<float>(item / norm);
+    }
+    return value;
+}
+
+float cosine(
+    const std::vector<float>& left,
+    const std::vector<float>& right) {
+    if (left.empty() || left.size() != right.size()) return -1.0f;
+    double score = 0.0;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        score += static_cast<double>(left[index]) * right[index];
+    }
+    return static_cast<float>(score);
+}
+
+bool same_label(const std::string& left, const std::string& right) {
+    return left == right;
+}
+
+bool contains_label(
+    const std::vector<std::string>& labels,
+    const std::string& candidate) {
+    return std::any_of(
+        labels.begin(), labels.end(),
+        [&](const std::string& value) {
+            return same_label(value, candidate);
+        });
+}
+
+std::size_t seconds_to_samples(float seconds, int sample_rate) {
+    return static_cast<std::size_t>(std::llround(
+        static_cast<double>(seconds) * sample_rate));
+}
+
+}  // namespace
+
+struct RecordingSpeakerIdentity::SessionVoice {
+    std::string label;
+    std::vector<float> centroid;
+    std::size_t sample_count = 1;
+    std::uint64_t last_match_tick = 0;
+    bool recording_local = false;
+};
+
+struct RecordingSpeakerIdentity::GroupEvidence {
+    std::string activity_label;
+    std::vector<std::size_t> block_indices;
+    std::vector<float> audio;
+    std::vector<SpeakerIdentityBackfill> ranges;
+    std::uint64_t paragraph = 0;
+};
+
+struct RecordingSpeakerIdentity::GalleryCandidate {
+    struct Fragment {
+        std::vector<float> audio;
+        std::vector<float> embedding;
+        std::vector<SpeakerIdentityBackfill> ranges;
+        std::uint64_t paragraph = 0;
+        std::string activity_label;
+    };
+
+    std::vector<float> centroid;
+    std::vector<Fragment> fragments;
+    std::map<std::uint64_t, std::string> paragraph_labels;
+    std::uint64_t last_tick = 0;
+};
+
+RecordingSpeakerIdentity::~RecordingSpeakerIdentity() = default;
+
+RecordingSpeakerIdentity::RecordingSpeakerIdentity(
+    EmbeddingInterface& embedder)
+    : RecordingSpeakerIdentity(embedder, Config{}) {}
+
+RecordingSpeakerIdentity::RecordingSpeakerIdentity(
+    EmbeddingInterface& embedder,
+    Config config)
+    : embedder_(embedder), config_(config) {
+    if (config.sample_rate <= 0
+        || config.minimum_short_seconds <= 0.0f
+        || config.minimum_long_seconds
+            < config.minimum_short_seconds
+        || config.novelty_threshold > config.match_threshold
+        || config.gallery_minimum_fragments < 3
+        || config.maximum_session_speakers == 0
+        || config.maximum_gallery_candidates == 0
+        || config.maximum_gallery_fragments
+            < config.gallery_minimum_fragments
+        || embedder.input_sample_rate() != config.sample_rate
+        || embedder.embedding_dim() <= 0) {
+        throw std::invalid_argument(
+            "Recording speaker-identity configuration is invalid");
+    }
+}
+
+void RecordingSpeakerIdentity::set_profiles(
+    std::vector<StoredSpeakerIdentityProfile> profiles) {
+    std::vector<StoredSpeakerIdentityProfile> accepted;
+    accepted.reserve(profiles.size());
+    for (auto& profile : profiles) {
+        profile.embedding = normalized(
+            std::move(profile.embedding));
+        if (profile.name.empty()
+            || profile.embedding.size()
+                != static_cast<std::size_t>(
+                    embedder_.embedding_dim())) {
+            throw std::invalid_argument(
+                "Stored speaker profile is invalid");
+        }
+        if (std::any_of(
+                accepted.begin(), accepted.end(),
+                [&](const auto& existing) {
+                    return same_label(
+                        existing.name, profile.name);
+                })) {
+            throw std::invalid_argument(
+                "Stored speaker profile names are not unique");
+        }
+        profile.sample_count =
+            std::max<std::size_t>(1, profile.sample_count);
+        accepted.push_back(std::move(profile));
+    }
+    profiles_ = std::move(accepted);
+}
+
+void RecordingSpeakerIdentity::begin_recording() {
+    session_voices_.clear();
+    gallery_.clear();
+    paragraph_sequence_ = 0;
+    gallery_tick_ = 0;
+    next_session_label_ = 1;
+}
+
+SpeakerIdentityResolution RecordingSpeakerIdentity::resolve(
+    const std::vector<MeetingTranscriptBlock>& blocks) {
+    SpeakerIdentityResolution resolution;
+    resolution.speakers.resize(blocks.size());
+    const std::uint64_t paragraph = ++paragraph_sequence_;
+
+    std::vector<GroupEvidence> groups;
+    std::unordered_map<std::string, std::size_t> group_index;
+    for (std::size_t index = 0; index < blocks.size(); ++index) {
+        const auto& block = blocks[index];
+        if (block.activity_label.empty()) continue;
+        auto [iterator, inserted] = group_index.emplace(
+            block.activity_label, groups.size());
+        if (inserted) {
+            groups.push_back({
+                block.activity_label, {}, {}, {}, paragraph,
+            });
+        }
+        auto& group = groups[iterator->second];
+        group.block_indices.push_back(index);
+        group.audio.insert(
+            group.audio.end(),
+            block.identity_audio.begin(),
+            block.identity_audio.end());
+        group.ranges.push_back({
+            block.start_time_ns,
+            block.end_time_ns,
+            block.text,
+            {},
+        });
+    }
+
+    struct EmbeddedGroup {
+        std::size_t index = 0;
+        std::vector<float> embedding;
+        bool long_form = false;
+        float existing_confidence = -1.0f;
+    };
+    std::vector<EmbeddedGroup> embedded;
+    const std::size_t short_minimum = seconds_to_samples(
+        config_.minimum_short_seconds, config_.sample_rate);
+    const std::size_t long_minimum = seconds_to_samples(
+        config_.minimum_long_seconds, config_.sample_rate);
+    for (std::size_t index = 0; index < groups.size(); ++index) {
+        const auto& audio = groups[index].audio;
+        if (audio.size() < short_minimum) continue;
+        const bool long_form = audio.size() >= long_minimum;
+        std::vector<float> vector = long_form
+            ? embedder_.embed(
+                audio.data(), audio.size(), config_.sample_rate)
+            : embedder_.embed_short_utterance(
+                audio.data(), audio.size(), config_.sample_rate);
+        vector = normalized(std::move(vector));
+        if (vector.size()
+            != static_cast<std::size_t>(
+                embedder_.embedding_dim())) {
+            continue;
+        }
+        float confidence = -1.0f;
+        for (const auto& profile : profiles_) {
+            confidence = std::max(
+                confidence,
+                cosine(profile.embedding, vector));
+        }
+        for (const auto& session : session_voices_) {
+            confidence = std::max(
+                confidence,
+                cosine(session.centroid, vector));
+        }
+        embedded.push_back({
+            index,
+            std::move(vector),
+            long_form,
+            confidence,
+        });
+    }
+    std::stable_sort(
+        embedded.begin(), embedded.end(),
+        [](const auto& left, const auto& right) {
+            return left.existing_confidence
+                > right.existing_confidence;
+        });
+
+    std::vector<std::string> claimed;
+    for (const auto& item : embedded) {
+        auto& group = groups[item.index];
+        std::optional<std::string> speaker =
+            item.long_form
+            ? resolve_long(item.embedding, claimed)
+            : resolve_short(item.embedding, claimed);
+        if (speaker) {
+            claimed.push_back(*speaker);
+            for (std::size_t block : group.block_indices) {
+                resolution.speakers[block] = *speaker;
+            }
+        } else if (!item.long_form) {
+            add_gallery_evidence(
+                group,
+                item.embedding,
+                claimed,
+                resolution,
+                item.index);
+            const auto assigned =
+                resolution.speakers[group.block_indices.front()];
+            if (assigned) claimed.push_back(*assigned);
+        }
+    }
+    return resolution;
+}
+
+std::optional<std::string>
+RecordingSpeakerIdentity::resolve_long(
+    const std::vector<float>& embedding,
+    const std::vector<std::string>& claimed) {
+    enum class Kind { Profile, Session };
+    struct Candidate {
+        Kind kind;
+        std::size_t index;
+        std::string label;
+        float score;
+    };
+    std::vector<Candidate> candidates;
+    for (std::size_t index = 0; index < profiles_.size(); ++index) {
+        candidates.push_back({
+            Kind::Profile,
+            index,
+            profiles_[index].name,
+            cosine(profiles_[index].embedding, embedding),
+        });
+    }
+    for (std::size_t index = 0;
+         index < session_voices_.size(); ++index) {
+        candidates.push_back({
+            Kind::Session,
+            index,
+            session_voices_[index].label,
+            cosine(session_voices_[index].centroid, embedding),
+        });
+    }
+    std::sort(
+        candidates.begin(), candidates.end(),
+        [](const auto& left, const auto& right) {
+            if (left.score == right.score) {
+                return left.label < right.label;
+            }
+            return left.score > right.score;
+        });
+    const auto best_overall =
+        candidates.empty()
+        ? candidates.end() : candidates.begin();
+    const auto best = std::find_if(
+        candidates.begin(), candidates.end(),
+        [&](const auto& candidate) {
+            return !contains_label(claimed, candidate.label);
+        });
+    const bool excluded_conflict =
+        best_overall != candidates.end()
+        && contains_label(claimed, best_overall->label)
+        && best_overall->score >= config_.match_threshold;
+
+    if (best != candidates.end()) {
+        const auto competitor = std::find_if(
+            std::next(best), candidates.end(),
+            [&](const auto& candidate) {
+                return !contains_label(
+                    claimed, candidate.label)
+                    && !same_label(
+                        candidate.label, best->label);
+            });
+        const bool margin_ok =
+            competitor == candidates.end()
+            || best->score - competitor->score
+                >= config_.ambiguity_margin;
+        if (best->score >= config_.match_threshold
+            && margin_ok) {
+            std::string label = best->label;
+            if (best->kind == Kind::Profile) {
+                auto existing = std::find_if(
+                    session_voices_.begin(),
+                    session_voices_.end(),
+                    [&](const auto& voice) {
+                        return same_label(
+                            voice.label, label);
+                    });
+                if (existing == session_voices_.end()) {
+                    session_voices_.push_back({
+                        label, embedding, 1, ++gallery_tick_, false,
+                    });
+                }
+            } else {
+                auto& voice = session_voices_[best->index];
+                const std::size_t previous =
+                    std::min<std::size_t>(
+                        voice.sample_count, 20);
+                std::vector<float> merged(
+                    embedding.size(), 0.0f);
+                for (std::size_t index = 0;
+                     index < embedding.size(); ++index) {
+                    merged[index] = static_cast<float>(
+                        (static_cast<double>(
+                             voice.centroid[index])
+                             * previous
+                         + embedding[index])
+                        / static_cast<double>(
+                            previous + 1));
+                }
+                voice.centroid = normalized(
+                    std::move(merged));
+                voice.sample_count = previous + 1;
+                voice.last_match_tick = ++gallery_tick_;
+            }
+            return label;
+        }
+    }
+
+    const bool novel =
+        candidates.empty()
+        || (best != candidates.end()
+            && best->score < config_.novelty_threshold);
+    if (!novel && !excluded_conflict) return std::nullopt;
+    if (session_voices_.size()
+        >= config_.maximum_session_speakers) {
+        const auto evict = std::min_element(
+            session_voices_.begin(),
+            session_voices_.end(),
+            [](const auto& left, const auto& right) {
+                const bool left_temporary =
+                    left.recording_local;
+                const bool right_temporary =
+                    right.recording_local;
+                if (left_temporary != right_temporary) {
+                    return left_temporary;
+                }
+                return left.last_match_tick
+                    < right.last_match_tick;
+            });
+        if (evict == session_voices_.end()
+            || !evict->recording_local) {
+            return std::nullopt;
+        }
+        session_voices_.erase(evict);
+    }
+    std::string label;
+    do {
+        label = "S" + std::to_string(next_session_label_++);
+    } while (has_profile(label)
+             || std::any_of(
+                 session_voices_.begin(),
+                 session_voices_.end(),
+                 [&](const auto& voice) {
+                     return same_label(voice.label, label);
+                 }));
+    session_voices_.push_back({
+        label, embedding, 1, ++gallery_tick_, true,
+    });
+    return label;
+}
+
+std::optional<std::string>
+RecordingSpeakerIdentity::resolve_short(
+    const std::vector<float>& embedding,
+    const std::vector<std::string>& claimed) const {
+    struct Candidate {
+        std::string label;
+        float score = -1.0f;
+        float threshold = 1.0f;
+        float margin = 1.0f;
+    };
+    std::vector<Candidate> candidates;
+    for (const auto& profile : profiles_) {
+        candidates.push_back({
+            profile.name,
+            cosine(profile.embedding, embedding),
+            config_.global_short_threshold,
+            config_.global_short_margin,
+        });
+    }
+    for (const auto& session : session_voices_) {
+        candidates.push_back({
+            session.label,
+            cosine(session.centroid, embedding),
+            config_.recording_short_threshold,
+            config_.recording_short_margin,
+        });
+    }
+    std::sort(
+        candidates.begin(), candidates.end(),
+        [](const auto& left, const auto& right) {
+            if (left.score == right.score) {
+                return left.label < right.label;
+            }
+            return left.score > right.score;
+        });
+    const auto best = std::find_if(
+        candidates.begin(), candidates.end(),
+        [&](const auto& candidate) {
+            return !contains_label(claimed, candidate.label);
+        });
+    if (best == candidates.end()
+        || best->score < best->threshold) {
+        return std::nullopt;
+    }
+    const auto competitor = std::find_if(
+        std::next(best), candidates.end(),
+        [&](const auto& candidate) {
+            return !contains_label(claimed, candidate.label)
+                && !same_label(
+                    candidate.label, best->label);
+        });
+    if (competitor != candidates.end()
+        && best->score - competitor->score < best->margin) {
+        return std::nullopt;
+    }
+    return best->label;
+}
+
+void RecordingSpeakerIdentity::add_gallery_evidence(
+    const GroupEvidence& group,
+    const std::vector<float>& embedding,
+    const std::vector<std::string>& claimed,
+    SpeakerIdentityResolution& resolution,
+    std::size_t /*group_index*/) {
+    struct Match {
+        std::size_t index = 0;
+        float score = -1.0f;
+    };
+    std::vector<Match> matches;
+    for (std::size_t index = 0; index < gallery_.size(); ++index) {
+        const auto paragraph =
+            gallery_[index].paragraph_labels.find(group.paragraph);
+        if (paragraph
+            != gallery_[index].paragraph_labels.end()
+            && paragraph->second != group.activity_label) {
+            continue;
+        }
+        matches.push_back({
+            index,
+            cosine(gallery_[index].centroid, embedding),
+        });
+    }
+    std::sort(
+        matches.begin(), matches.end(),
+        [](const auto& left, const auto& right) {
+            return left.score > right.score;
+        });
+
+    std::optional<std::size_t> selected;
+    if (!matches.empty()) {
+        const auto& best = matches.front();
+        const auto& candidate = gallery_[best.index];
+        const float threshold =
+            candidate.fragments.size() == 1
+            ? config_.gallery_bootstrap_threshold
+            : config_.gallery_support_threshold;
+        const bool margin_ok =
+            matches.size() == 1
+            || best.score - matches[1].score
+                >= config_.gallery_support_margin;
+        if (best.score >= threshold && margin_ok) {
+            selected = best.index;
+        }
+    }
+    if (!selected) {
+        if (gallery_.size()
+            >= config_.maximum_gallery_candidates) {
+            const auto oldest = std::min_element(
+                gallery_.begin(), gallery_.end(),
+                [](const auto& left, const auto& right) {
+                    return left.last_tick < right.last_tick;
+                });
+            gallery_.erase(oldest);
+        }
+        GalleryCandidate candidate;
+        candidate.centroid = embedding;
+        candidate.last_tick = ++gallery_tick_;
+        gallery_.push_back(std::move(candidate));
+        selected = gallery_.size() - 1;
+    }
+
+    auto& candidate = gallery_[*selected];
+    if (candidate.fragments.size()
+        >= config_.maximum_gallery_fragments) {
+        candidate.fragments.erase(
+            candidate.fragments.begin());
+    }
+    candidate.fragments.push_back({
+        group.audio,
+        embedding,
+        group.ranges,
+        group.paragraph,
+        group.activity_label,
+    });
+    candidate.paragraph_labels[group.paragraph] =
+        group.activity_label;
+    std::vector<float> centroid(
+        embedding.size(), 0.0f);
+    for (const auto& fragment : candidate.fragments) {
+        for (std::size_t index = 0;
+             index < centroid.size(); ++index) {
+            centroid[index] += fragment.embedding[index];
+        }
+    }
+    candidate.centroid = normalized(std::move(centroid));
+    candidate.last_tick = ++gallery_tick_;
+
+    std::size_t combined_samples = 0;
+    for (const auto& fragment : candidate.fragments) {
+        combined_samples += fragment.audio.size();
+    }
+    if (candidate.fragments.size()
+            < config_.gallery_minimum_fragments
+        || combined_samples < seconds_to_samples(
+            config_.minimum_long_seconds,
+            config_.sample_rate)) {
+        return;
+    }
+    std::vector<float> combined;
+    combined.reserve(combined_samples);
+    for (const auto& fragment : candidate.fragments) {
+        combined.insert(
+            combined.end(),
+            fragment.audio.begin(),
+            fragment.audio.end());
+    }
+    std::vector<float> long_embedding = normalized(
+        embedder_.embed(
+            combined.data(),
+            combined.size(),
+            config_.sample_rate));
+    if (long_embedding.size()
+        != static_cast<std::size_t>(
+            embedder_.embedding_dim())) {
+        return;
+    }
+    const auto speaker = resolve_long(
+        long_embedding, claimed);
+    if (!speaker) return;
+
+    for (const auto& fragment : candidate.fragments) {
+        for (auto range : fragment.ranges) {
+            range.speaker = *speaker;
+            resolution.backfills.push_back(std::move(range));
+        }
+    }
+    for (std::size_t block : group.block_indices) {
+        resolution.speakers[block] = *speaker;
+    }
+    gallery_.erase(
+        gallery_.begin()
+        + static_cast<std::ptrdiff_t>(*selected));
+}
+
+bool RecordingSpeakerIdentity::promote_recording_identity(
+    const std::string& label,
+    const std::string& name) {
+    if (name.empty()) {
+        throw std::invalid_argument(
+            "Speaker profile name must not be empty");
+    }
+    const auto voice = std::find_if(
+        session_voices_.begin(), session_voices_.end(),
+        [&](const auto& value) {
+            return same_label(value.label, label);
+        });
+    if (voice == session_voices_.end()) return false;
+    upsert_profile(
+        name, voice->centroid, voice->sample_count);
+    voice->label = name;
+    voice->recording_local = false;
+    return true;
+}
+
+void RecordingSpeakerIdentity::upsert_profile(
+    const std::string& name,
+    const std::vector<float>& embedding,
+    std::size_t sample_count) {
+    std::vector<float> value = normalized(embedding);
+    if (name.empty()
+        || value.size()
+            != static_cast<std::size_t>(
+                embedder_.embedding_dim())) {
+        throw std::invalid_argument(
+            "Speaker profile is invalid");
+    }
+    const auto existing = std::find_if(
+        profiles_.begin(), profiles_.end(),
+        [&](const auto& profile) {
+            return same_label(profile.name, name);
+        });
+    if (existing == profiles_.end()) {
+        profiles_.push_back({
+            name, std::move(value),
+            std::max<std::size_t>(1, sample_count),
+        });
+    } else {
+        existing->embedding = std::move(value);
+        existing->sample_count =
+            std::max<std::size_t>(1, sample_count);
+    }
+}
+
+bool RecordingSpeakerIdentity::delete_profile(
+    const std::string& name) {
+    const auto iterator = std::find_if(
+        profiles_.begin(), profiles_.end(),
+        [&](const auto& profile) {
+            return same_label(profile.name, name);
+        });
+    if (iterator == profiles_.end()) return false;
+    profiles_.erase(iterator);
+    return true;
+}
+
+bool RecordingSpeakerIdentity::has_profile(
+    const std::string& name) const {
+    return std::any_of(
+        profiles_.begin(), profiles_.end(),
+        [&](const auto& profile) {
+            return same_label(profile.name, name);
+        });
+}
+
+}  // namespace speech_core

--- a/src/pipeline/timestamped_echo_cancellation_stream.cpp
+++ b/src/pipeline/timestamped_echo_cancellation_stream.cpp
@@ -1,0 +1,820 @@
+#include "speech_core/pipeline/timestamped_echo_cancellation_stream.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+namespace speech_core {
+namespace {
+
+std::int64_t steady_time_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+std::int64_t duration_to_samples(
+    std::int64_t duration_ns, int sample_rate) {
+    const long double samples =
+        static_cast<long double>(duration_ns)
+        * static_cast<long double>(sample_rate)
+        / 1000000000.0L;
+    if (!std::isfinite(samples)
+        || samples < static_cast<long double>(
+            std::numeric_limits<std::int64_t>::min())
+        || samples > static_cast<long double>(
+            std::numeric_limits<std::int64_t>::max())) {
+        throw std::overflow_error(
+            "Echo-cancellation timestamp cannot map to a sample clock");
+    }
+    return static_cast<std::int64_t>(std::llround(samples));
+}
+
+std::int64_t samples_to_time_ns(
+    std::int64_t sample, int sample_rate) {
+    const long double nanoseconds =
+        static_cast<long double>(sample)
+        * 1000000000.0L
+        / static_cast<long double>(sample_rate);
+    if (!std::isfinite(nanoseconds)
+        || nanoseconds < static_cast<long double>(
+            std::numeric_limits<std::int64_t>::min())
+        || nanoseconds > static_cast<long double>(
+            std::numeric_limits<std::int64_t>::max())) {
+        throw std::overflow_error(
+            "Echo-cancellation sample clock cannot map to a timestamp");
+    }
+    return static_cast<std::int64_t>(std::llround(nanoseconds));
+}
+
+void validate_samples(
+    const float* samples, std::size_t count, const char* source) {
+    if (!samples && count != 0) {
+        throw std::invalid_argument(
+            std::string(source) + " samples must not be null");
+    }
+    for (std::size_t index = 0; index < count; ++index) {
+        if (!std::isfinite(samples[index])) {
+            throw std::invalid_argument(
+                std::string(source)
+                + " samples contain NaN or infinity");
+        }
+    }
+}
+
+}  // namespace
+
+class TimestampedEchoCancellationStream::Impl {
+public:
+    struct MicrophoneSegment {
+        std::int64_t start_sample = 0;
+        std::vector<float> samples;
+        std::size_t offset = 0;
+        bool reset_before = false;
+
+        std::int64_t current_start() const {
+            return start_sample + static_cast<std::int64_t>(offset);
+        }
+        std::int64_t end_sample() const {
+            return start_sample
+                + static_cast<std::int64_t>(samples.size());
+        }
+        std::size_t available() const {
+            return samples.size() - offset;
+        }
+    };
+
+    struct ReferenceSegment {
+        std::int64_t start_sample = 0;
+        std::vector<float> samples;
+        std::size_t offset = 0;
+
+        std::int64_t current_start() const {
+            return start_sample + static_cast<std::int64_t>(offset);
+        }
+        std::int64_t end_sample() const {
+            return start_sample
+                + static_cast<std::int64_t>(samples.size());
+        }
+    };
+
+    struct WorkFrame {
+        std::vector<float> microphone;
+        std::vector<float> reference;
+        std::size_t actual_count = 0;
+        std::int64_t start_sample = 0;
+        bool reset_before = false;
+    };
+
+    Impl(
+        FrameEchoCancellerInterface& canceller_value,
+        Config config_value,
+        OutputCallback output_value,
+        FailureCallback failure_value,
+        PrimingCallback priming_value)
+        : canceller(canceller_value),
+          config(std::move(config_value)),
+          output(std::move(output_value)),
+          failure_callback(std::move(failure_value)),
+          priming_callback(std::move(priming_value)),
+          needs_playback_priming(
+              config.playback_priming_samples > 0),
+          playback_priming_reason(
+              config.playback_priming_samples > 0
+              ? "initial_playback" : "") {
+        validate_config();
+        if (!config.current_time_ns) {
+            config.current_time_ns = steady_time_ns;
+        }
+        canceller.reset();
+        worker = std::thread([this] { worker_loop(); });
+    }
+
+    ~Impl() {
+        cancel();
+    }
+
+    void push_microphone(
+        const float* samples,
+        std::size_t count,
+        std::int64_t start_time_ns,
+        bool discontinuity) {
+        validate_samples(samples, count, "Microphone");
+        if (start_time_ns < 0) {
+            fail_from_capture(
+                "Microphone did not provide a valid monotonic timestamp");
+            return;
+        }
+        if (count == 0) return;
+        const std::int64_t reported =
+            duration_to_samples(start_time_ns, config.sample_rate);
+
+        std::string failure_to_emit;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (capture_ended || cancelled || failure_message) return;
+            std::int64_t normalized = reported;
+            bool reset_before = discontinuity;
+            if (last_microphone_end) {
+                const std::int64_t difference =
+                    reported - *last_microphone_end;
+                if (difference <= -discontinuity_samples) {
+                    failure_to_emit =
+                        "Microphone capture timestamps moved backwards";
+                } else if (std::llabs(difference)
+                           < discontinuity_samples
+                           && !discontinuity) {
+                    // Both routine converter carry and bounded callback jitter
+                    // describe continuous PCM. Preserve the established local
+                    // sample clock without repeatedly resetting adapted AEC.
+                    normalized = *last_microphone_end;
+                } else if (difference != 0 || discontinuity) {
+                    normalized = reported;
+                    reset_before = true;
+                    schedule_model_reset_locked(normalized);
+                }
+            } else if (discontinuity) {
+                schedule_model_reset_locked(normalized);
+            }
+            if (failure_to_emit.empty()
+                && queued_microphone_samples + count
+                    > config.capacity_samples) {
+                failure_to_emit =
+                    "Microphone echo cancellation exceeded its bounded queue";
+            }
+            if (!failure_to_emit.empty()) {
+                set_failure_locked(failure_to_emit);
+            } else {
+                if (!reset_before && !microphone_segments.empty()
+                    && microphone_segments.back().end_sample()
+                        == normalized) {
+                    auto& tail = microphone_segments.back().samples;
+                    tail.insert(tail.end(), samples, samples + count);
+                } else {
+                    microphone_segments.push_back({
+                        normalized,
+                        std::vector<float>(samples, samples + count),
+                        0,
+                        reset_before,
+                    });
+                }
+                queued_microphone_samples += count;
+                last_microphone_end =
+                    normalized + static_cast<std::int64_t>(count);
+                condition.notify_all();
+            }
+        }
+        if (!failure_to_emit.empty()) {
+            emit_failure_once(failure_to_emit);
+        }
+    }
+
+    void push_reference(
+        const float* samples,
+        std::size_t count,
+        std::int64_t start_time_ns,
+        bool discontinuity) {
+        validate_samples(samples, count, "Playback reference");
+        if (start_time_ns < 0) {
+            fail_from_capture(
+                "Playback reference did not provide a valid monotonic timestamp");
+            return;
+        }
+        if (count == 0) return;
+        const std::int64_t reported =
+            duration_to_samples(start_time_ns, config.sample_rate);
+
+        std::string failure_to_emit;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (capture_ended || cancelled || failure_message) return;
+            std::int64_t normalized = reported;
+            bool reset_required = discontinuity;
+            if (last_reference_end) {
+                const std::int64_t difference =
+                    reported - *last_reference_end;
+                if (difference <= -discontinuity_samples) {
+                    failure_to_emit =
+                        "Playback-reference timestamps moved backwards";
+                } else if (std::llabs(difference)
+                           < discontinuity_samples
+                           && !discontinuity) {
+                    normalized = *last_reference_end;
+                } else if (difference != 0 || discontinuity) {
+                    normalized = reported;
+                    reset_required = true;
+                }
+            }
+            if (failure_to_emit.empty()
+                && queued_reference_samples + count
+                    > config.capacity_samples) {
+                failure_to_emit =
+                    "Playback-reference synchronization exceeded its bounded queue";
+            }
+            if (!failure_to_emit.empty()) {
+                set_failure_locked(failure_to_emit);
+            } else {
+                if (reset_required) {
+                    schedule_model_reset_locked(normalized);
+                }
+                reference_segments.push_back({
+                    normalized,
+                    std::vector<float>(samples, samples + count),
+                    0,
+                });
+                queued_reference_samples += count;
+                const std::int64_t end =
+                    normalized + static_cast<std::int64_t>(count);
+                last_reference_end = end;
+                latest_reference_end = latest_reference_end
+                    ? std::max(*latest_reference_end, end) : end;
+                condition.notify_all();
+            }
+        }
+        if (!failure_to_emit.empty()) {
+            emit_failure_once(failure_to_emit);
+        }
+    }
+
+    void finish() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!cancelled) capture_ended = true;
+            condition.notify_all();
+        }
+        if (worker.joinable()
+            && worker.get_id() != std::this_thread::get_id()) {
+            worker.join();
+        }
+        const auto failed = failure();
+        if (failed) {
+            throw std::runtime_error(*failed);
+        }
+    }
+
+    void cancel() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (cancelled && !worker.joinable()) return;
+            cancelled = true;
+            microphone_segments.clear();
+            reference_segments.clear();
+            queued_microphone_samples = 0;
+            queued_reference_samples = 0;
+            condition.notify_all();
+        }
+        if (worker.joinable()
+            && worker.get_id() != std::this_thread::get_id()) {
+            worker.join();
+        }
+        canceller.reset();
+    }
+
+    std::optional<std::string> failure() const {
+        std::lock_guard<std::mutex> lock(mutex);
+        return failure_message;
+    }
+
+private:
+    void validate_config() {
+        if (config.sample_rate <= 0
+            || config.frame_size == 0
+            || config.capacity_samples < config.frame_size
+            || config.reference_wait_ns < 0
+            || config.clock_skew_tolerance_ns < 0
+            || config.timestamp_discontinuity_ns
+                <= config.clock_skew_tolerance_ns
+            || config.playback_activation_rms < 0.0f
+            || !std::isfinite(config.playback_activation_rms)) {
+            throw std::invalid_argument(
+                "Timestamped echo-cancellation configuration is invalid");
+        }
+        if (canceller.input_sample_rate() != config.sample_rate
+            || canceller.frame_size() != config.frame_size) {
+            throw std::invalid_argument(
+                "Echo canceller frame contract does not match the stream");
+        }
+        if (!output) {
+            throw std::invalid_argument(
+                "Echo-cancellation output callback is required");
+        }
+        clock_skew_tolerance_samples = std::max<std::int64_t>(
+            0,
+            duration_to_samples(
+                config.clock_skew_tolerance_ns,
+                config.sample_rate));
+        discontinuity_samples = std::max<std::int64_t>(
+            clock_skew_tolerance_samples + 1,
+            duration_to_samples(
+                config.timestamp_discontinuity_ns,
+                config.sample_rate));
+        reference_wait_samples = std::max<std::int64_t>(
+            0,
+            duration_to_samples(
+                config.reference_wait_ns,
+                config.sample_rate));
+    }
+
+    void worker_loop() {
+        try {
+            for (;;) {
+                std::optional<WorkFrame> work;
+                bool should_finish = false;
+                {
+                    std::unique_lock<std::mutex> lock(mutex);
+                    condition.wait_for(
+                        lock,
+                        std::chrono::milliseconds(10),
+                        [this] {
+                            return cancelled || failure_message
+                                || capture_ended
+                                || !microphone_segments.empty();
+                        });
+                    if (cancelled || failure_message) return;
+                    work = take_work_frame_locked();
+                    should_finish =
+                        capture_ended && microphone_segments.empty();
+                    if (!work && !should_finish) {
+                        // A microphone frame can be ready before the
+                        // independently scheduled reference callback. Release
+                        // the lock briefly instead of spinning until either
+                        // that callback arrives or the reference wait expires.
+                        condition.wait_for(
+                            lock, std::chrono::milliseconds(10));
+                    }
+                }
+
+                if (work) {
+                    process_work_frame(std::move(*work));
+                    continue;
+                }
+                if (should_finish) {
+                    flush_playback_priming_frames();
+                    return;
+                }
+            }
+        } catch (const std::exception& error) {
+            const std::string message =
+                "Microphone echo cancellation stopped: "
+                + std::string(error.what());
+            bool first = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                first = set_failure_locked(message);
+            }
+            if (first) emit_failure_once(message);
+        } catch (...) {
+            const std::string message =
+                "Microphone echo cancellation stopped with an unknown error";
+            bool first = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                first = set_failure_locked(message);
+            }
+            if (first) emit_failure_once(message);
+        }
+    }
+
+    std::optional<WorkFrame> take_work_frame_locked() {
+        while (!microphone_segments.empty()
+               && microphone_segments.front().available() == 0) {
+            microphone_segments.pop_front();
+        }
+        if (microphone_segments.empty()) return std::nullopt;
+
+        auto& segment = microphone_segments.front();
+        const std::size_t available = segment.available();
+        const bool followed_by_discontinuity =
+            microphone_segments.size() > 1
+            && microphone_segments[1].reset_before;
+        if (available < config.frame_size
+            && !followed_by_discontinuity && !capture_ended) {
+            return std::nullopt;
+        }
+        const std::size_t actual_count =
+            std::min(config.frame_size, available);
+        const std::int64_t frame_start = segment.current_start();
+        const std::int64_t frame_end =
+            frame_start + static_cast<std::int64_t>(actual_count);
+        const std::int64_t wall_sample = duration_to_samples(
+            config.current_time_ns(), config.sample_rate);
+        const bool reference_ready =
+            capture_ended
+            || (latest_reference_end
+                && *latest_reference_end >= frame_end)
+            || wall_sample >= frame_end + reference_wait_samples;
+        if (!reference_ready) return std::nullopt;
+
+        WorkFrame work;
+        work.actual_count = actual_count;
+        work.start_sample = frame_start;
+        work.microphone.assign(
+            segment.samples.begin()
+                + static_cast<std::ptrdiff_t>(segment.offset),
+            segment.samples.begin()
+                + static_cast<std::ptrdiff_t>(
+                    segment.offset + actual_count));
+        work.microphone.resize(config.frame_size, 0.0f);
+        work.reference =
+            reference_frame_locked(frame_start, actual_count);
+        const bool scheduled_reset =
+            pending_model_reset_at
+            && frame_end > *pending_model_reset_at;
+        if (scheduled_reset) pending_model_reset_at.reset();
+        work.reset_before =
+            (segment.reset_before && segment.offset == 0)
+            || scheduled_reset;
+
+        segment.offset += actual_count;
+        queued_microphone_samples -= actual_count;
+        if (segment.offset == segment.samples.size()) {
+            microphone_segments.pop_front();
+        }
+        discard_reference_locked(frame_end);
+        return work;
+    }
+
+    std::vector<float> reference_frame_locked(
+        std::int64_t start_sample,
+        std::size_t actual_count) const {
+        std::vector<float> frame(config.frame_size, 0.0f);
+        const std::int64_t requested_end =
+            start_sample + static_cast<std::int64_t>(actual_count);
+        for (const auto& segment : reference_segments) {
+            if (segment.current_start() >= requested_end) break;
+            if (segment.end_sample() <= start_sample) continue;
+            const std::int64_t overlap_start =
+                std::max(start_sample, segment.current_start());
+            const std::int64_t overlap_end =
+                std::min(requested_end, segment.end_sample());
+            if (overlap_end <= overlap_start) continue;
+            const std::size_t source_start = static_cast<std::size_t>(
+                overlap_start - segment.start_sample);
+            const std::size_t destination_start =
+                static_cast<std::size_t>(overlap_start - start_sample);
+            const std::size_t count =
+                static_cast<std::size_t>(overlap_end - overlap_start);
+            std::copy_n(
+                segment.samples.data() + source_start,
+                count,
+                frame.data() + destination_start);
+        }
+        return frame;
+    }
+
+    void discard_reference_locked(std::int64_t before_sample) {
+        while (!reference_segments.empty()
+               && reference_segments.front().end_sample()
+                    <= before_sample) {
+            const auto& first = reference_segments.front();
+            queued_reference_samples -=
+                first.samples.size() - first.offset;
+            reference_segments.pop_front();
+        }
+        if (reference_segments.empty()) return;
+        auto& first = reference_segments.front();
+        if (first.current_start() >= before_sample
+            || before_sample >= first.end_sample()) {
+            return;
+        }
+        const std::size_t discarded = static_cast<std::size_t>(
+            before_sample - first.current_start());
+        first.offset += discarded;
+        queued_reference_samples -= discarded;
+    }
+
+    void process_work_frame(WorkFrame work) {
+        if (work.reset_before) {
+            flush_playback_priming_frames();
+            canceller.reset();
+            needs_playback_priming =
+                config.playback_priming_samples > 0;
+            playback_priming_reason =
+                needs_playback_priming
+                ? "timestamp_realign" : "";
+            inactive_reference_samples = 0;
+        }
+
+        const bool reference_active = reference_is_active(work);
+        if (!needs_playback_priming
+            && config.playback_priming_samples > 0
+            && config.playback_repriming_silence_samples > 0
+            && reference_active
+            && inactive_reference_samples
+                >= config.playback_repriming_silence_samples) {
+            needs_playback_priming = true;
+            playback_priming_reason = "reference_resume";
+        }
+
+        if (needs_playback_priming
+            && (!playback_priming_frames.empty()
+                || reference_active)) {
+            playback_priming_collected_samples += work.actual_count;
+            playback_priming_frames.push_back(std::move(work));
+            if (playback_priming_collected_samples
+                >= config.playback_priming_samples) {
+                flush_playback_priming_frames();
+            }
+            return;
+        }
+
+        record_reference_activity(
+            reference_active, work.actual_count);
+        std::vector<float> cleaned(config.frame_size, 0.0f);
+        canceller.process_frame(
+            work.microphone.data(),
+            work.reference.data(),
+            cleaned.data());
+        publish(work, cleaned);
+    }
+
+    bool reference_is_active(const WorkFrame& work) const {
+        if (work.actual_count == 0) return false;
+        const double threshold =
+            static_cast<double>(config.playback_activation_rms)
+            * config.playback_activation_rms;
+        double sum = 0.0;
+        for (std::size_t index = 0;
+             index < work.actual_count; ++index) {
+            sum += static_cast<double>(work.reference[index])
+                * work.reference[index];
+        }
+        return sum / static_cast<double>(work.actual_count)
+            >= threshold;
+    }
+
+    void record_reference_activity(
+        bool active, std::size_t sample_count) {
+        if (active) {
+            inactive_reference_samples = 0;
+            return;
+        }
+        if (config.playback_repriming_silence_samples == 0) return;
+        inactive_reference_samples = std::min(
+            config.playback_repriming_silence_samples,
+            inactive_reference_samples + sample_count);
+    }
+
+    std::size_t trailing_inactive_reference_samples(
+        const std::vector<WorkFrame>& frames) const {
+        if (config.playback_repriming_silence_samples == 0) {
+            return 0;
+        }
+        std::size_t samples = 0;
+        for (auto iterator = frames.rbegin();
+             iterator != frames.rend(); ++iterator) {
+            if (reference_is_active(*iterator)) break;
+            samples = std::min(
+                config.playback_repriming_silence_samples,
+                samples + iterator->actual_count);
+        }
+        return samples;
+    }
+
+    void flush_playback_priming_frames() {
+        if (playback_priming_frames.empty()) return;
+        std::vector<WorkFrame> frames;
+        frames.swap(playback_priming_frames);
+        playback_priming_collected_samples = 0;
+
+        std::size_t total = 0;
+        for (const auto& frame : frames) {
+            total += frame.actual_count;
+        }
+        std::vector<float> microphone;
+        std::vector<float> reference;
+        microphone.reserve(total);
+        reference.reserve(total);
+        for (const auto& frame : frames) {
+            microphone.insert(
+                microphone.end(),
+                frame.microphone.begin(),
+                frame.microphone.begin()
+                    + static_cast<std::ptrdiff_t>(
+                        frame.actual_count));
+            reference.insert(
+                reference.end(),
+                frame.reference.begin(),
+                frame.reference.begin()
+                    + static_cast<std::ptrdiff_t>(
+                        frame.actual_count));
+        }
+        canceller.prime_delay(
+            microphone.data(), reference.data(), total);
+
+        if (priming_callback && !frames.empty()) {
+            EchoCancellationPrimingEvent event;
+            event.start_time_ns = samples_to_time_ns(
+                frames.front().start_sample, config.sample_rate);
+            const auto& last = frames.back();
+            event.end_time_ns = samples_to_time_ns(
+                last.start_sample
+                    + static_cast<std::int64_t>(last.actual_count),
+                config.sample_rate);
+            event.reason = playback_priming_reason.empty()
+                ? "unspecified" : playback_priming_reason;
+            event.delay_samples =
+                canceller.current_delay_samples();
+            event.delay_confidence =
+                canceller.delay_confidence();
+            priming_callback(event);
+        }
+
+        for (const auto& frame : frames) {
+            std::vector<float> cleaned(config.frame_size, 0.0f);
+            canceller.process_frame(
+                frame.microphone.data(),
+                frame.reference.data(),
+                cleaned.data());
+            publish(frame, cleaned);
+        }
+        inactive_reference_samples =
+            trailing_inactive_reference_samples(frames);
+        needs_playback_priming = false;
+        playback_priming_reason.clear();
+    }
+
+    void publish(
+        const WorkFrame& work,
+        const std::vector<float>& cleaned) {
+        if (cleaned.size() != config.frame_size) {
+            throw std::runtime_error(
+                "Echo canceller returned an invalid frame length");
+        }
+        EchoCancelledFrame frame;
+        frame.start_time_ns = samples_to_time_ns(
+            work.start_sample, config.sample_rate);
+        frame.sample_count = work.actual_count;
+        frame.discontinuity = work.reset_before;
+        frame.raw_microphone.assign(
+            work.microphone.begin(),
+            work.microphone.begin()
+                + static_cast<std::ptrdiff_t>(work.actual_count));
+        frame.playback_reference.assign(
+            work.reference.begin(),
+            work.reference.begin()
+                + static_cast<std::ptrdiff_t>(work.actual_count));
+        frame.cleaned_microphone.assign(
+            cleaned.begin(),
+            cleaned.begin()
+                + static_cast<std::ptrdiff_t>(work.actual_count));
+        output(frame);
+    }
+
+    void schedule_model_reset_locked(std::int64_t at_sample) {
+        pending_model_reset_at = pending_model_reset_at
+            ? std::min(*pending_model_reset_at, at_sample)
+            : at_sample;
+    }
+
+    bool set_failure_locked(const std::string& message) {
+        if (failure_message) return false;
+        failure_message = message;
+        condition.notify_all();
+        return true;
+    }
+
+    void fail_from_capture(const std::string& message) {
+        bool first = false;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            first = set_failure_locked(message);
+        }
+        if (first) emit_failure_once(message);
+    }
+
+    void emit_failure_once(const std::string& message) {
+        if (failure_callback) failure_callback(message);
+    }
+
+    FrameEchoCancellerInterface& canceller;
+    Config config;
+    OutputCallback output;
+    FailureCallback failure_callback;
+    PrimingCallback priming_callback;
+
+    mutable std::mutex mutex;
+    std::condition_variable condition;
+    std::thread worker;
+    std::deque<MicrophoneSegment> microphone_segments;
+    std::deque<ReferenceSegment> reference_segments;
+    std::size_t queued_microphone_samples = 0;
+    std::size_t queued_reference_samples = 0;
+    std::optional<std::int64_t> last_microphone_end;
+    std::optional<std::int64_t> last_reference_end;
+    std::optional<std::int64_t> latest_reference_end;
+    std::optional<std::int64_t> pending_model_reset_at;
+    std::optional<std::string> failure_message;
+    std::int64_t clock_skew_tolerance_samples = 0;
+    std::int64_t discontinuity_samples = 0;
+    std::int64_t reference_wait_samples = 0;
+    bool capture_ended = false;
+    bool cancelled = false;
+
+    // Worker-only model acquisition state.
+    std::vector<WorkFrame> playback_priming_frames;
+    std::size_t playback_priming_collected_samples = 0;
+    bool needs_playback_priming = false;
+    std::string playback_priming_reason;
+    std::size_t inactive_reference_samples = 0;
+};
+
+TimestampedEchoCancellationStream::
+TimestampedEchoCancellationStream(
+    FrameEchoCancellerInterface& canceller,
+    Config config,
+    OutputCallback output,
+    FailureCallback failure,
+    PrimingCallback priming)
+    : impl_(std::make_unique<Impl>(
+          canceller,
+          std::move(config),
+          std::move(output),
+          std::move(failure),
+          std::move(priming))) {}
+
+TimestampedEchoCancellationStream::
+~TimestampedEchoCancellationStream() = default;
+
+void TimestampedEchoCancellationStream::push_microphone(
+    const float* samples,
+    std::size_t count,
+    std::int64_t start_time_ns,
+    bool discontinuity) {
+    impl_->push_microphone(
+        samples, count, start_time_ns, discontinuity);
+}
+
+void TimestampedEchoCancellationStream::push_reference(
+    const float* samples,
+    std::size_t count,
+    std::int64_t start_time_ns,
+    bool discontinuity) {
+    impl_->push_reference(
+        samples, count, start_time_ns, discontinuity);
+}
+
+void TimestampedEchoCancellationStream::finish() {
+    impl_->finish();
+}
+
+void TimestampedEchoCancellationStream::cancel() {
+    impl_->cancel();
+}
+
+std::optional<std::string>
+TimestampedEchoCancellationStream::failure() const {
+    return impl_->failure();
+}
+
+}  // namespace speech_core

--- a/src/transcription/moss_transcript_parser.cpp
+++ b/src/transcription/moss_transcript_parser.cpp
@@ -1,0 +1,202 @@
+#include "speech_core/transcription/moss_transcript_parser.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+
+namespace speech_core {
+namespace {
+
+bool ascii_space(char value) {
+    return value == ' ' || value == '\t' || value == '\n' ||
+           value == '\r' || value == '\f' || value == '\v';
+}
+
+std::string trim_ascii(const std::string& text) {
+    std::size_t first = 0;
+    while (first < text.size() && ascii_space(text[first])) ++first;
+    std::size_t last = text.size();
+    while (last > first && ascii_space(text[last - 1])) --last;
+    return text.substr(first, last - first);
+}
+
+bool parse_timestamp_token(
+    const std::string& text, std::size_t open, std::size_t& after,
+    double& value) {
+    if (open >= text.size() || text[open] != '[') return false;
+    const std::size_t close = text.find(']', open + 1);
+    if (close == std::string::npos || close == open + 1) return false;
+    bool saw_digit = false;
+    bool saw_dot = false;
+    for (std::size_t index = open + 1; index < close; ++index) {
+        const char character = text[index];
+        if (character >= '0' && character <= '9') {
+            saw_digit = true;
+        } else if (character == '.' && !saw_dot) {
+            saw_dot = true;
+        } else {
+            return false;
+        }
+    }
+    if (!saw_digit) return false;
+    const std::string token = text.substr(open + 1, close - open - 1);
+    char* parsed_end = nullptr;
+    value = std::strtod(token.c_str(), &parsed_end);
+    if (!parsed_end || *parsed_end != '\0' ||
+        !std::isfinite(value)) {
+        return false;
+    }
+    after = close + 1;
+    return true;
+}
+
+bool parse_speaker_token(
+    const std::string& text, std::size_t open, std::size_t& after,
+    std::string& speaker) {
+    if (open >= text.size() || text[open] != '[') return false;
+    const std::size_t close = text.find(']', open + 1);
+    if (close == std::string::npos || close <= open + 2 ||
+        text[open + 1] != 'S') {
+        return false;
+    }
+    for (std::size_t index = open + 2; index < close; ++index) {
+        if (text[index] < '0' || text[index] > '9') return false;
+    }
+    speaker = text.substr(open + 1, close - open - 1);
+    after = close + 1;
+    return true;
+}
+
+bool marker_at(
+    const std::string& text, std::size_t open, std::size_t& after) {
+    double timestamp = 0.0;
+    std::string speaker;
+    return parse_timestamp_token(text, open, after, timestamp) ||
+           parse_speaker_token(text, open, after, speaker);
+}
+
+std::string collapse_ascii_whitespace(const std::string& text) {
+    std::ostringstream result;
+    bool needs_space = false;
+    for (char character : text) {
+        if (ascii_space(character)) {
+            needs_space = result.tellp() > 0;
+            continue;
+        }
+        if (needs_space) {
+            result << ' ';
+            needs_space = false;
+        }
+        result << character;
+    }
+    return result.str();
+}
+
+bool has_ascii_or_utf8_lexical_content(const std::string& text) {
+    for (unsigned char character : text) {
+        if (character >= 0x80 || std::isalnum(character)) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+bool contains_moss_wire_marker(const std::string& text) {
+    std::size_t position = 0;
+    while ((position = text.find('[', position)) != std::string::npos) {
+        std::size_t after = position;
+        if (marker_at(text, position, after)) return true;
+        ++position;
+    }
+    return false;
+}
+
+std::string sanitize_moss_segment_text(const std::string& text) {
+    std::string stripped;
+    stripped.reserve(text.size());
+    std::size_t position = 0;
+    while (position < text.size()) {
+        if (text[position] == '[') {
+            std::size_t after = position;
+            if (marker_at(text, position, after)) {
+                stripped.push_back(' ');
+                position = after;
+                continue;
+            }
+        }
+        stripped.push_back(text[position++]);
+    }
+    std::string collapsed = collapse_ascii_whitespace(stripped);
+    if (!has_ascii_or_utf8_lexical_content(collapsed)) return {};
+    return collapsed;
+}
+
+DiarizedTranscriptionResult parse_moss_transcript(
+    const std::string& raw_text) {
+    DiarizedTranscriptionResult result;
+    result.raw_text = raw_text;
+    const std::string trimmed = trim_ascii(raw_text);
+
+    std::size_t search = 0;
+    while (search < trimmed.size()) {
+        const std::size_t start_open = trimmed.find('[', search);
+        if (start_open == std::string::npos) break;
+
+        std::size_t after_start = start_open;
+        double start = 0.0;
+        if (!parse_timestamp_token(
+                trimmed, start_open, after_start, start)) {
+            search = start_open + 1;
+            continue;
+        }
+
+        std::size_t after_speaker = after_start;
+        std::string speaker;
+        if (!parse_speaker_token(
+                trimmed, after_start, after_speaker, speaker)) {
+            search = start_open + 1;
+            continue;
+        }
+
+        std::size_t end_open = trimmed.find('[', after_speaker);
+        bool emitted = false;
+        while (end_open != std::string::npos) {
+            std::size_t after_end = end_open;
+            double end = 0.0;
+            if (parse_timestamp_token(
+                    trimmed, end_open, after_end, end)) {
+                const std::string text = sanitize_moss_segment_text(
+                    trimmed.substr(after_speaker, end_open - after_speaker));
+                if (end >= start && !text.empty()) {
+                    result.segments.push_back({
+                        static_cast<float>(start),
+                        static_cast<float>(end),
+                        speaker,
+                        text,
+                    });
+                    search = after_end;
+                    emitted = true;
+                }
+                break;
+            }
+            end_open = trimmed.find('[', end_open + 1);
+        }
+        if (!emitted) search = start_open + 1;
+    }
+
+    if (result.segments.empty()) {
+        result.text = trimmed;
+    } else {
+        std::ostringstream plain;
+        for (const auto& segment : result.segments) {
+            if (plain.tellp() > 0) plain << ' ';
+            plain << segment.text;
+        }
+        result.text = plain.str();
+    }
+    return result;
+}
+
+}  // namespace speech_core

--- a/tests/test_meeting_transcription_track.cpp
+++ b/tests/test_meeting_transcription_track.cpp
@@ -1,0 +1,667 @@
+#include "speech_core/pipeline/meeting_transcription_track.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+class FakeVad final : public speech_core::VADInterface {
+public:
+    explicit FakeVad(int sample_rate, std::size_t chunk)
+        : sample_rate_(sample_rate), chunk_(chunk) {}
+
+    float process_chunk(
+        const float* samples, std::size_t length) override {
+        assert(length == chunk_);
+        float peak = 0.0f;
+        for (std::size_t index = 0; index < length; ++index) {
+            peak = std::max(peak, std::abs(samples[index]));
+        }
+        return peak > 0.25f ? 0.9f : 0.0f;
+    }
+    void reset() override {}
+    int input_sample_rate() const override { return sample_rate_; }
+    std::size_t chunk_size() const override { return chunk_; }
+
+private:
+    int sample_rate_;
+    std::size_t chunk_;
+};
+
+class FakePreview final : public speech_core::STTInterface {
+public:
+    explicit FakePreview(int sample_rate, std::string text)
+        : sample_rate_(sample_rate), text_(std::move(text)) {}
+
+    speech_core::TranscriptionResult transcribe(
+        const float*, std::size_t, int) override {
+        return {text_, {}, 1.0f, 0.0f, 0.0f};
+    }
+    int input_sample_rate() const override { return sample_rate_; }
+    bool supports_streaming() const override { return true; }
+    void begin_stream(int) override { active_ = true; }
+    speech_core::PartialResult push_chunk(
+        const float*, std::size_t) override {
+        return {};
+    }
+    void flush_stream() override {}
+    speech_core::TranscriptionResult end_stream() override {
+        active_ = false;
+        return {text_, {}, 1.0f, 0.0f, 0.0f};
+    }
+    void cancel_stream() override { active_ = false; }
+
+private:
+    int sample_rate_;
+    std::string text_;
+    bool active_ = false;
+};
+
+class FakeMoss final
+    : public speech_core::TranscribeDiarizeInterface {
+public:
+    FakeMoss(
+        int sample_rate,
+        std::string text,
+        bool structured)
+        : sample_rate_(sample_rate),
+          text_(std::move(text)),
+          structured_(structured) {}
+
+    speech_core::DiarizedTranscriptionResult
+    transcribe_diarized(
+        const float*, std::size_t length, int sample_rate) override {
+        assert(sample_rate == sample_rate_);
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            lengths_.push_back(length);
+        }
+        speech_core::DiarizedTranscriptionResult result;
+        result.text = text_;
+        result.raw_text = structured_
+            ? "[0.00][S01]" + text_ + "[0.50]"
+            : text_;
+        if (structured_) {
+            result.segments.push_back(
+                {0.0f, 0.5f, "S01", text_});
+        }
+        return result;
+    }
+    int input_sample_rate() const override { return sample_rate_; }
+
+    std::vector<std::size_t> lengths() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return lengths_;
+    }
+
+private:
+    int sample_rate_;
+    std::string text_;
+    bool structured_;
+    mutable std::mutex mutex_;
+    std::vector<std::size_t> lengths_;
+};
+
+class SegmentMoss final
+    : public speech_core::TranscribeDiarizeInterface {
+public:
+    SegmentMoss(
+        int sample_rate,
+        std::vector<speech_core::DiarizedTranscriptionSegment>
+            segments)
+        : sample_rate_(sample_rate),
+          segments_(std::move(segments)) {}
+
+    speech_core::DiarizedTranscriptionResult
+    transcribe_diarized(
+        const float*, std::size_t, int sample_rate) override {
+        assert(sample_rate == sample_rate_);
+        speech_core::DiarizedTranscriptionResult result;
+        result.segments = segments_;
+        for (const auto& segment : segments_) {
+            if (!result.text.empty()) result.text.push_back(' ');
+            result.text += segment.text;
+        }
+        result.raw_text = "structured";
+        return result;
+    }
+
+    int input_sample_rate() const override { return sample_rate_; }
+
+private:
+    int sample_rate_;
+    std::vector<speech_core::DiarizedTranscriptionSegment>
+        segments_;
+};
+
+class ScriptedMoss final
+    : public speech_core::TranscribeDiarizeInterface {
+public:
+    ScriptedMoss(
+        int sample_rate,
+        std::vector<
+            speech_core::DiarizedTranscriptionResult> results)
+        : sample_rate_(sample_rate),
+          results_(std::move(results)) {}
+
+    speech_core::DiarizedTranscriptionResult
+    transcribe_diarized(
+        const float*, std::size_t length,
+        int sample_rate) override {
+        assert(sample_rate == sample_rate_);
+        std::lock_guard<std::mutex> lock(mutex_);
+        assert(next_ < results_.size());
+        lengths_.push_back(length);
+        return results_[next_++];
+    }
+
+    int input_sample_rate() const override {
+        return sample_rate_;
+    }
+
+    std::size_t call_count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return next_;
+    }
+
+private:
+    int sample_rate_;
+    std::vector<speech_core::DiarizedTranscriptionResult>
+        results_;
+    mutable std::mutex mutex_;
+    std::size_t next_ = 0;
+    std::vector<std::size_t> lengths_;
+};
+
+class FullSpanMoss final
+    : public speech_core::TranscribeDiarizeInterface {
+public:
+    explicit FullSpanMoss(int sample_rate)
+        : sample_rate_(sample_rate) {}
+
+    speech_core::DiarizedTranscriptionResult
+    transcribe_diarized(
+        const float*, std::size_t length,
+        int sample_rate) override {
+        assert(sample_rate == sample_rate_);
+        const float seconds = static_cast<float>(length)
+            / static_cast<float>(sample_rate_);
+        speech_core::DiarizedTranscriptionResult result;
+        result.text = "continuous";
+        result.raw_text = "structured";
+        result.segments.push_back(
+            {0.0f, seconds, "S01", "continuous"});
+        return result;
+    }
+
+    int input_sample_rate() const override {
+        return sample_rate_;
+    }
+
+private:
+    int sample_rate_;
+};
+
+speech_core::DiarizedTranscriptionResult moss_result(
+    std::string text,
+    std::vector<
+        speech_core::DiarizedTranscriptionSegment> segments = {}) {
+    speech_core::DiarizedTranscriptionResult result;
+    result.text = std::move(text);
+    result.raw_text = result.text;
+    result.segments = std::move(segments);
+    return result;
+}
+
+std::vector<speech_core::MeetingTrackEvent> events_with_lock(
+    std::mutex& mutex,
+    const std::vector<speech_core::MeetingTrackEvent>& events) {
+    std::lock_guard<std::mutex> lock(mutex);
+    return events;
+}
+
+void push_chunks(
+    speech_core::MeetingTranscriptionTrack& track,
+    int sample_rate,
+    int speech_chunks,
+    int silence_chunks,
+    std::size_t chunk,
+    std::int64_t start_ns = 1'000'000'000) {
+    std::vector<float> speech(chunk, 0.5f);
+    std::vector<float> silence(chunk, 0.0f);
+    std::size_t offset = 0;
+    auto push = [&](const std::vector<float>& audio) {
+        const std::int64_t time = start_ns
+            + static_cast<std::int64_t>(
+                std::llround(
+                    static_cast<long double>(offset)
+                    * 1'000'000'000.0L / sample_rate));
+        track.push_audio(audio.data(), audio.size(), time);
+        offset += audio.size();
+    };
+    for (int index = 0; index < speech_chunks; ++index) push(speech);
+    for (int index = 0; index < silence_chunks; ++index) push(silence);
+}
+
+void test_final_structured_revision() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "hello world");
+    FakeMoss moss(sample_rate, "hello world", true);
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    config.continuous_update_seconds = 10.0f;
+    config.maximum_window_seconds = 20.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    const auto revision = std::find_if(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                == speech_core::MeetingTrackEventType::Revision;
+        });
+    assert(revision != captured.end());
+    assert(revision->paragraph_final);
+    assert(revision->blocks.size() == 1);
+    assert(revision->blocks[0].text == "hello world");
+    assert(revision->blocks[0].activity_label == "S01");
+    assert(revision->blocks[0].identity_audio.size() == 500);
+    assert(revision->blocks[0].start_time_ns
+        >= revision->replace_start_time_ns);
+    assert(revision->blocks[0].end_time_ns
+        <= revision->replace_end_time_ns);
+}
+
+void test_short_microphone_requires_preview_agreement() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "different words");
+    FakeMoss moss(sample_rate, "hallucinated words", false);
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.microphone = true;
+    config.minimum_speech_seconds = 0.05f;
+    config.silence_close_seconds = 0.5f;
+    config.continuous_update_seconds = 10.0f;
+    config.maximum_window_seconds = 20.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+    push_chunks(track, sample_rate, 1, 5, chunk);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(std::none_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && !event.blocks.empty();
+        }));
+}
+
+void test_short_microphone_agreement_is_per_segment() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "different long words");
+    SegmentMoss moss(
+        sample_rate,
+        {
+            {0.0f, 0.2f, "S01", "hallucinated"},
+            {0.2f, 1.0f, "S01", "long words"},
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.microphone = true;
+    config.minimum_speech_seconds = 0.05f;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    const auto revision = std::find_if(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && !event.blocks.empty();
+        });
+    assert(revision != captured.end());
+    assert(revision->blocks.size() == 1);
+    assert(revision->blocks[0].text == "long words");
+}
+
+void test_short_microphone_agreement_preserves_languages() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    auto run = [&](const std::string& preview_text,
+                   const std::string& moss_text) {
+        FakeVad vad(sample_rate, chunk);
+        FakePreview preview(sample_rate, preview_text);
+        FakeMoss moss(sample_rate, moss_text, false);
+        std::mutex event_mutex;
+        std::vector<speech_core::MeetingTrackEvent> events;
+        speech_core::MeetingTranscriptionTrack::Config config;
+        config.sample_rate = sample_rate;
+        config.microphone = true;
+        config.minimum_speech_seconds = 0.05f;
+        config.silence_close_seconds = 0.5f;
+        speech_core::MeetingTranscriptionTrack track(
+            preview, moss, vad, config,
+            [&](const speech_core::MeetingTrackEvent& event) {
+                std::lock_guard<std::mutex> lock(event_mutex);
+                events.push_back(event);
+            });
+        push_chunks(track, sample_rate, 1, 5, chunk);
+        track.wait_idle();
+        const auto captured = events_with_lock(event_mutex, events);
+        return std::any_of(
+            captured.begin(), captured.end(),
+            [](const auto& event) {
+                return event.type
+                        == speech_core::MeetingTrackEventType::Revision
+                    && !event.blocks.empty();
+            });
+    };
+    assert(run("ПРИВЕТ", "Привет!"));
+    assert(run("你好", "你好。"));
+}
+
+void test_numeric_moss_wire_marker_is_never_published() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "preview");
+    FakeMoss moss(sample_rate, "[0.63]", false);
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.minimum_speech_seconds = 0.05f;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+    push_chunks(track, sample_rate, 5, 5, chunk);
+    track.wait_idle();
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(std::none_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && !event.blocks.empty();
+        }));
+}
+
+void test_continuous_windows_are_bounded() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "continuous");
+    FakeMoss moss(sample_rate, "continuous", true);
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    config.continuous_update_seconds = 1.0f;
+    config.maximum_window_seconds = 2.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [](const speech_core::MeetingTrackEvent&) {});
+    push_chunks(track, sample_rate, 31, 5, chunk);
+    track.wait_idle();
+    const auto lengths = moss.lengths();
+    assert(!lengths.empty());
+    assert(std::all_of(
+        lengths.begin(), lengths.end(),
+        [](std::size_t length) { return length <= 2000; }));
+}
+
+void test_continuous_windows_consume_identity_audio_once() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "continuous");
+    FullSpanMoss moss(sample_rate);
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    config.continuous_update_seconds = 1.0f;
+    config.maximum_window_seconds = 2.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+    push_chunks(track, sample_rate, 31, 5, chunk);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    std::size_t identity_samples = 0;
+    for (const auto& event : captured) {
+        for (const auto& block : event.blocks) {
+            identity_samples += block.identity_audio.size();
+        }
+    }
+    if (identity_samples != 3100) {
+        std::cerr << "identity samples: "
+                  << identity_samples << '\n';
+    }
+    assert(identity_samples == 3100);
+}
+
+void test_preceding_speech_recovers_activity_without_inheritance() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "yes");
+    ScriptedMoss moss(
+        sample_rate,
+        {
+            moss_result(
+                "first paragraph",
+                {{0.0f, 1.0f, "S01", "first paragraph"}}),
+            moss_result("yes"),
+            moss_result(
+                "yes",
+                {{1.5f, 2.5f, "S02", "yes"}}),
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+    push_chunks(
+        track, sample_rate, 10, 5, chunk,
+        2'500'000'000);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(moss.call_count() == 3);
+    assert(std::any_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && event.blocks.size() == 1
+                && event.blocks[0].text == "yes"
+                && event.blocks[0].activity_label == "S02";
+        }));
+}
+
+void test_following_speech_backfills_only_compatible_fragment() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "yes");
+    ScriptedMoss moss(
+        sample_rate,
+        {
+            moss_result("yes"),
+            moss_result(
+                "current words",
+                {{0.2f, 1.2f, "S02", "current words"}}),
+            moss_result(
+                "yes current words",
+                {
+                    {0.0f, 1.0f, "S01", "yes"},
+                    {1.5f, 2.5f, "S02", "current words"},
+                }),
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+    push_chunks(
+        track, sample_rate, 10, 5, chunk,
+        2'500'000'000);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(moss.call_count() == 3);
+    std::size_t matching_revisions = 0;
+    bool recovered_activity = false;
+    for (const auto& event : captured) {
+        if (event.type
+                != speech_core::MeetingTrackEventType::Revision
+            || event.blocks.size() != 1
+            || event.blocks[0].text != "yes") {
+            continue;
+        }
+        ++matching_revisions;
+        recovered_activity =
+            recovered_activity
+            || event.blocks[0].activity_label == "S01";
+    }
+    assert(matching_revisions == 2);
+    assert(recovered_activity);
+}
+
+void test_following_speech_does_not_guess_from_mismatched_text() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "yes");
+    ScriptedMoss moss(
+        sample_rate,
+        {
+            moss_result("yes"),
+            moss_result(
+                "current words",
+                {{0.2f, 1.2f, "S02", "current words"}}),
+            moss_result(
+                "unrelated words",
+                {{0.0f, 1.0f, "S01", "unrelated words"}}),
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+    push_chunks(
+        track, sample_rate, 10, 5, chunk,
+        2'500'000'000);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(moss.call_count() == 3);
+    assert(std::none_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && event.blocks.size() == 1
+                && event.blocks[0].text == "unrelated words";
+        }));
+}
+
+}  // namespace
+
+int main() {
+    test_final_structured_revision();
+    test_short_microphone_requires_preview_agreement();
+    test_short_microphone_agreement_is_per_segment();
+    test_short_microphone_agreement_preserves_languages();
+    test_numeric_moss_wire_marker_is_never_published();
+    test_continuous_windows_are_bounded();
+    test_continuous_windows_consume_identity_audio_once();
+    test_preceding_speech_recovers_activity_without_inheritance();
+    test_following_speech_backfills_only_compatible_fragment();
+    test_following_speech_does_not_guess_from_mismatched_text();
+    std::cout << "Meeting transcription track tests passed\n";
+    return 0;
+}

--- a/tests/test_moss_prompt_processor.cpp
+++ b/tests/test_moss_prompt_processor.cpp
@@ -1,0 +1,41 @@
+#include "speech_core/models/moss_prompt_processor.h"
+
+#include <algorithm>
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+int main() {
+    using speech_core::MossPromptProcessor;
+    using speech_core::MossTokenizerDecoder;
+
+    const auto prompt = MossPromptProcessor::prepare(375);
+    assert(prompt.audio_placeholder_count == 375);
+    assert(prompt.input_ids.size() == 472);
+    assert(prompt.eos_token_id == 151645);
+
+    const auto span = MossPromptProcessor::make_audio_span(375);
+    assert(span.size() == 386);
+    assert(std::count(span.begin(), span.end(), 151671) == 375);
+    assert(span[62] == 20);
+    assert(span[125] == 16 && span[126] == 15);
+    assert(span[189] == 16 && span[190] == 20);
+    assert(span[253] == 17 && span[254] == 15);
+    assert(span[317] == 17 && span[318] == 20);
+    assert(span[381] == 18 && span[382] == 15);
+
+    const auto fixture = std::filesystem::temp_directory_path()
+        / "speech-core-moss-vocab-fixture.json";
+    {
+        std::ofstream output(fixture, std::ios::binary);
+        output << R"({"Hello":0,"\u0120world":1,"!":2})";
+    }
+    const MossTokenizerDecoder decoder(fixture.string());
+    assert(decoder.vocab_size() == 3);
+    assert(decoder.decode({0, 1, 2, 151645}) == "Hello world!");
+    std::filesystem::remove(fixture);
+
+    std::cout << "MOSS prompt/tokenizer tests passed\n";
+    return 0;
+}

--- a/tests/test_moss_transcript_parser.cpp
+++ b/tests/test_moss_transcript_parser.cpp
@@ -1,0 +1,54 @@
+#include "speech_core/transcription/moss_transcript_parser.h"
+
+#include <cassert>
+#include <iostream>
+
+using speech_core::contains_moss_wire_marker;
+using speech_core::parse_moss_transcript;
+using speech_core::sanitize_moss_segment_text;
+
+int main() {
+    {
+        const auto result = parse_moss_transcript(
+            "[0.93][S01] Hello there.[2.10]"
+            "[1.75][S02] General Kenobi.[3.25]");
+        assert(result.text == "Hello there. General Kenobi.");
+        assert(result.segments.size() == 2);
+        assert(result.segments[0].speaker == "S01");
+        assert(result.segments[0].start_time == 0.93f);
+        assert(result.segments[0].end_time == 2.10f);
+        assert(result.segments[1].speaker == "S02");
+    }
+    {
+        const std::string malformed = "[2.0][S01] backwards[1.0]";
+        const auto result = parse_moss_transcript(malformed);
+        assert(result.segments.empty());
+        assert(result.text == malformed);
+    }
+    {
+        const auto result = parse_moss_transcript(
+            "[0][S01]   [1]"
+            "[4][S02] backwards[3]"
+            "[5][S03] valid[6]");
+        assert(result.segments.size() == 1);
+        assert(result.segments[0].speaker == "S03");
+        assert(result.segments[0].text == "valid");
+    }
+    {
+        const auto text = sanitize_moss_segment_text(
+            "[S01] When we were banned,[0.63][S01] it left a vacuum.");
+        assert(text == "When we were banned, it left a vacuum.");
+        assert(contains_moss_wire_marker("[0.63]"));
+        assert(contains_moss_wire_marker("[S01]"));
+        assert(!contains_moss_wire_marker("[important]"));
+    }
+    {
+        const auto result = parse_moss_transcript(
+            "noise [0.0][S01] Привет, как дела?[1.0] tail");
+        assert(result.segments.size() == 1);
+        assert(result.text == "Привет, как дела?");
+    }
+
+    std::cout << "MOSS transcript parser tests passed\n";
+    return 0;
+}

--- a/tests/test_moss_whisper_features.cpp
+++ b/tests/test_moss_whisper_features.cpp
@@ -1,0 +1,63 @@
+#include "speech_core/models/moss_whisper_features.h"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+int main() {
+    using speech_core::MossWhisperFeatureExtractor;
+
+    assert(MossWhisperFeatureExtractor::audio_token_count(0) == 0);
+    assert(MossWhisperFeatureExtractor::audio_token_count(1) == 1);
+    assert(MossWhisperFeatureExtractor::audio_token_count(16000) == 13);
+    assert(MossWhisperFeatureExtractor::audio_token_count(480000) == 375);
+
+    std::vector<float> audio(16000);
+    for (std::size_t index = 0; index < audio.size(); ++index) {
+        audio[index] = static_cast<float>(
+            static_cast<int>(index % 257) - 128) / 1024.0f;
+    }
+    const auto features =
+        MossWhisperFeatureExtractor().extract_padded_chunk(
+            audio.data(), audio.size());
+    assert(features.mel_bins == 80);
+    assert(features.time_frames == 3000);
+    assert(features.data.size() == 240000);
+
+    struct Fixture {
+        int mel;
+        int frame;
+        float value;
+    };
+    const std::vector<Fixture> fixtures = {
+        {0, 0, 1.1125666f},
+        {0, 1, 1.0164478f},
+        {0, 10, 0.99898136f},
+        {5, 0, 0.31692964f},
+        {5, 50, 0.8176489f},
+        {10, 99, 0.5653128f},
+        {20, 10, 0.5086993f},
+        {20, 50, 0.54108286f},
+        {40, 20, 0.18729377f},
+        {40, 99, 0.25527418f},
+        {79, 0, -0.8874334f},
+        {79, 50, 0.1336894f},
+        {0, 100, 0.91144305f},
+        {20, 100, 0.49058753f},
+        {40, 100, 0.29211235f},
+        {79, 100, 0.09761804f},
+        {0, 101, 0.06924677f},
+        {20, 250, -0.8874334f},
+        {79, 2999, -0.8874334f},
+    };
+    for (const auto& fixture : fixtures) {
+        const float actual = features.data[
+            static_cast<std::size_t>(
+                fixture.mel * features.time_frames + fixture.frame)];
+        assert(std::fabs(actual - fixture.value) <= 5e-4f);
+    }
+
+    std::cout << "MOSS Whisper frontend tests passed\n";
+    return 0;
+}

--- a/tests/test_onnx_localvqe_model.cpp
+++ b/tests/test_onnx_localvqe_model.cpp
@@ -1,0 +1,138 @@
+#include "speech_core/models/onnx_localvqe_echo_canceller.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846264338327950288;
+
+bool all_finite(const std::vector<float>& values) {
+    return std::all_of(
+        values.begin(), values.end(),
+        [](float value) { return std::isfinite(value); });
+}
+
+float maximum_difference(
+    const std::vector<float>& left,
+    const std::vector<float>& right) {
+    float maximum = 0.0f;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        maximum = std::max(
+            maximum, std::abs(left[index] - right[index]));
+    }
+    return maximum;
+}
+
+}  // namespace
+
+int main() {
+    const char* bundle = std::getenv("SPEECH_LOCALVQE_ONNX_DIR");
+    if (!bundle || std::string(bundle).empty()) {
+        std::cout << "Skipping LocalVQE ONNX model test: "
+                     "SPEECH_LOCALVQE_ONNX_DIR is not set\n";
+        return 0;
+    }
+
+    using Canceller = speech_core::OnnxLocalVQEEchoCanceller;
+    Canceller::Config config;
+    config.hardware_acceleration = false;
+    config.enable_prealignment = false;
+    Canceller model(bundle, config);
+
+    constexpr std::size_t frames = 6;
+    const std::size_t sample_count = frames * Canceller::kFrameSize;
+    std::vector<float> microphone(sample_count);
+    std::vector<float> reference(sample_count);
+    for (std::size_t index = 0; index < sample_count; ++index) {
+        const double time = static_cast<double>(index)
+            / Canceller::kSampleRate;
+        reference[index] = static_cast<float>(
+            0.08 * std::sin(2.0 * kPi * 440.0 * time));
+        microphone[index] = static_cast<float>(
+            0.04 * std::sin(2.0 * kPi * 173.0 * time)
+            + 0.35 * reference[index]);
+    }
+
+    auto process_direct = [&]() {
+        std::vector<float> output(sample_count, 0.0f);
+        for (std::size_t offset = 0; offset < sample_count;
+             offset += Canceller::kFrameSize) {
+            model.process_frame(
+                microphone.data() + offset,
+                reference.data() + offset,
+                output.data() + offset);
+        }
+        return output;
+    };
+
+    const std::vector<float> first = process_direct();
+    if (!all_finite(first)
+        || std::all_of(
+            first.begin(), first.end(),
+            [](float value) { return value == 0.0f; })) {
+        std::cerr << "LocalVQE produced invalid or empty audio\n";
+        return 1;
+    }
+    const auto profile = model.last_profile();
+    if (profile.total_ms <= 0.0 || profile.neural_mask_ms <= 0.0) {
+        std::cerr << "LocalVQE profile did not cover inference\n";
+        return 1;
+    }
+
+    model.reset();
+    const std::vector<float> second = process_direct();
+    if (maximum_difference(first, second) > 1e-6f) {
+        std::cerr << "LocalVQE reset did not reproduce the stream\n";
+        return 1;
+    }
+
+    model.reset();
+    model.feed_reference(reference.data(), reference.size());
+    std::vector<float> queued(sample_count, 0.0f);
+    model.cancel_echo(
+        microphone.data(), microphone.size(), queued.data());
+    if (maximum_difference(first, queued) > 1e-6f) {
+        std::cerr << "LocalVQE queued-reference path changed output\n";
+        return 1;
+    }
+
+    model.reset();
+    std::vector<float> untouched(
+        Canceller::kFrameSize, 123.0f);
+    bool rejected = false;
+    try {
+        model.cancel_echo(
+            microphone.data(),
+            Canceller::kFrameSize,
+            untouched.data());
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    if (!rejected || !std::all_of(
+            untouched.begin(), untouched.end(),
+            [](float value) { return value == 123.0f; })) {
+        std::cerr << "LocalVQE did not fail closed on reference underrun\n";
+        return 1;
+    }
+
+    model.reset();
+    std::vector<float> silence(Canceller::kFrameSize, 0.0f);
+    std::vector<float> silent_output(Canceller::kFrameSize, 1.0f);
+    model.process_frame(
+        silence.data(), silence.data(), silent_output.data());
+    if (!std::all_of(
+            silent_output.begin(), silent_output.end(),
+            [](float value) { return std::abs(value) < 1e-8f; })) {
+        std::cerr << "LocalVQE silence did not stay silent\n";
+        return 1;
+    }
+
+    std::cout << "LocalVQE ONNX model test passed\n";
+    return 0;
+}

--- a/tests/test_onnx_moss_model.cpp
+++ b/tests/test_onnx_moss_model.cpp
@@ -1,0 +1,151 @@
+#include "speech_core/models/onnx_moss_transcribe_diarize.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct WavData {
+    std::vector<float> samples;
+    int sample_rate = 0;
+};
+
+WavData load_pcm16_mono(const std::string& path) {
+    WavData output;
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) return output;
+
+    char riff[4] = {};
+    char wave[4] = {};
+    std::uint32_t file_size = 0;
+    stream.read(riff, sizeof(riff));
+    stream.read(reinterpret_cast<char*>(&file_size), sizeof(file_size));
+    stream.read(wave, sizeof(wave));
+    if (std::memcmp(riff, "RIFF", sizeof(riff)) != 0
+        || std::memcmp(wave, "WAVE", sizeof(wave)) != 0) {
+        return output;
+    }
+
+    std::uint16_t audio_format = 0;
+    std::uint16_t channels = 0;
+    std::uint16_t bits_per_sample = 0;
+    std::uint32_t sample_rate = 0;
+    bool have_format = false;
+    char chunk_id[4] = {};
+    std::uint32_t chunk_size = 0;
+    while (stream.read(chunk_id, sizeof(chunk_id))) {
+        stream.read(reinterpret_cast<char*>(&chunk_size), sizeof(chunk_size));
+        if (!stream) return {};
+        if (std::memcmp(chunk_id, "fmt ", sizeof(chunk_id)) == 0) {
+            if (chunk_size < 16) return {};
+            stream.read(
+                reinterpret_cast<char*>(&audio_format),
+                sizeof(audio_format));
+            stream.read(reinterpret_cast<char*>(&channels), sizeof(channels));
+            stream.read(
+                reinterpret_cast<char*>(&sample_rate),
+                sizeof(sample_rate));
+            stream.seekg(6, std::ios::cur);
+            stream.read(
+                reinterpret_cast<char*>(&bits_per_sample),
+                sizeof(bits_per_sample));
+            if (chunk_size > 16) {
+                stream.seekg(
+                    static_cast<std::streamoff>(chunk_size - 16),
+                    std::ios::cur);
+            }
+            have_format = true;
+        } else if (std::memcmp(chunk_id, "data", sizeof(chunk_id)) == 0) {
+            if (!have_format || audio_format != 1 || channels != 1
+                || bits_per_sample != 16 || chunk_size % 2 != 0) {
+                return {};
+            }
+            std::vector<std::int16_t> pcm(chunk_size / 2);
+            stream.read(
+                reinterpret_cast<char*>(pcm.data()),
+                static_cast<std::streamsize>(chunk_size));
+            if (!stream) return {};
+            output.samples.resize(pcm.size());
+            std::transform(
+                pcm.begin(), pcm.end(), output.samples.begin(),
+                [](std::int16_t sample) {
+                    return static_cast<float>(sample) / 32768.0f;
+                });
+            output.sample_rate = static_cast<int>(sample_rate);
+            return output;
+        } else {
+            stream.seekg(
+                static_cast<std::streamoff>(chunk_size), std::ios::cur);
+        }
+        if ((chunk_size & 1u) != 0u) stream.seekg(1, std::ios::cur);
+    }
+    return {};
+}
+
+std::string test_audio_path() {
+#ifdef SPEECH_CORE_TEST_DATA_DIR
+    return std::string(SPEECH_CORE_TEST_DATA_DIR) + "/test_audio.wav";
+#else
+    return "tests/data/test_audio.wav";
+#endif
+}
+
+bool contains_wire_control(const std::string& text) {
+    return text.find("[S") != std::string::npos
+        || text.find("<|") != std::string::npos;
+}
+
+}  // namespace
+
+int main() {
+    const char* bundle = std::getenv("SPEECH_MOSS_ONNX_DIR");
+    if (!bundle || std::string(bundle).empty()) {
+        std::cout << "Skipping MOSS ONNX model test: "
+                     "SPEECH_MOSS_ONNX_DIR is not set\n";
+        return 0;
+    }
+
+    const WavData wav = load_pcm16_mono(test_audio_path());
+    if (wav.samples.empty() || wav.sample_rate <= 0) {
+        std::cerr << "Could not load the MOSS test WAV\n";
+        return 1;
+    }
+
+    // The fixture contains two timestamped speakers. Use the complete clip so
+    // an arbitrary cut cannot turn a valid final segment into malformed wire.
+    const std::size_t sample_count = wav.samples.size();
+    speech_core::OnnxMossTranscribeDiarize::Config config;
+    config.max_new_tokens = 128;
+    config.audio_hardware_acceleration = false;
+    config.decoder_hardware_acceleration = false;
+    speech_core::OnnxMossTranscribeDiarize model(bundle, config);
+    const auto result = model.transcribe_diarized(
+        wav.samples.data(), sample_count, wav.sample_rate);
+    const auto profile = model.last_profile();
+    std::cout << "MOSS raw: " << result.raw_text << '\n'
+              << "MOSS text: " << result.text << '\n';
+
+    if (result.raw_text.empty() || result.text.empty()
+        || result.segments.size() != 2) {
+        std::cerr << "MOSS produced no usable transcript\n";
+        return 1;
+    }
+    if (contains_wire_control(result.text)) {
+        std::cerr << "MOSS published a wire-control token\n";
+        return 1;
+    }
+    if (profile.audio_chunks != 1 || profile.generated_tokens <= 0
+        || profile.total_ms <= 0.0) {
+        std::cerr << "MOSS profile did not cover a complete inference\n";
+        return 1;
+    }
+
+    std::cout << "MOSS ONNX model test passed: " << result.text << '\n';
+    return 0;
+}

--- a/tests/test_onnx_redimnet_model.cpp
+++ b/tests/test_onnx_redimnet_model.cpp
@@ -1,0 +1,49 @@
+#include "speech_core/models/onnx_redimnet_speaker_embedding.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+int main() {
+    const char* configured = std::getenv("SPEECH_REDIMNET_ONNX");
+    if (!configured || !*configured) {
+        std::cout
+            << "SPEECH_REDIMNET_ONNX not set — skipping ReDimNet model test\n";
+        return 0;
+    }
+
+    speech_core::OnnxReDimNetSpeakerEmbedding model(
+        configured, /*hardware_acceleration=*/false);
+    std::vector<float> audio(32000);
+    for (std::size_t index = 0; index < audio.size(); ++index) {
+        const float time = static_cast<float>(index) / 16000.0f;
+        audio[index] =
+            0.12f * std::sin(2.0f * 3.14159265358979323846f * 173.0f * time)
+            + 0.06f
+                * std::sin(
+                    2.0f * 3.14159265358979323846f * 271.0f * time);
+    }
+
+    const auto first = model.embed(audio.data(), audio.size(), 16000);
+    const auto second = model.embed(audio.data(), audio.size(), 16000);
+    assert(first.size() == 192);
+    assert(second.size() == first.size());
+    float norm = 0.0f;
+    float dot = 0.0f;
+    for (std::size_t index = 0; index < first.size(); ++index) {
+        assert(std::isfinite(first[index]));
+        norm += first[index] * first[index];
+        dot += first[index] * second[index];
+    }
+    assert(std::fabs(std::sqrt(norm) - 1.0f) < 1e-5f);
+    assert(dot > 0.99999f);
+
+    const auto short_probe = model.embed_short_utterance(
+        audio.data(), 9600, 16000);
+    assert(short_probe.size() == 192);
+
+    std::cout << "ReDimNet ONNX model test passed\n";
+    return 0;
+}

--- a/tests/test_recording_speaker_identity.cpp
+++ b/tests/test_recording_speaker_identity.cpp
@@ -1,0 +1,218 @@
+#include "speech_core/pipeline/recording_speaker_identity.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+class FakeEmbedder final : public EmbeddingInterface {
+public:
+    std::vector<float> embed(
+        const float* audio,
+        std::size_t length,
+        int sample_rate) override {
+        assert(sample_rate == 16000);
+        assert(length >= 2);
+        return {audio[0], audio[1]};
+    }
+
+    std::vector<float> embed_short_utterance(
+        const float* audio,
+        std::size_t length,
+        int sample_rate) override {
+        return embed(audio, length, sample_rate);
+    }
+
+    int embedding_dim() const override { return 2; }
+    int input_sample_rate() const override { return 16000; }
+};
+
+std::vector<float> evidence(
+    std::size_t samples, float x, float y) {
+    std::vector<float> audio(samples, 0.0f);
+    audio[0] = x;
+    audio[1] = y;
+    return audio;
+}
+
+MeetingTranscriptBlock block(
+    const char* activity,
+    std::int64_t start,
+    std::int64_t end,
+    std::size_t samples,
+    float x = 1.0f,
+    float y = 0.0f) {
+    MeetingTranscriptBlock value;
+    value.start_time_ns = start;
+    value.end_time_ns = end;
+    value.text = "words";
+    value.activity_label = activity;
+    value.identity_audio = evidence(samples, x, y);
+    return value;
+}
+
+void test_joint_activity_labels_never_collapse() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.begin_recording();
+    const auto result = identity.resolve({
+        block("S01", 0, 2000000000, 32000),
+        block("S02", 0, 2000000000, 32000),
+    });
+    assert(result.speakers.size() == 2);
+    assert(result.speakers[0] == "S1");
+    assert(result.speakers[1] == "S2");
+}
+
+void test_short_probe_retrieves_but_never_creates() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.set_profiles({{"Alice", {1.0f, 0.0f}, 1}});
+    identity.begin_recording();
+    auto result = identity.resolve({
+        block("S01", 0, 1000000000, 16000),
+    });
+    assert(result.speakers[0] == "Alice");
+
+    RecordingSpeakerIdentity empty(embedder);
+    empty.begin_recording();
+    result = empty.resolve({
+        block("S01", 0, 1000000000, 16000),
+    });
+    assert(!result.speakers[0]);
+    assert(result.backfills.empty());
+}
+
+void test_ambiguous_short_probe_abstains() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.set_profiles({
+        {"Alice", {1.0f, 0.0f}, 1},
+        {"Bob", {0.99f, 0.1f}, 1},
+    });
+    identity.begin_recording();
+    const auto result = identity.resolve({
+        block("S01", 0, 1000000000, 16000),
+    });
+    assert(!result.speakers[0]);
+}
+
+void test_three_supported_fragments_create_and_exactly_backfill() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.begin_recording();
+    for (int paragraph = 0; paragraph < 2; ++paragraph) {
+        const auto result = identity.resolve({
+            block(
+                "S01",
+                paragraph * 1000000000LL,
+                paragraph * 1000000000LL + 700000000,
+                11200),
+        });
+        assert(!result.speakers[0]);
+        assert(result.backfills.empty());
+    }
+    const auto result = identity.resolve({
+        block("S01", 2000000000, 2700000000, 11200),
+    });
+    assert(result.speakers[0] == "S1");
+    assert(result.backfills.size() == 3);
+    assert(result.backfills[0].start_time_ns == 0);
+    assert(result.backfills[1].start_time_ns == 1000000000);
+    assert(result.backfills[2].start_time_ns == 2000000000);
+    for (const auto& backfill : result.backfills) {
+        assert(backfill.text == "words");
+        assert(backfill.speaker == "S1");
+    }
+}
+
+void test_different_labels_in_one_paragraph_cannot_share_gallery() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.begin_recording();
+    const auto first = identity.resolve({
+        block("S01", 0, 700000000, 11200),
+        block(
+            "S02", 700000000, 1400000000,
+            11200, 0.0f, 1.0f),
+    });
+    assert(!first.speakers[0]);
+    assert(!first.speakers[1]);
+
+    // Two further S01 fragments can resolve its candidate. The same-paragraph
+    // S02 fragment was forbidden from contributing to that candidate.
+    auto second = identity.resolve({
+        block("S01", 2000000000, 2700000000, 11200),
+    });
+    assert(!second.speakers[0]);
+    auto third = identity.resolve({
+        block("S01", 3000000000, 3700000000, 11200),
+    });
+    assert(third.speakers[0] == "S1");
+    assert(third.backfills.size() == 3);
+}
+
+void test_promote_recording_identity() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.begin_recording();
+    const auto result = identity.resolve({
+        block("S01", 0, 2000000000, 32000),
+    });
+    assert(result.speakers[0] == "S1");
+    assert(identity.promote_recording_identity("S1", "Viktor"));
+    assert(identity.has_profile("Viktor"));
+    assert(!identity.promote_recording_identity("missing", "Nobody"));
+    assert(identity.delete_profile("Viktor"));
+}
+
+void test_profile_names_starting_with_s_are_not_evictable() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity::Config config;
+    config.maximum_session_speakers = 1;
+    RecordingSpeakerIdentity identity(embedder, config);
+    identity.set_profiles({{"Sam", {1.0f, 0.0f}, 1}});
+    identity.begin_recording();
+    auto result = identity.resolve({
+        block("S01", 0, 2000000000, 32000),
+    });
+    assert(result.speakers[0] == "Sam");
+    result = identity.resolve({
+        block(
+            "S01", 3000000000, 5000000000,
+            32000, 0.0f, 1.0f),
+    });
+    assert(!result.speakers[0]);
+}
+
+void test_recording_label_does_not_collide_with_profile_name() {
+    FakeEmbedder embedder;
+    RecordingSpeakerIdentity identity(embedder);
+    identity.set_profiles({{"S1", {1.0f, 0.0f}, 1}});
+    identity.begin_recording();
+    const auto result = identity.resolve({
+        block(
+            "S01", 0, 2000000000,
+            32000, 0.0f, 1.0f),
+    });
+    assert(result.speakers[0] == "S2");
+}
+
+}  // namespace
+
+int main() {
+    test_joint_activity_labels_never_collapse();
+    test_short_probe_retrieves_but_never_creates();
+    test_ambiguous_short_probe_abstains();
+    test_three_supported_fragments_create_and_exactly_backfill();
+    test_different_labels_in_one_paragraph_cannot_share_gallery();
+    test_promote_recording_identity();
+    test_profile_names_starting_with_s_are_not_evictable();
+    test_recording_label_does_not_collide_with_profile_name();
+    std::puts("Recording speaker-identity tests passed");
+    return 0;
+}

--- a/tests/test_redimnet_audio_preparation.cpp
+++ b/tests/test_redimnet_audio_preparation.cpp
@@ -1,0 +1,55 @@
+#include "speech_core/models/onnx_redimnet_speaker_embedding.h"
+
+#include <cassert>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+int main() {
+    using speech_core::OnnxReDimNetSpeakerEmbedding;
+
+    std::vector<float> two_seconds(32000);
+    for (std::size_t index = 0; index < two_seconds.size(); ++index) {
+        two_seconds[index] = static_cast<float>(index);
+    }
+    const auto repeated =
+        OnnxReDimNetSpeakerEmbedding::prepare_audio(
+            two_seconds.data(), two_seconds.size());
+    assert(repeated.size() == 96000);
+    assert(repeated[0] == 0.0f);
+    assert(repeated[31999] == 31999.0f);
+    assert(repeated[32000] == 0.0f);
+    assert(repeated[95999] == 31999.0f);
+
+    std::vector<float> long_audio(100000);
+    for (std::size_t index = 0; index < long_audio.size(); ++index) {
+        long_audio[index] = static_cast<float>(index);
+    }
+    const auto cropped =
+        OnnxReDimNetSpeakerEmbedding::prepare_audio(
+            long_audio.data(), long_audio.size());
+    assert(cropped.front() == 2000.0f);
+    assert(cropped.back() == 97999.0f);
+
+    bool rejected = false;
+    try {
+        std::vector<float> short_audio(31999);
+        (void)OnnxReDimNetSpeakerEmbedding::prepare_audio(
+            short_audio.data(), short_audio.size());
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    assert(rejected);
+
+    rejected = false;
+    try {
+        (void)OnnxReDimNetSpeakerEmbedding::prepare_audio(
+            nullptr, 0, 0);
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    assert(rejected);
+
+    std::cout << "ReDimNet audio preparation tests passed\n";
+    return 0;
+}

--- a/tests/test_resampler.cpp
+++ b/tests/test_resampler.cpp
@@ -143,6 +143,57 @@ void test_24k_to_16k() {
     printf("  PASS: 24k_to_16k (max_err=%.5f)\n", max_err);
 }
 
+void test_streaming_long_run_sample_conservation() {
+    // Seven 48 kHz samples never divide evenly into the 16 kHz clock. A
+    // packet-local floor would lose one output sample every callback; carrying
+    // the rational phase must remain exact across a long callback run.
+    constexpr size_t kCallbacks = 100000;
+    constexpr size_t kPacketSamples = 7;
+    StreamingResampler streaming(48000, 16000);
+    std::vector<float> packet(kPacketSamples, 0.0f);
+    uint64_t produced = 0;
+    for (size_t callback = 0; callback < kCallbacks; ++callback) {
+        auto output = streaming.process(packet.data(), packet.size());
+        produced += output.size();
+    }
+    produced += streaming.flush().size();
+    const uint64_t expected =
+        static_cast<uint64_t>(kCallbacks) * kPacketSamples / 3;
+    assert(produced == expected);
+    assert(streaming.total_input_samples()
+           == static_cast<uint64_t>(kCallbacks) * kPacketSamples);
+    assert(streaming.total_output_samples() == expected);
+    printf("  PASS: streaming_long_run_sample_conservation\n");
+}
+
+void test_streaming_packet_boundaries_match_one_shot_interior() {
+    auto sine = make_sine(1000.0f, 48000, 48000);
+    auto expected =
+        Resampler::resample(sine.data(), sine.size(), 48000, 16000);
+    StreamingResampler streaming(48000, 16000);
+    std::vector<float> actual;
+    const std::vector<size_t> packet_sizes = {137, 480, 1024, 53, 997};
+    size_t offset = 0;
+    size_t packet = 0;
+    while (offset < sine.size()) {
+        const size_t count = std::min(
+            packet_sizes[packet++ % packet_sizes.size()],
+            sine.size() - offset);
+        auto output = streaming.process(sine.data() + offset, count);
+        actual.insert(actual.end(), output.begin(), output.end());
+        offset += count;
+    }
+    auto tail = streaming.flush();
+    actual.insert(actual.end(), tail.begin(), tail.end());
+    assert(actual.size() == expected.size());
+    // Both paths use the same polyphase table. Ignore only the one-shot
+    // implementation's independently clamped right edge.
+    for (size_t index = 0; index + 16 < actual.size(); ++index) {
+        assert(std::abs(actual[index] - expected[index]) < 1e-6f);
+    }
+    printf("  PASS: streaming_packet_boundaries_match_one_shot_interior\n");
+}
+
 int main() {
     printf("test_resampler:\n");
 
@@ -154,6 +205,8 @@ int main() {
     test_upsample();
     test_kernel_cache();
     test_24k_to_16k();
+    test_streaming_long_run_sample_conservation();
+    test_streaming_packet_boundaries_match_one_shot_interior();
 
     Resampler::clear_cache();
     printf("All resampler tests passed.\n");

--- a/tests/test_timestamped_echo_cancellation_stream.cpp
+++ b/tests/test_timestamped_echo_cancellation_stream.cpp
@@ -1,0 +1,289 @@
+#include "speech_core/pipeline/timestamped_echo_cancellation_stream.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+constexpr int kSampleRate = 16000;
+constexpr std::size_t kFrameSize = 256;
+
+std::int64_t time_for_sample(std::int64_t sample) {
+    return static_cast<std::int64_t>(std::llround(
+        static_cast<long double>(sample) * 1000000000.0L
+        / kSampleRate));
+}
+
+class FakeCanceller final : public FrameEchoCancellerInterface {
+public:
+    int input_sample_rate() const override { return kSampleRate; }
+    std::size_t frame_size() const override { return kFrameSize; }
+
+    void process_frame(
+        const float* microphone,
+        const float* reference,
+        float* output) override {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (should_fail) throw std::runtime_error("fake failure");
+        microphone_frames.emplace_back(
+            microphone, microphone + kFrameSize);
+        reference_frames.emplace_back(
+            reference, reference + kFrameSize);
+        std::copy_n(microphone, kFrameSize, output);
+    }
+
+    bool prime_delay(
+        const float* microphone,
+        const float* reference,
+        std::size_t sample_count) override {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (should_fail) throw std::runtime_error("fake failure");
+        primed_microphone.emplace_back(
+            microphone, microphone + sample_count);
+        primed_reference.emplace_back(
+            reference, reference + sample_count);
+        return true;
+    }
+
+    int current_delay_samples() const override { return 37; }
+    float delay_confidence() const override { return 0.9f; }
+
+    void reset() override {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++reset_count;
+    }
+
+    mutable std::mutex mutex;
+    bool should_fail = false;
+    int reset_count = 0;
+    std::vector<std::vector<float>> microphone_frames;
+    std::vector<std::vector<float>> reference_frames;
+    std::vector<std::vector<float>> primed_microphone;
+    std::vector<std::vector<float>> primed_reference;
+};
+
+struct Harness {
+    FakeCanceller canceller;
+    std::atomic<std::int64_t> now_ns{0};
+    std::mutex mutex;
+    std::vector<EchoCancelledFrame> frames;
+    std::vector<EchoCancellationPrimingEvent> priming;
+    std::vector<std::string> failures;
+
+    TimestampedEchoCancellationStream::Config config() {
+        TimestampedEchoCancellationStream::Config value;
+        value.playback_priming_samples = 0;
+        value.current_time_ns = [this] { return now_ns.load(); };
+        return value;
+    }
+
+    std::unique_ptr<TimestampedEchoCancellationStream> make(
+        TimestampedEchoCancellationStream::Config value) {
+        return std::make_unique<TimestampedEchoCancellationStream>(
+            canceller,
+            std::move(value),
+            [this](const EchoCancelledFrame& frame) {
+                std::lock_guard<std::mutex> lock(mutex);
+                frames.push_back(frame);
+            },
+            [this](const std::string& failure) {
+                std::lock_guard<std::mutex> lock(mutex);
+                failures.push_back(failure);
+            },
+            [this](const EchoCancellationPrimingEvent& event) {
+                std::lock_guard<std::mutex> lock(mutex);
+                priming.push_back(event);
+            });
+    }
+};
+
+void test_timestamp_alignment_keeps_sources_separate() {
+    Harness harness;
+    auto stream = harness.make(harness.config());
+    std::vector<float> reference(kFrameSize * 2, 0.1f);
+    std::fill(
+        reference.begin() + static_cast<std::ptrdiff_t>(kFrameSize),
+        reference.end(),
+        0.2f);
+    std::vector<float> microphone(kFrameSize, 0.7f);
+    stream->push_reference(
+        reference.data(), reference.size(), time_for_sample(0));
+    stream->push_microphone(
+        microphone.data(), microphone.size(),
+        time_for_sample(kFrameSize));
+    stream->finish();
+
+    assert(harness.frames.size() == 1);
+    assert(harness.frames[0].raw_microphone == microphone);
+    assert(harness.frames[0].cleaned_microphone == microphone);
+    assert(harness.frames[0].playback_reference
+           == std::vector<float>(kFrameSize, 0.2f));
+    assert(harness.frames[0].start_time_ns
+           == time_for_sample(kFrameSize));
+}
+
+void test_worker_waits_for_late_reference() {
+    Harness harness;
+    harness.now_ns.store(time_for_sample(500));
+    auto stream = harness.make(harness.config());
+    std::vector<float> microphone(kFrameSize, 0.8f);
+    std::vector<float> reference(kFrameSize, 0.2f);
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    {
+        std::lock_guard<std::mutex> lock(harness.mutex);
+        assert(harness.frames.empty());
+    }
+    stream->push_reference(
+        reference.data(), reference.size(), time_for_sample(0));
+    stream->finish();
+    assert(harness.frames.size() == 1);
+    assert(harness.frames[0].playback_reference == reference);
+}
+
+void test_active_playback_is_primed_before_publish() {
+    Harness harness;
+    auto config = harness.config();
+    config.playback_priming_samples = kFrameSize * 2;
+    auto stream = harness.make(config);
+    std::vector<float> reference(kFrameSize * 2, 0.2f);
+    std::vector<float> microphone(kFrameSize * 2, 0.7f);
+    stream->push_reference(
+        reference.data(), reference.size(), time_for_sample(0));
+    stream->push_microphone(
+        microphone.data(), kFrameSize, time_for_sample(0));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    {
+        std::lock_guard<std::mutex> lock(harness.mutex);
+        assert(harness.frames.empty());
+    }
+    stream->push_microphone(
+        microphone.data() + kFrameSize,
+        kFrameSize,
+        time_for_sample(kFrameSize));
+    stream->finish();
+
+    assert(harness.canceller.primed_microphone.size() == 1);
+    assert(harness.canceller.primed_microphone[0] == microphone);
+    assert(harness.canceller.primed_reference[0] == reference);
+    assert(harness.frames.size() == 2);
+    assert(harness.priming.size() == 1);
+    assert(harness.priming[0].reason == "initial_playback");
+    assert(harness.priming[0].delay_samples == 37);
+}
+
+void test_quiet_reference_uses_zeros() {
+    Harness harness;
+    harness.now_ns.store(time_for_sample(5000));
+    auto stream = harness.make(harness.config());
+    std::vector<float> microphone(kFrameSize, 0.6f);
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    stream->finish();
+    assert(harness.frames.size() == 1);
+    assert(std::all_of(
+        harness.frames[0].playback_reference.begin(),
+        harness.frames[0].playback_reference.end(),
+        [](float value) { return value == 0.0f; }));
+    assert(harness.frames[0].cleaned_microphone == microphone);
+}
+
+void test_model_failure_never_publishes_raw_microphone() {
+    Harness harness;
+    harness.canceller.should_fail = true;
+    harness.now_ns.store(time_for_sample(5000));
+    auto stream = harness.make(harness.config());
+    std::vector<float> microphone(kFrameSize, 0.9f);
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    bool threw = false;
+    try {
+        stream->finish();
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    assert(threw);
+    assert(harness.frames.empty());
+    assert(!harness.failures.empty());
+}
+
+void test_large_backward_timestamp_fails_closed() {
+    Harness harness;
+    auto stream = harness.make(harness.config());
+    std::vector<float> microphone(kFrameSize, 0.4f);
+    stream->push_microphone(
+        microphone.data(), microphone.size(),
+        time_for_sample(2000));
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    bool threw = false;
+    try {
+        stream->finish();
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    assert(threw);
+    assert(harness.frames.empty());
+}
+
+void test_timestamp_gap_resets_before_next_frame() {
+    Harness harness;
+    auto config = harness.config();
+    auto stream = harness.make(config);
+    std::vector<float> reference(kFrameSize, 0.2f);
+    std::vector<float> microphone(kFrameSize, 0.5f);
+    stream->push_reference(
+        reference.data(), reference.size(), time_for_sample(0));
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    stream->push_reference(
+        reference.data(), reference.size(), time_for_sample(2256));
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(2256));
+    stream->finish();
+    assert(harness.frames.size() == 2);
+    assert(!harness.frames[0].discontinuity);
+    assert(harness.frames[1].discontinuity);
+    assert(harness.canceller.reset_count >= 2);
+}
+
+void test_finish_pads_model_only() {
+    Harness harness;
+    auto stream = harness.make(harness.config());
+    std::vector<float> microphone(100, 0.6f);
+    stream->push_microphone(
+        microphone.data(), microphone.size(), time_for_sample(0));
+    stream->finish();
+    assert(harness.canceller.microphone_frames.size() == 1);
+    assert(harness.canceller.microphone_frames[0].size()
+           == kFrameSize);
+    assert(harness.frames.size() == 1);
+    assert(harness.frames[0].sample_count == 100);
+    assert(harness.frames[0].cleaned_microphone == microphone);
+}
+
+}  // namespace
+
+int main() {
+    test_timestamp_alignment_keeps_sources_separate();
+    test_worker_waits_for_late_reference();
+    test_active_playback_is_primed_before_publish();
+    test_quiet_reference_uses_zeros();
+    test_model_failure_never_publishes_raw_microphone();
+    test_large_backward_timestamp_fails_closed();
+    test_timestamp_gap_resets_before_next_frame();
+    test_finish_pads_model_only();
+    std::puts("Timestamped echo-cancellation stream tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a portable MOSS Transcribe-Diarize ONNX runtime and strict wire parser
- add ReDimNet2-B6 identity embeddings and precision-first recording identity reconciliation
- add the complete LocalVQE hybrid AEC runtime behind timestamp-aligned, fail-closed microphone streaming
- add source-local Nemotron preview/MOSS final meeting tracks with 550 ms closure, 10-second rolling updates, 20-second windows, bounded context recovery, and one-time identity evidence
- add a stateful packet resampler with long-run sample conservation
- add the fixed Windows model download set and runtime documentation

## Validation

- default build: 31/31 tests passed
- ONNX build: 39/39 tests passed
- real MOSS bundle reproduced the reference transcription exactly
- real LocalVQE bundle matched the exported reference with relative RMSE 1.605e-6
- real ReDimNet bundle matched its reference embedding with cosine 1.0
- rolling-window, multilingual short-result, wire-marker, recovery, identity-gallery, timestamp-alignment, fail-closed AEC, and long-run resampling regressions pass

## Rollout dependency

The MOSS bundle is available. The ReDimNet and LocalVQE model repositories named by the downloader must be published before downstream unauthenticated first-run download is ready.