### PR TITLE
fix: isolate voice pipeline input sessions

### DIFF
--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -98,7 +98,14 @@ sc_pipeline_t sc_pipeline_create(...);
 void sc_pipeline_destroy(sc_pipeline_t);
 void sc_pipeline_start(sc_pipeline_t);
 void sc_pipeline_stop(sc_pipeline_t);
+void sc_pipeline_cancel_current_turn(sc_pipeline_t);
 ```
+
+`sc_pipeline_stop()` ends the running session and joins the pipeline workers.
+`sc_pipeline_cancel_current_turn()` keeps the pipeline running but discards
+buffered, queued, and in-progress turn work. Use it when a long-lived consumer
+starts a new mic/dictation session or the user explicitly cancels input.
+Conversation context is not cleared.
 
 ### Audio input
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -82,6 +82,24 @@ Five states with automatic transitions:
 | **Thinking** | LLM is generating a response | Speaking or Idle |
 | **Speaking** | TTS audio is being emitted / waiting for playback to finish | Idle (on resume_listening) or Listening (on interruption) |
 
+## Input Session Boundaries
+
+`stop()` and the next `start()` form a hard input-session boundary. Buffered
+turn-detector audio, the pre-speech ring, queued utterances, streaming STT
+state, and late results from the previous session are discarded.
+
+For long-lived pipelines, call `cancel_current_turn()` instead. It provides the
+same turn isolation without tearing down worker threads or reloading models:
+
+```cpp
+pipeline.cancel_current_turn();
+// The pipeline is still running and ready for audio from a new mic session.
+```
+
+Cancellation does not clear conversation context. It resets VAD and AEC input
+state, cancels STT/LLM/TTS on a best-effort basis, and uses a turn generation
+to prevent backends that ignore cancellation from emitting stale results.
+
 ## Turn Detection
 
 `TurnDetector` wraps a `VADInterface` + `StreamingVAD` hysteresis:
@@ -154,7 +172,8 @@ The pipeline emits events via the `EventCallback`:
 - `push_audio()` is mutex-protected — safe to call from any thread
 - STT/LLM/TTS run on a dedicated worker thread — `push_audio()` never blocks on inference
 - Events are emitted on the calling thread (push_audio events) or the worker thread (STT/TTS events) — platform dispatches to main thread as needed
-- `start()`/`stop()`/`resume_listening()` are mutex-protected
+- Lifecycle calls synchronize with audio and worker state; callers must not
+  invoke `start()` and `stop()` concurrently with each other
 - `resume_listening()` is non-blocking — post-playback guard is applied as a sample counter in the turn detector
 - State reads (`state()`, `is_running()`) are atomic — lock-free
 

--- a/include/speech_core/pipeline/turn_detector.h
+++ b/include/speech_core/pipeline/turn_detector.h
@@ -73,6 +73,12 @@ public:
     /// Reset all state (clears any active post-playback guard).
     void reset();
 
+    /// Reset for an independent audio-input session.
+    ///
+    /// Unlike reset(), this also discards the pre-speech ring and resets the
+    /// VAD model's recurrent state so audio cannot cross session boundaries.
+    void reset_for_new_stream();
+
     /// Whether the user is currently speaking.
     bool in_speech() const { return in_speech_; }
 

--- a/include/speech_core/pipeline/voice_pipeline.h
+++ b/include/speech_core/pipeline/voice_pipeline.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -79,10 +80,19 @@ public:
     State state() const { return state_.load(); }
 
     /// Start the pipeline (enables audio processing).
+    /// A start after stop begins with clean input/turn-detection state.
     void start();
 
-    /// Stop the pipeline (cancels any in-progress work).
+    /// Stop the pipeline, discarding buffered/queued input and cancelling
+    /// in-progress work.
     void stop();
+
+    /// Discard the active turn without tearing down worker threads or models.
+    ///
+    /// Clears buffered and queued input, invalidates in-progress STT/LLM/TTS
+    /// results, and resets turn detection for a new audio stream. Does not
+    /// clear ConversationContext.
+    void cancel_current_turn();
 
     /// Signal that response playback has finished.
     /// Transitions from Speaking back to Idle.
@@ -138,6 +148,7 @@ private:
         std::vector<float> audio;
         float time;
         bool eager = false;  // true if from eager STT (agent_speaking_ not set)
+        uint64_t generation = 0;
     };
     std::thread worker_thread_;
     std::mutex worker_mutex_;
@@ -145,7 +156,10 @@ private:
     std::condition_variable worker_idle_cv_;  // signaled when worker finishes processing
     std::vector<PendingUtterance> pending_utterances_;
     std::atomic<bool> worker_busy_{false};
-    std::atomic<bool> eager_invalidated_{false};  // set when SpeechResumed discards an eager utterance
+    bool worker_reset_requested_ = false;  // protected by worker_mutex_
+    std::atomic<uint64_t> turn_generation_{1};
+    // Generation whose eager utterance should be discarded after SpeechResumed.
+    std::atomic<uint64_t> eager_invalidated_generation_{0};
 
     // Cancel dispatcher — keeps tts_.cancel() / llm_->cancel() off the
     // audio thread so push_audio is not stalled by slow third-party
@@ -163,12 +177,16 @@ private:
     void worker_loop();
     void cancel_loop();
     void on_turn_event(const TurnEvent& event);
-    void process_utterance(const std::string& transcript, const std::string& language = "",
-                           float stt_duration_ms = 0.0f);
-    void speak(const std::string& text, const std::string& language = "",
-               float stt_duration_ms = 0.0f, float llm_duration_ms = 0.0f);
-    void emit_error(const std::string& message);
-    std::string call_llm_with_tools();
+    void process_utterance(const std::string& transcript,
+                           const std::string& language,
+                           float stt_duration_ms,
+                           uint64_t generation);
+    void speak(const std::string& text, const std::string& language,
+               float stt_duration_ms, float llm_duration_ms,
+               uint64_t generation);
+    void emit_error(const std::string& message, uint64_t generation);
+    std::string call_llm_with_tools(uint64_t generation);
+    bool is_current_turn(uint64_t generation) const;
 };
 
 }  // namespace speech_core

--- a/include/speech_core/speech_core_c.h
+++ b/include/speech_core/speech_core_c.h
@@ -231,11 +231,17 @@ sc_pipeline_t sc_pipeline_create(
 /// Destroy a pipeline and free all resources.
 void sc_pipeline_destroy(sc_pipeline_t pipeline);
 
-/// Start processing audio.
+/// Start processing audio with clean input/turn-detection state.
 void sc_pipeline_start(sc_pipeline_t pipeline);
 
-/// Stop processing and cancel in-progress work.
+/// Stop processing, discard buffered/queued input, and cancel in-progress work.
 void sc_pipeline_stop(sc_pipeline_t pipeline);
+
+/// Discard the active turn without stopping the pipeline.
+///
+/// Clears buffered and queued input, invalidates in-progress STT/LLM/TTS
+/// results, and resets turn detection for an independent audio stream.
+void sc_pipeline_cancel_current_turn(sc_pipeline_t pipeline);
 
 /// Feed microphone audio samples (Float32 PCM at VAD sample rate).
 void sc_pipeline_push_audio(sc_pipeline_t pipeline,

--- a/src/pipeline/turn_detector.cpp
+++ b/src/pipeline/turn_detector.cpp
@@ -300,4 +300,10 @@ void TurnDetector::reset() {
     guard_remaining_samples_ = 0;
 }
 
+void TurnDetector::reset_for_new_stream() {
+    reset();
+    pre_speech_ring_.clear();
+    vad_.reset();
+}
+
 }  // namespace speech_core

--- a/src/pipeline/voice_pipeline.cpp
+++ b/src/pipeline/voice_pipeline.cpp
@@ -32,12 +32,14 @@ VoicePipeline::~VoicePipeline() {
 }
 
 void VoicePipeline::start() {
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        running_.store(true);
-        state_.store(State::Idle);
-        if (echo_canceller_) echo_canceller_->reset();
-    }
+    if (running_.load()) return;
+
+    // A completed stop() leaves both thread objects non-joinable. Join any
+    // already-finished objects defensively before marking the new session
+    // running; setting running_ first could revive an old worker and deadlock.
+    if (worker_thread_.joinable()) worker_thread_.join();
+    if (cancel_thread_.joinable()) cancel_thread_.join();
+
     // Reset dispatcher flags BEFORE spawning so a previous stop() cycle
     // doesn't leave shutdown=true (which would make the new dispatcher
     // exit immediately, silently dropping every Interruption).
@@ -46,41 +48,66 @@ void VoicePipeline::start() {
         cancel_shutdown_ = false;
         cancel_pending_ = false;
     }
-    // Defensive: a prior stop() always joins the dispatcher, so the
-    // thread object should be non-joinable here. Joining belt-and-
-    // suspenders rather than std::terminate'ing if some path skipped
-    // stop().
-    if (cancel_thread_.joinable()) cancel_thread_.join();
-    if (worker_thread_.joinable()) worker_thread_.join();
+
+    // start() is an independent input-stream boundary even if a caller reached
+    // it after an incomplete shutdown path. Match on_turn_event's lock order:
+    // pipeline mutex first, worker mutex second.
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> wlock(worker_mutex_);
+        turn_generation_.fetch_add(1, std::memory_order_acq_rel);
+        eager_invalidated_generation_.store(0, std::memory_order_release);
+        pending_utterances_.clear();
+        worker_reset_requested_ = false;
+        worker_busy_.store(false);
+        turn_detector_.reset_for_new_stream();
+        speech_queue_.cancel_all();
+        running_.store(true);
+        state_.store(State::Idle);
+        if (echo_canceller_) echo_canceller_->reset();
+    }
+
     worker_thread_ = std::thread(&VoicePipeline::worker_loop, this);
     cancel_thread_ = std::thread(&VoicePipeline::cancel_loop, this);
 }
 
 void VoicePipeline::stop() {
+    // Close the input boundary and invalidate all work before asking backends
+    // to cancel. on_turn_event uses the same mutex_ -> worker_mutex_ order.
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        tts_.cancel();
-        if (llm_) llm_->cancel();
+        std::lock_guard<std::mutex> wlock(worker_mutex_);
+        turn_generation_.fetch_add(1, std::memory_order_acq_rel);
+        eager_invalidated_generation_.store(0, std::memory_order_release);
+        running_.store(false);
+        pending_utterances_.clear();
+        worker_reset_requested_ = false;
+        turn_detector_.reset_for_new_stream();
         speech_queue_.cancel_all();
         state_.store(State::Idle);
     }
-    // Mark the worker for shutdown under worker_mutex_, NOT just atomically.
-    // The worker's cv predicate reads running_ while holding worker_mutex_,
-    // and entering cv.wait releases the mutex atomically with sleeping.
-    // If we stored running_ outside the mutex and notified, the worker could
-    // be between "predicate returned true" and "actually sleeping": the
-    // notify would have no waiter to wake, the worker would then sleep
-    // forever, and join() would hang. Holding worker_mutex_ here serializes
-    // the store with the worker's predicate evaluation, closing the window.
-    {
-        std::lock_guard<std::mutex> wlock(worker_mutex_);
-        running_.store(false);
-    }
+
     worker_cv_.notify_all();
     worker_idle_cv_.notify_all();
+
+    // Cancellation hooks are thread-safe by interface contract. They run with
+    // no pipeline locks held so a backend can finish its worker callback.
+    stt_.cancel();
+    tts_.cancel();
+    if (llm_) llm_->cancel();
+
     if (worker_thread_.joinable()) {
         worker_thread_.join();
     }
+
+    {
+        std::lock_guard<std::mutex> wlock(worker_mutex_);
+        pending_utterances_.clear();
+        worker_reset_requested_ = false;
+        worker_busy_.store(false);
+    }
+    worker_idle_cv_.notify_all();
+
     // Tear down the cancel dispatcher AFTER the worker so the worker's
     // force_final speak() path (which calls tts_.cancel() on the worker
     // thread) cannot race with the dispatcher's own cancel call. Same
@@ -95,6 +122,29 @@ void VoicePipeline::stop() {
     if (cancel_thread_.joinable()) {
         cancel_thread_.join();
     }
+}
+
+void VoicePipeline::cancel_current_turn() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> wlock(worker_mutex_);
+        turn_generation_.fetch_add(1, std::memory_order_acq_rel);
+        eager_invalidated_generation_.store(0, std::memory_order_release);
+        pending_utterances_.clear();
+        worker_reset_requested_ = running_.load();
+        turn_detector_.reset_for_new_stream();
+        speech_queue_.cancel_all();
+        state_.store(State::Idle);
+        if (echo_canceller_) echo_canceller_->reset();
+    }
+
+    worker_cv_.notify_all();
+
+    // Batch cancellation is best-effort; generation checks remain the source
+    // of correctness for implementations whose cancel() is a no-op.
+    stt_.cancel();
+    if (llm_) llm_->cancel();
+    tts_.cancel();
 }
 
 void VoicePipeline::resume_listening() {
@@ -117,6 +167,9 @@ void VoicePipeline::resume_listening() {
 void VoicePipeline::push_audio(const float* samples, size_t count) {
     if (!running_.load()) return;
     std::lock_guard<std::mutex> lock(mutex_);
+    // Close the check/lock race with stop(): a producer may have observed
+    // running=true immediately before stop() acquired this mutex.
+    if (!running_.load()) return;
 
     const float* audio = samples;
 
@@ -148,6 +201,7 @@ void VoicePipeline::worker_loop() {
 
     bool streaming_active = false;
     size_t stream_offset = 0;  // samples already sent to push_chunk
+    uint64_t streaming_generation = 0;
 
     // Cancel any active streaming STT on exit from any path — the inner
     // !running_ check at the top of the loop only fires when the worker
@@ -165,9 +219,18 @@ void VoicePipeline::worker_loop() {
         }
     } stream_guard{stt_, streaming_active};
 
+    auto finish_utterance = [this] {
+        std::lock_guard<std::mutex> lock(worker_mutex_);
+        if (pending_utterances_.empty()) {
+            worker_busy_.store(false);
+            worker_idle_cv_.notify_all();
+        }
+    };
+
     while (running_.load()) {
         PendingUtterance utterance;
         bool have_utterance = false;
+        bool reset_worker_state = false;
         {
             std::unique_lock<std::mutex> lock(worker_mutex_);
             bool use_timed_wait = config_.emit_partial_transcriptions
@@ -179,22 +242,34 @@ void VoicePipeline::worker_loop() {
                 auto timeout = std::chrono::milliseconds(
                     static_cast<int>(config_.partial_transcription_interval * 1000));
                 worker_cv_.wait_for(lock, timeout, [this] {
-                    return !pending_utterances_.empty() || !running_.load();
+                    return !pending_utterances_.empty()
+                        || worker_reset_requested_
+                        || !running_.load();
                 });
             } else {
                 worker_cv_.wait(lock, [this] {
-                    return !pending_utterances_.empty() || !running_.load();
+                    return !pending_utterances_.empty()
+                        || worker_reset_requested_
+                        || !running_.load();
                 });
             }
             if (!running_.load()) {
                 if (streaming_active) {
                     stt_.cancel_stream();
                     streaming_active = false;
+                    streaming_generation = 0;
+                    stream_offset = 0;
                 }
                 return;
             }
 
-            if (!pending_utterances_.empty()) {
+            // cancel_current_turn() cannot directly touch the worker-owned
+            // streaming session: cancel_stream() implementations are not
+            // required to be thread-safe. Handle and acknowledge the reset
+            // here before considering an utterance from the new generation.
+            if (worker_reset_requested_) {
+                reset_worker_state = true;
+            } else if (!pending_utterances_.empty()) {
                 worker_busy_.store(true);
                 utterance = std::move(pending_utterances_.front());
                 pending_utterances_.erase(pending_utterances_.begin());
@@ -202,12 +277,38 @@ void VoicePipeline::worker_loop() {
             }
         }
 
+        if (reset_worker_state) {
+            if (streaming_active) {
+                try { stt_.cancel_stream(); } catch (...) {}
+                streaming_active = false;
+                streaming_generation = 0;
+                stream_offset = 0;
+            }
+            {
+                std::lock_guard<std::mutex> lock(worker_mutex_);
+                worker_reset_requested_ = false;
+                if (pending_utterances_.empty() && !worker_busy_.load()) {
+                    worker_idle_cv_.notify_all();
+                }
+            }
+            continue;
+        }
+
         // Streaming STT: feed new audio chunks during speech
         if (!have_utterance && streaming_active) {
+            if (!is_current_turn(streaming_generation)) {
+                try { stt_.cancel_stream(); } catch (...) {}
+                streaming_active = false;
+                streaming_generation = 0;
+                stream_offset = 0;
+                continue;
+            }
+
             std::vector<float> snapshot;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                if (turn_detector_.in_speech()) {
+                if (is_current_turn(streaming_generation)
+                    && turn_detector_.in_speech()) {
                     snapshot = turn_detector_.utterance_snapshot();
                 }
             }
@@ -217,7 +318,8 @@ void VoicePipeline::worker_loop() {
                         snapshot.data() + stream_offset,
                         snapshot.size() - stream_offset);
                     stream_offset = snapshot.size();
-                    if (!partial.text.empty()) {
+                    if (!partial.text.empty()
+                        && is_current_turn(streaming_generation)) {
                         PipelineEvent event;
                         event.type = EventType::PartialTranscription;
                         event.text = partial.text;
@@ -234,19 +336,33 @@ void VoicePipeline::worker_loop() {
             && config_.emit_partial_transcriptions
             && stt_.supports_streaming()) {
             bool speech_active;
+            uint64_t generation;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
                 speech_active = turn_detector_.in_speech();
+                generation = turn_generation_.load(std::memory_order_acquire);
             }
-            if (speech_active) {
+            if (speech_active && is_current_turn(generation)) {
                 stt_.begin_stream(stt_.input_sample_rate());
                 streaming_active = true;
+                streaming_generation = generation;
                 stream_offset = 0;
+                if (!is_current_turn(generation)) {
+                    try { stt_.cancel_stream(); } catch (...) {}
+                    streaming_active = false;
+                    streaming_generation = 0;
+                    stream_offset = 0;
+                }
             }
             continue;
         }
 
         if (!have_utterance) continue;
+
+        if (!is_current_turn(utterance.generation)) {
+            finish_utterance();
+            continue;
+        }
 
         // Emit SpeechEnded before starting STT
         {
@@ -255,11 +371,23 @@ void VoicePipeline::worker_loop() {
             ended.start_time = utterance.time;
             on_event_(ended);
         }
+        if (!is_current_turn(utterance.generation)) {
+            finish_utterance();
+            continue;
+        }
 
         // Run STT (no pipeline mutex held — push_audio continues to flow)
         try {
             auto stt_start = std::chrono::steady_clock::now();
             TranscriptionResult result;
+
+            if (streaming_active
+                && streaming_generation != utterance.generation) {
+                try { stt_.cancel_stream(); } catch (...) {}
+                streaming_active = false;
+                streaming_generation = 0;
+                stream_offset = 0;
+            }
 
             if (streaming_active) {
                 // Feed any remaining audio, then finalize stream
@@ -270,6 +398,7 @@ void VoicePipeline::worker_loop() {
                 }
                 result = stt_.end_stream();
                 streaming_active = false;
+                streaming_generation = 0;
                 stream_offset = 0;
             } else {
                 result = stt_.transcribe(
@@ -280,10 +409,18 @@ void VoicePipeline::worker_loop() {
             float stt_ms = std::chrono::duration<float, std::milli>(
                 std::chrono::steady_clock::now() - stt_start).count();
 
+            if (!is_current_turn(utterance.generation)) {
+                finish_utterance();
+                continue;
+            }
+
             // Check if this eager utterance was invalidated (user resumed speaking).
             // agent_speaking_ is NOT set during STT, so new speech during
             // transcription queues as a new utterance instead of interrupting.
-            bool invalidated = eager_invalidated_.exchange(false);
+            uint64_t expected_generation = utterance.generation;
+            bool invalidated =
+                eager_invalidated_generation_.compare_exchange_strong(
+                    expected_generation, 0, std::memory_order_acq_rel);
 
             if (invalidated) {
                 // Eager utterance discarded — user resumed speaking.
@@ -301,7 +438,8 @@ void VoicePipeline::worker_loop() {
                                   result.confidence < config_.min_transcription_confidence;
 
             if (!invalidated && !result.text.empty() && !low_confidence) {
-                process_utterance(result.text, result.language, stt_ms);
+                process_utterance(result.text, result.language, stt_ms,
+                                  utterance.generation);
             } else if (invalidated) {
                 // Eager utterance discarded — turn detector is tracking
                 // active speech, state is already Listening.
@@ -311,39 +449,49 @@ void VoicePipeline::worker_loop() {
                 // can detect new speech immediately.
                 {
                     std::lock_guard<std::mutex> lock(mutex_);
-                    turn_detector_.set_agent_speaking(false);
-                    turn_detector_.reset();
+                    if (is_current_turn(utterance.generation)) {
+                        turn_detector_.set_agent_speaking(false);
+                        turn_detector_.reset();
+                        state_.store(State::Idle);
+                    }
                 }
-                state_.store(State::Idle);
             }
         } catch (const std::exception& ex) {
-            emit_error(std::string("STT failed: ") + ex.what());
-            state_.store(State::Idle);
-        }
-
-        // Signal idle
-        {
-            std::lock_guard<std::mutex> lock(worker_mutex_);
-            if (pending_utterances_.empty()) {
-                worker_busy_.store(false);
-                worker_idle_cv_.notify_all();
+            if (streaming_active) {
+                try { stt_.cancel_stream(); } catch (...) {}
+                streaming_active = false;
+                streaming_generation = 0;
+                stream_offset = 0;
+            }
+            if (is_current_turn(utterance.generation)) {
+                emit_error(std::string("STT failed: ") + ex.what(),
+                           utterance.generation);
+                state_.store(State::Idle);
             }
         }
+
+        finish_utterance();
     }
 }
 
 void VoicePipeline::wait_idle() {
     std::unique_lock<std::mutex> lock(worker_mutex_);
     worker_idle_cv_.wait(lock, [this] {
-        return (pending_utterances_.empty() && !worker_busy_.load()) || !running_.load();
+        return (pending_utterances_.empty()
+                && !worker_busy_.load()
+                && !worker_reset_requested_)
+            || !running_.load();
     });
 }
 
 void VoicePipeline::push_text(const std::string& text) {
     if (!running_.load()) return;
+    const uint64_t generation =
+        turn_generation_.load(std::memory_order_acquire);
+    if (!running_.load()) return;
     // push_text bypasses STT — called by user, not audio thread.
     // Safe to process inline (caller expects blocking).
-    process_utterance(text);
+    process_utterance(text, "", 0.0f, generation);
 }
 
 void VoicePipeline::on_turn_event(const TurnEvent& event) {
@@ -353,7 +501,9 @@ void VoicePipeline::on_turn_event(const TurnEvent& event) {
         // If user resumed speaking after an eager STT utterance was dispatched,
         // signal the worker to discard its result (it's a partial utterance).
         if (event.eager_resumed) {
-            eager_invalidated_.store(true);
+            eager_invalidated_generation_.store(
+                turn_generation_.load(std::memory_order_acquire),
+                std::memory_order_release);
             turn_detector_.set_agent_speaking(false);
         }
         state_.store(State::Listening);
@@ -374,7 +524,12 @@ void VoicePipeline::on_turn_event(const TurnEvent& event) {
         // with STT/TTS which can take seconds.
         {
             std::lock_guard<std::mutex> wlock(worker_mutex_);
-            pending_utterances_.push_back({event.audio, event.time, event.eager});
+            pending_utterances_.push_back({
+                event.audio,
+                event.time,
+                event.eager,
+                turn_generation_.load(std::memory_order_acquire)
+            });
         }
         worker_cv_.notify_one();
         break;
@@ -431,7 +586,10 @@ void VoicePipeline::on_turn_event(const TurnEvent& event) {
 
 void VoicePipeline::process_utterance(const std::string& transcript,
                                       const std::string& language,
-                                      float stt_duration_ms) {
+                                      float stt_duration_ms,
+                                      uint64_t generation) {
+    if (!is_current_turn(generation)) return;
+
     context_.add_user_message(transcript);
 
     std::string response_text;
@@ -443,59 +601,76 @@ void VoicePipeline::process_utterance(const std::string& transcript,
         break;
 
     case AgentConfig::Mode::TranscribeOnly:
-        state_.store(State::Idle);
+        if (is_current_turn(generation)) {
+            state_.store(State::Idle);
+        }
         return;
 
     case AgentConfig::Mode::Pipeline:
         if (!llm_) {
             response_text = transcript;
         } else {
+            if (!is_current_turn(generation)) return;
             state_.store(State::Thinking);
             // Now the agent is actively responding — mark as speaking so
             // new speech triggers interruption (cancels LLM).
             {
                 std::lock_guard<std::mutex> lock(mutex_);
+                if (!is_current_turn(generation)) return;
                 turn_detector_.set_agent_speaking(true);
             }
 
             try {
                 auto llm_start = std::chrono::steady_clock::now();
-                response_text = call_llm_with_tools();
+                response_text = call_llm_with_tools(generation);
                 llm_ms = std::chrono::duration<float, std::milli>(
                     std::chrono::steady_clock::now() - llm_start).count();
             } catch (const std::exception& ex) {
-                {
+                if (is_current_turn(generation)) {
                     std::lock_guard<std::mutex> lock(mutex_);
-                    turn_detector_.set_agent_speaking(false);
+                    if (is_current_turn(generation)) {
+                        turn_detector_.set_agent_speaking(false);
+                    }
                 }
-                emit_error(std::string("LLM failed: ") + ex.what());
-                state_.store(State::Idle);
+                emit_error(std::string("LLM failed: ") + ex.what(), generation);
+                if (is_current_turn(generation)) {
+                    state_.store(State::Idle);
+                }
                 return;
             }
 
             // If interrupted during LLM generation (state changed from
             // Thinking to Listening), discard the partial response.
             // agent_speaking_ was already reset by the interruption handler.
-            if (state_.load() != State::Thinking) {
+            if (!is_current_turn(generation)
+                || state_.load() != State::Thinking) {
                 return;
             }
         }
         break;
     }
 
+    if (!is_current_turn(generation)) return;
+
     if (!response_text.empty()) {
         context_.add_assistant_message(response_text);
-        speak(response_text, language, stt_duration_ms, llm_ms);
+        speak(response_text, language, stt_duration_ms, llm_ms, generation);
     } else {
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            turn_detector_.set_agent_speaking(false);
+            if (is_current_turn(generation)) {
+                turn_detector_.set_agent_speaking(false);
+            }
         }
-        state_.store(State::Idle);
+        if (is_current_turn(generation)) {
+            state_.store(State::Idle);
+        }
     }
 }
 
-std::string VoicePipeline::call_llm_with_tools() {
+std::string VoicePipeline::call_llm_with_tools(uint64_t generation) {
+    if (!is_current_turn(generation)) return std::string();
+
     // Pass tool definitions to LLM if tools are registered
     if (tool_registry_.size() > 0) {
         llm_->set_tools(tool_registry_.tools());
@@ -507,24 +682,31 @@ std::string VoicePipeline::call_llm_with_tools() {
             accumulated += token;
         });
 
+    if (!is_current_turn(generation)) return std::string();
+
     // Handle tool calls from LLM
     if (!response.tool_calls.empty()) {
         for (const auto& tc : response.tool_calls) {
+            if (!is_current_turn(generation)) return std::string();
+
             // Emit tool call started
             PipelineEvent tool_started;
             tool_started.type = EventType::ToolCallStarted;
             tool_started.text = tc.name;
             on_event_(tool_started);
+            if (!is_current_turn(generation)) return std::string();
 
             // Find and execute the tool
             const auto* tool = tool_registry_.find(tc.name);
             if (tool) {
                 auto result = tool_executor_.execute(*tool);
+                if (!is_current_turn(generation)) return std::string();
 
                 PipelineEvent tool_completed;
                 tool_completed.type = EventType::ToolCallCompleted;
                 tool_completed.text = result.output;
                 on_event_(tool_completed);
+                if (!is_current_turn(generation)) return std::string();
 
                 // Inject tool result into conversation
                 context_.add_tool_message(tc.name,
@@ -539,7 +721,8 @@ std::string VoicePipeline::call_llm_with_tools() {
         // completion and its response would race with the now-cancelled
         // turn. process_utterance does check state_ post-return but only
         // AFTER the second chat() has already consumed an LLM call.
-        if (state_.load() != State::Thinking) {
+        if (!is_current_turn(generation)
+            || state_.load() != State::Thinking) {
             return std::string();
         }
 
@@ -551,24 +734,32 @@ std::string VoicePipeline::call_llm_with_tools() {
             });
     }
 
+    if (!is_current_turn(generation)) return std::string();
     return response.text.empty() ? accumulated : response.text;
 }
 
 void VoicePipeline::speak(const std::string& text, const std::string& language,
-                          float stt_duration_ms, float llm_duration_ms) {
-    state_.store(State::Speaking);
+                          float stt_duration_ms, float llm_duration_ms,
+                          uint64_t generation) {
+    if (!is_current_turn(generation)) return;
+
+    uint64_t speech_id;
     {
         std::lock_guard<std::mutex> lock(mutex_);
+        if (!is_current_turn(generation)) return;
+        state_.store(State::Speaking);
         turn_detector_.set_agent_speaking(true);
+        speech_id = speech_queue_.enqueue(text);
+        speech_queue_.next();  // mark as playing
     }
 
-    uint64_t speech_id = speech_queue_.enqueue(text);
-    speech_queue_.next();  // mark as playing
+    if (!is_current_turn(generation)) return;
 
     PipelineEvent response_created;
     response_created.type = EventType::ResponseCreated;
     response_created.llm_duration_ms = llm_duration_ms;
     on_event_(response_created);
+    if (!is_current_turn(generation)) return;
 
     // Use detected language from STT if available, otherwise fall back to config
     const auto& tts_language = !language.empty() ? language : config_.language;
@@ -583,14 +774,17 @@ void VoicePipeline::speak(const std::string& text, const std::string& language,
 
         tts_.synthesize(text, tts_language,
             [this, speech_id, &total_samples, max_samples,
-             tts_start, stt_duration_ms, llm_duration_ms](
+             tts_start, stt_duration_ms, llm_duration_ms, generation](
                 const float* samples, size_t length, bool is_final) {
                 // Drop chunks if we've left Speaking (interruption, stop()).
                 // Some TTS impls don't honor cancel() promptly between chunks;
                 // without this guard, ResponseAudioDelta events keep firing
                 // after ResponseInterrupted, and AEC reference is fed audio
                 // the speaker never actually played.
-                if (state_.load() != State::Speaking) return;
+                if (!is_current_turn(generation)
+                    || state_.load() != State::Speaking) {
+                    return;
+                }
 
                 // Enforce max response duration to prevent TTS hallucination
                 size_t emit_length = length;
@@ -604,14 +798,21 @@ void VoicePipeline::speak(const std::string& text, const std::string& language,
                 if (emit_length > 0) {
                     // Feed TTS audio as far-end reference for echo cancellation
                     if (echo_canceller_) {
+                        std::lock_guard<std::mutex> lock(mutex_);
+                        if (!is_current_turn(generation)
+                            || state_.load() != State::Speaking) {
+                            return;
+                        }
                         echo_canceller_->feed_reference(samples, emit_length);
                     }
+                    if (!is_current_turn(generation)) return;
 
                     auto pcm = PCMCodec::float_to_pcm16(samples, emit_length);
                     PipelineEvent audio_event;
                     audio_event.type = EventType::ResponseAudioDelta;
                     audio_event.audio_data = std::move(pcm);
                     on_event_(audio_event);
+                    if (!is_current_turn(generation)) return;
                 }
 
                 if (is_final || force_final) {
@@ -628,27 +829,40 @@ void VoicePipeline::speak(const std::string& text, const std::string& language,
                     on_event_(done);
 
                     // Stay in Speaking — platform owns playback timing
-                    if (force_final && !is_final) {
+                    if (force_final && !is_final
+                        && is_current_turn(generation)) {
                         tts_.cancel();  // Stop TTS if we hit the cap
                     }
                 }
             });
     } catch (const std::exception& ex) {
         speech_queue_.mark_done(speech_id);
-        {
+        if (is_current_turn(generation)) {
             std::lock_guard<std::mutex> lock(mutex_);
-            turn_detector_.set_agent_speaking(false);
+            if (is_current_turn(generation)) {
+                turn_detector_.set_agent_speaking(false);
+            }
         }
-        emit_error(std::string("TTS failed: ") + ex.what());
-        state_.store(State::Idle);
+        emit_error(std::string("TTS failed: ") + ex.what(), generation);
+        if (is_current_turn(generation)) {
+            state_.store(State::Idle);
+        }
     }
 }
 
-void VoicePipeline::emit_error(const std::string& message) {
+void VoicePipeline::emit_error(const std::string& message,
+                               uint64_t generation) {
+    if (!is_current_turn(generation)) return;
+
     PipelineEvent error;
     error.type = EventType::Error;
     error.text = message;
     on_event_(error);
+}
+
+bool VoicePipeline::is_current_turn(uint64_t generation) const {
+    return generation != 0
+        && turn_generation_.load(std::memory_order_acquire) == generation;
 }
 
 void VoicePipeline::cancel_loop() {

--- a/src/speech_core_c.cpp
+++ b/src/speech_core_c.cpp
@@ -346,6 +346,10 @@ void sc_pipeline_stop(sc_pipeline_t pipeline) {
     if (pipeline) pipeline->pipeline->stop();
 }
 
+void sc_pipeline_cancel_current_turn(sc_pipeline_t pipeline) {
+    if (pipeline) pipeline->pipeline->cancel_current_turn();
+}
+
 void sc_pipeline_push_audio(sc_pipeline_t pipeline,
                             const float* samples, size_t count)
 {

--- a/tests/test_c_api.cpp
+++ b/tests/test_c_api.cpp
@@ -114,6 +114,10 @@ void test_start_stop() {
     assert(sc_pipeline_is_running(p) == true);
     assert(sc_pipeline_state(p) == SC_STATE_IDLE);
 
+    sc_pipeline_cancel_current_turn(p);
+    assert(sc_pipeline_is_running(p) == true);
+    assert(sc_pipeline_state(p) == SC_STATE_IDLE);
+
     sc_pipeline_stop(p);
     assert(sc_pipeline_is_running(p) == false);
 
@@ -435,6 +439,7 @@ void test_null_safety() {
     // All functions should handle NULL pipeline gracefully
     sc_pipeline_start(nullptr);
     sc_pipeline_stop(nullptr);
+    sc_pipeline_cancel_current_turn(nullptr);
     sc_pipeline_push_audio(nullptr, nullptr, 0);
     sc_pipeline_push_text(nullptr, nullptr);
     sc_pipeline_clear_tools(nullptr);

--- a/tests/test_pipeline_e2e.cpp
+++ b/tests/test_pipeline_e2e.cpp
@@ -4,8 +4,10 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -13,6 +15,14 @@
 #include <vector>
 
 using namespace speech_core;
+
+#define REGRESSION_REQUIRE(condition) do {                                  \
+    if (!(condition)) {                                                      \
+        std::fprintf(stderr, "Regression check failed: %s (%s:%d)\n",       \
+                     #condition, __FILE__, __LINE__);                        \
+        std::abort();                                                        \
+    }                                                                        \
+} while (false)
 
 // ---------------------------------------------------------------------------
 // Mock implementations
@@ -37,6 +47,69 @@ public:
     bool should_throw = false;
 };
 
+class BlockingSTT : public STTInterface {
+public:
+    TranscriptionResult transcribe(
+        const float* /*audio*/, size_t /*length*/, int /*sample_rate*/) override
+    {
+        const int call = ++call_count;
+        if (call == 1) {
+            std::unique_lock<std::mutex> lock(mutex);
+            first_call_started = true;
+            cv.notify_all();
+            cv.wait(lock, [this] { return release_first_call; });
+        }
+        return {"utterance " + std::to_string(call), "", 1.0f, 0.0f, 1.0f};
+    }
+
+    int input_sample_rate() const override { return 16000; }
+
+    void cancel() override { ++cancel_count; }
+
+    void wait_for_first_call() {
+        std::unique_lock<std::mutex> lock(mutex);
+        const bool started = cv.wait_for(
+            lock, std::chrono::seconds(2),
+            [this] { return first_call_started; });
+        REGRESSION_REQUIRE(started);
+    }
+
+    void release_first() {
+        std::lock_guard<std::mutex> lock(mutex);
+        release_first_call = true;
+        cv.notify_all();
+    }
+
+    std::atomic<int> call_count{0};
+    std::atomic<int> cancel_count{0};
+
+private:
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool first_call_started = false;
+    bool release_first_call = false;
+};
+
+class InspectingSTT : public STTInterface {
+public:
+    TranscriptionResult transcribe(
+        const float* audio, size_t length, int /*sample_rate*/) override
+    {
+        ++call_count;
+        for (size_t i = 0; i < length; ++i) {
+            saw_old_audio = saw_old_audio || audio[i] == 0.25f;
+            saw_new_audio = saw_new_audio || audio[i] == 0.75f;
+        }
+        return {"new session", "", 1.0f, 0.0f, 1.0f};
+    }
+
+    int input_sample_rate() const override { return 16000; }
+
+    int call_count = 0;
+    bool saw_old_audio = false;
+    bool saw_new_audio = false;
+};
+
 class MockTTS : public TTSInterface {
 public:
     std::string last_text;
@@ -54,10 +127,10 @@ public:
     }
 
     int output_sample_rate() const override { return 24000; }
-    void cancel() override { cancelled = true; }
+    void cancel() override { cancelled.store(true); }
 
     bool should_throw = false;
-    bool cancelled = false;
+    std::atomic<bool> cancelled{false};
 };
 
 class MockLLM : public LLMInterface {
@@ -81,10 +154,10 @@ public:
         return r;
     }
 
-    void cancel() override { cancelled = true; }
+    void cancel() override { cancelled.store(true); }
 
     bool should_throw = false;
-    bool cancelled = false;
+    std::atomic<bool> cancelled{false};
 };
 
 class MockVAD : public VADInterface {
@@ -92,13 +165,17 @@ public:
     // Queue of probabilities to return
     std::vector<float> probs;
     size_t prob_index = 0;
+    std::atomic<int> reset_count{0};
 
     float process_chunk(const float* /*samples*/, size_t /*length*/) override {
         if (prob_index < probs.size()) return probs[prob_index++];
         return 0.0f;
     }
 
-    void reset() override { prob_index = 0; }
+    void reset() override {
+        ++reset_count;
+        prob_index = 0;
+    }
     int input_sample_rate() const override { return 16000; }
     size_t chunk_size() const override { return 512; }
 };
@@ -1294,6 +1371,265 @@ void test_stop_during_processing() {
     assert(ms < 1000);
 
     printf("  PASS: stop_during_processing\n");
+}
+
+// Regression #120: stop()/start() must create a hard audio-session boundary.
+// The first session stops during speech, before VAD emits SpeechEnded. The next
+// session must not transcribe samples retained from the first detector buffer.
+void test_stop_start_discards_open_utterance() {
+    InspectingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+    config.vad.pre_speech_buffer_duration = 0.0f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f};
+    pipeline.start();
+    std::vector<float> old_audio(vad.probs.size() * 512, 0.25f);
+    pipeline.push_audio(old_audio.data(), old_audio.size());
+    pipeline.stop();
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    pipeline.start();
+    std::vector<float> new_audio(vad.probs.size() * 512, 0.75f);
+    pipeline.push_audio(new_audio.data(), new_audio.size());
+    pipeline.wait_idle();
+
+    REGRESSION_REQUIRE(stt.call_count == 1);
+    REGRESSION_REQUIRE(stt.saw_new_audio);
+    REGRESSION_REQUIRE(!stt.saw_old_audio);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 1);
+
+    pipeline.stop();
+    printf("  PASS: stop_start_discards_open_utterance\n");
+}
+
+// Regression #120: an utterance still in pending_utterances_ at shutdown must
+// not be picked up by the worker created by the next start().
+void test_stop_start_discards_queued_utterance() {
+    BlockingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.start();
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    auto first = make_audio(vad.probs.size());
+    pipeline.push_audio(first.data(), first.size());
+    stt.wait_for_first_call();
+
+    // Queue a second complete utterance while the worker owns the first.
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    auto second = make_audio(vad.probs.size());
+    pipeline.push_audio(second.data(), second.size());
+
+    std::thread stopper([&pipeline] { pipeline.stop(); });
+    while (pipeline.is_running()) std::this_thread::yield();
+    stt.release_first();
+    stopper.join();
+
+    const size_t before_restart =
+        log.count(EventType::TranscriptionCompleted);
+
+    // No audio is submitted in this session. A new transcript can only have
+    // come from the previous session's pending queue.
+    pipeline.start();
+    pipeline.wait_idle();
+    REGRESSION_REQUIRE(
+        log.count(EventType::TranscriptionCompleted) == before_restart);
+
+    pipeline.stop();
+    printf("  PASS: stop_start_discards_queued_utterance\n");
+}
+
+// Regression #120: stop() promises to cancel in-progress work. A batch STT
+// result that returns while stop() is joining the worker must not be emitted.
+void test_stop_invalidates_inflight_batch_stt() {
+    BlockingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    pipeline.start();
+    auto audio = make_audio(vad.probs.size());
+    pipeline.push_audio(audio.data(), audio.size());
+    stt.wait_for_first_call();
+
+    std::thread stopper([&pipeline] { pipeline.stop(); });
+    while (pipeline.is_running()) std::this_thread::yield();
+    stt.release_first();
+    stopper.join();
+
+    REGRESSION_REQUIRE(stt.cancel_count.load() == 1);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 0);
+    printf("  PASS: stop_invalidates_inflight_batch_stt\n");
+}
+
+// Regression #120: a caller must be able to discard an open utterance and
+// begin a clean input session without stopping or recreating model workers.
+void test_cancel_current_turn_discards_open_utterance() {
+    InspectingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+    config.vad.pre_speech_buffer_duration = 0.0f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f};
+    pipeline.start();
+    std::vector<float> old_audio(vad.probs.size() * 512, 0.25f);
+    pipeline.push_audio(old_audio.data(), old_audio.size());
+
+    pipeline.cancel_current_turn();
+    REGRESSION_REQUIRE(pipeline.is_running());
+    REGRESSION_REQUIRE(pipeline.state() == VoicePipeline::State::Idle);
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    std::vector<float> new_audio(vad.probs.size() * 512, 0.75f);
+    pipeline.push_audio(new_audio.data(), new_audio.size());
+    pipeline.wait_idle();
+
+    REGRESSION_REQUIRE(stt.call_count == 1);
+    REGRESSION_REQUIRE(stt.saw_new_audio);
+    REGRESSION_REQUIRE(!stt.saw_old_audio);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 1);
+
+    pipeline.stop();
+    printf("  PASS: cancel_current_turn_discards_open_utterance\n");
+}
+
+// A normal TurnDetector reset intentionally retains pre-speech audio and VAD
+// model state. An independent input session must clear/reset both.
+void test_cancel_current_turn_hard_resets_input_state() {
+    InspectingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+    config.vad.pre_speech_buffer_duration = 0.1f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.start();
+    const int resets_after_start = vad.reset_count.load();
+
+    // Silence from the discarded session lives only in pre_speech_ring_.
+    vad.probs = {0.0f, 0.0f, 0.0f};
+    std::vector<float> old_silence(vad.probs.size() * 512, 0.25f);
+    pipeline.push_audio(old_silence.data(), old_silence.size());
+
+    pipeline.cancel_current_turn();
+    REGRESSION_REQUIRE(vad.reset_count.load() == resets_after_start + 1);
+
+    // New speech prepends its own leading silence, never the previous ring.
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    std::vector<float> new_audio(vad.probs.size() * 512, 0.75f);
+    pipeline.push_audio(new_audio.data(), new_audio.size());
+    pipeline.wait_idle();
+
+    REGRESSION_REQUIRE(stt.call_count == 1);
+    REGRESSION_REQUIRE(stt.saw_new_audio);
+    REGRESSION_REQUIRE(!stt.saw_old_audio);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 1);
+
+    pipeline.stop();
+    printf("  PASS: cancel_current_turn_hard_resets_input_state\n");
+}
+
+// Regression #120: cancellation invalidates the currently running batch STT,
+// drains queued utterances, and leaves the same worker ready for a new turn.
+void test_cancel_current_turn_discards_inflight_and_queued() {
+    BlockingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.start();
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    auto first = make_audio(vad.probs.size());
+    pipeline.push_audio(first.data(), first.size());
+    stt.wait_for_first_call();
+
+    // This utterance is queued behind the blocked first transcription.
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    auto second = make_audio(vad.probs.size());
+    pipeline.push_audio(second.data(), second.size());
+
+    pipeline.cancel_current_turn();
+    REGRESSION_REQUIRE(pipeline.is_running());
+    REGRESSION_REQUIRE(stt.cancel_count.load() == 1);
+
+    stt.release_first();
+    pipeline.wait_idle();
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 0);
+
+    // A fresh utterance uses the same live worker. The old queued utterance
+    // must not consume call 2 or emit before it.
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    auto third = make_audio(vad.probs.size());
+    pipeline.push_audio(third.data(), third.size());
+    pipeline.wait_idle();
+
+    REGRESSION_REQUIRE(stt.call_count.load() == 2);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 1);
+    REGRESSION_REQUIRE(
+        log.text_for(EventType::TranscriptionCompleted) == "utterance 2");
+
+    pipeline.stop();
+    printf("  PASS: cancel_current_turn_discards_inflight_and_queued\n");
 }
 
 // Test: brief interruption triggers InterruptionRecovered (playback can resume)
@@ -3018,6 +3354,129 @@ void test_partial_transcription_cancel_on_stop() {
     printf("  PASS: partial_transcription_cancel_on_stop\n");
 }
 
+void test_partial_transcription_cancel_current_turn() {
+    // Resetting an input session must cancel worker-owned streaming state and
+    // allow a second stream to begin without restarting the pipeline.
+    class StreamingSTT : public STTInterface {
+    public:
+        TranscriptionResult transcribe(
+            const float*, size_t, int) override
+        {
+            ++batch_count;
+            return {"batch", "", 0.9f, 0.0f, 1.0f};
+        }
+
+        int input_sample_rate() const override { return 16000; }
+        bool supports_streaming() const override { return true; }
+
+        void begin_stream(int) override {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++begin_count;
+            stream_active = true;
+            cv.notify_all();
+        }
+
+        PartialResult push_chunk(const float*, size_t) override {
+            return {"partial", "", 0.8f};
+        }
+
+        TranscriptionResult end_stream() override {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++end_count;
+            stream_active = false;
+            cv.notify_all();
+            return {"new stream final", "", 0.9f, 0.0f, 1.0f};
+        }
+
+        void cancel_stream() override {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++cancel_stream_count;
+            stream_active = false;
+            cv.notify_all();
+        }
+
+        void wait_for_begins(int expected) {
+            std::unique_lock<std::mutex> lock(mutex);
+            const bool reached = cv.wait_for(
+                lock, std::chrono::seconds(2),
+                [this, expected] { return begin_count.load() >= expected; });
+            REGRESSION_REQUIRE(reached);
+        }
+
+        void wait_for_cancels(int expected) {
+            std::unique_lock<std::mutex> lock(mutex);
+            const bool reached = cv.wait_for(
+                lock, std::chrono::seconds(2),
+                [this, expected] {
+                    return cancel_stream_count.load() >= expected;
+                });
+            REGRESSION_REQUIRE(reached);
+        }
+
+        std::atomic<int> batch_count{0};
+        std::atomic<int> begin_count{0};
+        std::atomic<int> end_count{0};
+        std::atomic<int> cancel_stream_count{0};
+        std::atomic<bool> stream_active{false};
+
+    private:
+        std::mutex mutex;
+        std::condition_variable cv;
+    };
+
+    StreamingSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    auto config = test_config();
+    config.mode = AgentConfig::Mode::TranscribeOnly;
+    config.vad.min_speech_duration = 0.0f;
+    config.vad.min_silence_duration = 0.0f;
+    config.emit_partial_transcriptions = true;
+    config.partial_transcription_interval = 0.01f;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.start();
+
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f};
+    auto old_speech = make_audio(vad.probs.size());
+    pipeline.push_audio(old_speech.data(), old_speech.size());
+    stt.wait_for_begins(1);
+
+    pipeline.cancel_current_turn();
+    stt.wait_for_cancels(1);
+    REGRESSION_REQUIRE(pipeline.is_running());
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 0);
+
+    // Begin and finish an independent stream on the same worker.
+    vad.probs = {0.0f, 0.9f, 0.9f, 0.9f, 0.9f, 0.9f};
+    vad.prob_index = 0;
+    auto new_speech = make_audio(vad.probs.size());
+    pipeline.push_audio(new_speech.data(), new_speech.size());
+    stt.wait_for_begins(2);
+
+    vad.probs = {0.1f, 0.1f, 0.1f, 0.1f};
+    vad.prob_index = 0;
+    auto silence = make_audio(vad.probs.size());
+    pipeline.push_audio(silence.data(), silence.size());
+    pipeline.wait_idle();
+
+    REGRESSION_REQUIRE(stt.begin_count.load() == 2);
+    REGRESSION_REQUIRE(stt.cancel_stream_count.load() == 1);
+    REGRESSION_REQUIRE(stt.end_count.load() == 1);
+    REGRESSION_REQUIRE(!stt.stream_active.load());
+    REGRESSION_REQUIRE(stt.batch_count.load() == 0);
+    REGRESSION_REQUIRE(log.count(EventType::TranscriptionCompleted) == 1);
+    REGRESSION_REQUIRE(
+        log.text_for(EventType::TranscriptionCompleted) == "new stream final");
+
+    pipeline.stop();
+    printf("  PASS: partial_transcription_cancel_current_turn\n");
+}
+
 void test_partial_transcription_empty_skipped() {
     // push_chunk returns empty text → no PartialTranscription event emitted
     class SilentStreamSTT : public STTInterface {
@@ -3427,6 +3886,12 @@ int main() {
     test_interruption_during_stt_skips_tts();
     test_post_playback_guard();
     test_stop_during_processing();
+    test_stop_start_discards_open_utterance();
+    test_stop_start_discards_queued_utterance();
+    test_stop_invalidates_inflight_batch_stt();
+    test_cancel_current_turn_discards_open_utterance();
+    test_cancel_current_turn_hard_resets_input_state();
+    test_cancel_current_turn_discards_inflight_and_queued();
     test_interruption_recovery();
     test_push_text_during_tts();
     test_rapid_start_stop();
@@ -3460,6 +3925,7 @@ int main() {
     test_partial_transcription_batch_fallback();
     test_partial_transcription_disabled();
     test_partial_transcription_cancel_on_stop();
+    test_partial_transcription_cancel_current_turn();
     test_partial_transcription_empty_skipped();
     test_speech_during_stt_queues_not_interrupts();
     test_llm_cancel_on_interruption();


### PR DESCRIPTION
## Summary

Fix utterance audio and asynchronous work leaking across `VoicePipeline` input sessions. `stop()`/`start()` now form a hard boundary, and long-lived consumers can discard a turn without recreating workers or models.

Closes #120.

## What changed

- Clear buffered detector audio, pre-speech audio, queued utterances, streaming STT state, VAD state, speech state, and AEC state at input-session boundaries.
- Add `VoicePipeline::cancel_current_turn()` and `sc_pipeline_cancel_current_turn()` for live pipeline reuse.
- Tag queued and in-flight work with a generation and suppress stale STT, LLM, tool, TTS, and error events after cancellation.
- Invoke backend cancellation hooks as a best-effort latency optimization; generation checks provide correctness when cancellation is ignored.
- Add deterministic regression coverage for open, queued, in-flight, pre-speech, batch, and streaming state.
- Document C++ and C lifecycle semantics.

## Test plan

- Release build and full `ctest --output-on-failure`: 31/31 passed.
- Debug build and full `ctest --output-on-failure`: 31/31 passed.
- ASAN/UBSAN focused pipeline, stress, and C API tests passed.
- TSAN pipeline E2E passed.
- Release pipeline E2E passed five consecutive runs.