### PR TITLE
refactor: hand activity-recovery acceptance to the caller

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -57,6 +57,16 @@ configuration closes a paragraph after 550 ms of silence, retains 200 ms of
 pre/post-roll, first publishes continuous speech at ten seconds, and then
 revises a rolling window capped at twenty seconds.
 
+When MOSS returns paragraph text with no speaker activity, the track decodes
+again with extra source-local audio. Whether that retry still says what the
+paragraph said is application policy, so the track asks the caller:
+`Config::activity_recovery_compatible` judges a retry over the same audio, and
+`Config::following_recovery_compatible` a retry whose speaker-marked text runs
+on past the paragraph. Both receive flattened text; the structural
+preconditions stay in the engine. Leave either unset and that retry is
+rejected — the original paragraph publishes unchanged. There is no default
+rule.
+
 `MeetingTrackEvent::Preview` is non-durable text. A
 `MeetingTrackEvent::Revision` supplies an exact source-local replacement
 interval and authoritative blocks. MOSS activity labels remain scoped to that

--- a/include/speech_core/pipeline/meeting_transcription_track.h
+++ b/include/speech_core/pipeline/meeting_transcription_track.h
@@ -67,6 +67,31 @@ public:
         /// Microphone keeps MOSS text/timing but discards activity labels and
         /// gates sub-400 ms results on independent preview agreement.
         bool microphone = false;
+
+        /// Whether a retry over the SAME audio may supply this paragraph's
+        /// speaker activity. Both decodes heard the same speech, so the
+        /// caller's rule should be symmetric.
+        ///
+        /// Deciding whether a re-decode still says what the paragraph said is
+        /// application policy, not engine mechanics: it is a judgement about
+        /// the product's transcripts and it carries a measured threshold the
+        /// engine cannot own. When this is unset the retry is REJECTED and the
+        /// original paragraph is published unchanged. There is deliberately no
+        /// default rule — an engine that has not been told how to judge a
+        /// re-decode should not judge it. Do not restore one.
+        std::function<bool(const std::string& original,
+                           const std::string& recovered)>
+            activity_recovery_compatible;
+
+        /// Whether a retry's speaker-marked text may supply a pending
+        /// paragraph's activity when the marked segment runs on past it.
+        ///
+        /// Same ownership and the same default: unset REJECTS the retry and
+        /// the original paragraph is published unchanged. Do not restore a
+        /// default rule here either.
+        std::function<bool(const std::string& original,
+                           const std::string& activity)>
+            following_recovery_compatible;
     };
 
     using EventCallback = std::function<void(const MeetingTrackEvent&)>;

--- a/src/pipeline/meeting_transcription_track.cpp
+++ b/src/pipeline/meeting_transcription_track.cpp
@@ -245,37 +245,6 @@ bool short_microphone_agrees(
     return contains_contiguous(preview_tokens, result_tokens);
 }
 
-double text_similarity(
-    const std::vector<std::string>& left,
-    const std::vector<std::string>& right) {
-    if (left.empty() || right.empty()) return 0.0;
-    std::vector<std::size_t> previous(right.size() + 1, 0);
-    for (const auto& left_word : left) {
-        std::vector<std::size_t> current(
-            right.size() + 1, 0);
-        for (std::size_t index = 0;
-             index < right.size(); ++index) {
-            current[index + 1] =
-                left_word == right[index]
-                ? previous[index] + 1
-                : std::max(
-                    previous[index + 1], current[index]);
-        }
-        previous = std::move(current);
-    }
-    return static_cast<double>(previous.back())
-        / static_cast<double>(
-            std::max(left.size(), right.size()));
-}
-
-bool activity_recovery_compatible(
-    const std::string& original,
-    const std::string& recovered) {
-    return text_similarity(
-        normalized_tokens(original),
-        normalized_tokens(recovered)) >= 0.60;
-}
-
 double elapsed_ms(const Clock::time_point& started) {
     return std::chrono::duration<double, std::milli>(
         Clock::now() - started).count();
@@ -931,8 +900,12 @@ private:
                 if (!current_text.empty()) current_text.push_back(' ');
                 current_text += segment.text;
             }
+            // Whether the retry still says what the paragraph said is the
+            // caller's rule. With no rule installed the retry is rejected and
+            // the original paragraph publishes unchanged.
             if (!current_segments.empty()
-                && activity_recovery_compatible(
+                && config.activity_recovery_compatible
+                && config.activity_recovery_compatible(
                     current_text, result.text)) {
                 const double shift = static_cast<double>(
                     request.audio_start_sample
@@ -1070,12 +1043,18 @@ private:
             });
     }
 
-    static bool following_recovery_compatible(
+    // Shape is the engine's business: the paragraph must still be missing
+    // activity, the retry must have some, and the marked text must be at
+    // least as long as the paragraph it is meant to cover. Whether the two
+    // agree is the caller's, and with no rule installed the retry is rejected
+    // so the original paragraph publishes unchanged.
+    bool following_recovery_compatible(
         const std::vector<MeetingTranscriptBlock>& original,
-        const std::vector<MeetingTranscriptBlock>& recovered) {
+        const std::vector<MeetingTranscriptBlock>& recovered) const {
         if (original.empty()
             || blocks_contain_activity(original)
-            || !blocks_contain_activity(recovered)) {
+            || !blocks_contain_activity(recovered)
+            || !config.following_recovery_compatible) {
             return false;
         }
         std::string original_text;
@@ -1102,13 +1081,8 @@ private:
                 < original_words.size()) {
             return false;
         }
-        const std::vector<std::string> prefix(
-            activity_words.begin(),
-            activity_words.begin()
-                + static_cast<std::ptrdiff_t>(
-                    original_words.size()));
-        return text_similarity(
-            original_words, prefix) >= 0.80;
+        return config.following_recovery_compatible(
+            original_text, activity_text);
     }
 
     std::optional<MeetingTrackEvent>

--- a/tests/test_meeting_transcription_track.cpp
+++ b/tests/test_meeting_transcription_track.cpp
@@ -1,7 +1,13 @@
 #include "speech_core/pipeline/meeting_transcription_track.h"
 
+// CI configures Release and RelWithDebInfo, both of which define NDEBUG, so
+// every assertion below would otherwise compile away and the file would pass
+// without checking anything.
+#undef NDEBUG
+
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -208,6 +214,46 @@ public:
 private:
     int sample_rate_;
 };
+
+std::vector<std::string> lowercase_words(const std::string& text) {
+    std::vector<std::string> result;
+    std::string token;
+    for (const char value : text) {
+        if (std::isspace(static_cast<unsigned char>(value))) {
+            if (!token.empty()) {
+                result.push_back(token);
+                token.clear();
+            }
+            continue;
+        }
+        token.push_back(static_cast<char>(
+            std::tolower(static_cast<unsigned char>(value))));
+    }
+    if (!token.empty()) result.push_back(token);
+    return result;
+}
+
+// Stands in for the application policy the engine no longer owns. A retry over
+// the same audio has to repeat the paragraph, so this rule is symmetric.
+bool retry_repeats_paragraph(
+    const std::string& original, const std::string& recovered) {
+    const auto original_words = lowercase_words(original);
+    return !original_words.empty()
+        && original_words == lowercase_words(recovered);
+}
+
+// Stands in for the application policy for a retry whose speaker-marked text
+// runs on past the paragraph: the paragraph's words have to open it.
+bool activity_opens_with_paragraph(
+    const std::string& original, const std::string& activity) {
+    const auto original_words = lowercase_words(original);
+    const auto activity_words = lowercase_words(activity);
+    return !original_words.empty()
+        && activity_words.size() >= original_words.size()
+        && std::equal(
+            original_words.begin(), original_words.end(),
+            activity_words.begin());
+}
 
 speech_core::DiarizedTranscriptionResult moss_result(
     std::string text,
@@ -517,6 +563,7 @@ void test_preceding_speech_recovers_activity_without_inheritance() {
     speech_core::MeetingTranscriptionTrack::Config config;
     config.sample_rate = sample_rate;
     config.silence_close_seconds = 0.5f;
+    config.activity_recovery_compatible = retry_repeats_paragraph;
     speech_core::MeetingTranscriptionTrack track(
         preview, moss, vad, config,
         [&](const speech_core::MeetingTrackEvent& event) {
@@ -544,6 +591,65 @@ void test_preceding_speech_recovers_activity_without_inheritance() {
         }));
 }
 
+// The engine still re-decodes with preceding context, but with no caller rule
+// it has nothing to judge the retry by, so the paragraph publishes as it was.
+void test_activity_recovery_without_policy_keeps_original() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "yes");
+    ScriptedMoss moss(
+        sample_rate,
+        {
+            moss_result(
+                "first paragraph",
+                {{0.0f, 1.0f, "S01", "first paragraph"}}),
+            moss_result("yes"),
+            moss_result(
+                "yes",
+                {{1.5f, 2.5f, "S02", "yes"}}),
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+    push_chunks(
+        track, sample_rate, 10, 5, chunk,
+        2'500'000'000);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(moss.call_count() == 3);
+    assert(std::any_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return event.type
+                    == speech_core::MeetingTrackEventType::Revision
+                && event.blocks.size() == 1
+                && event.blocks[0].text == "yes"
+                && event.blocks[0].activity_label.empty();
+        }));
+    assert(std::none_of(
+        captured.begin(), captured.end(),
+        [](const auto& event) {
+            return std::any_of(
+                event.blocks.begin(), event.blocks.end(),
+                [](const auto& block) {
+                    return block.activity_label == "S02";
+                });
+        }));
+}
+
 void test_following_speech_backfills_only_compatible_fragment() {
     constexpr int sample_rate = 1000;
     constexpr std::size_t chunk = 100;
@@ -568,6 +674,8 @@ void test_following_speech_backfills_only_compatible_fragment() {
     speech_core::MeetingTranscriptionTrack::Config config;
     config.sample_rate = sample_rate;
     config.silence_close_seconds = 0.5f;
+    config.following_recovery_compatible =
+        activity_opens_with_paragraph;
     speech_core::MeetingTranscriptionTrack track(
         preview, moss, vad, config,
         [&](const speech_core::MeetingTrackEvent& event) {
@@ -623,6 +731,8 @@ void test_following_speech_does_not_guess_from_mismatched_text() {
     speech_core::MeetingTranscriptionTrack::Config config;
     config.sample_rate = sample_rate;
     config.silence_close_seconds = 0.5f;
+    config.following_recovery_compatible =
+        activity_opens_with_paragraph;
     speech_core::MeetingTranscriptionTrack track(
         preview, moss, vad, config,
         [&](const speech_core::MeetingTrackEvent& event) {
@@ -649,6 +759,62 @@ void test_following_speech_does_not_guess_from_mismatched_text() {
         }));
 }
 
+// Same retry, no caller rule: the fragment keeps the unlabelled form it was
+// first published with and is never republished with a borrowed label.
+void test_following_recovery_without_policy_keeps_original() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "yes");
+    ScriptedMoss moss(
+        sample_rate,
+        {
+            moss_result("yes"),
+            moss_result(
+                "current words",
+                {{0.2f, 1.2f, "S02", "current words"}}),
+            moss_result(
+                "yes current words",
+                {
+                    {0.0f, 1.0f, "S01", "yes"},
+                    {1.5f, 2.5f, "S02", "current words"},
+                }),
+        });
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 10, 5, chunk);
+    track.wait_idle();
+    push_chunks(
+        track, sample_rate, 10, 5, chunk,
+        2'500'000'000);
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    assert(moss.call_count() == 3);
+    std::size_t matching_revisions = 0;
+    for (const auto& event : captured) {
+        if (event.type
+                != speech_core::MeetingTrackEventType::Revision
+            || event.blocks.size() != 1
+            || event.blocks[0].text != "yes") {
+            continue;
+        }
+        ++matching_revisions;
+        assert(event.blocks[0].activity_label.empty());
+    }
+    assert(matching_revisions == 1);
+}
+
 }  // namespace
 
 int main() {
@@ -660,8 +826,10 @@ int main() {
     test_continuous_windows_are_bounded();
     test_continuous_windows_consume_identity_audio_once();
     test_preceding_speech_recovers_activity_without_inheritance();
+    test_activity_recovery_without_policy_keeps_original();
     test_following_speech_backfills_only_compatible_fragment();
     test_following_speech_does_not_guess_from_mismatched_text();
+    test_following_recovery_without_policy_keeps_original();
     std::cout << "Meeting transcription track tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary

`MeetingTranscriptionTrack` retries a paragraph that MOSS returned with text but no speaker activity markers, decoding again with extra source-local audio. It also decided, on its own, whether the retry still said what the paragraph said — a `text_similarity(...) >= 0.60` check for the same-audio retry and a `>= 0.80` prefix check for the following-context retry.

That judgement is application policy with a measured threshold, not engine mechanics. It belongs to the app whose transcripts it is about, and living here it had drifted from that app. This moves the decision out and leaves the mechanics behind.

## What changed

`MeetingTranscriptionTrack::Config` gains two optional predicates:

- `activity_recovery_compatible(original, recovered)` — a retry over the **same** audio. Both decodes heard the same speech, so the caller's rule should be symmetric.
- `following_recovery_compatible(original, activity)` — a retry whose speaker-marked text runs on past the pending paragraph.

Both take flattened text. Block-to-text flattening is mechanical and stays in the engine, as do the structural preconditions: the paragraph must still have no activity, the retry must have some, and the marked text must be at least as long as the paragraph it is meant to cover. Those are about shape, not about agreement.

**With a predicate unset the retry is rejected and the original paragraph publishes unchanged.** The thresholds are deleted rather than kept as a fallback — an engine that has not been told how to judge a re-decode should not judge it. The header says so, so nobody restores a default later.

Deleted: `text_similarity` and the file-local `activity_recovery_compatible`. `normalized_tokens` and everything under it stay — the short-microphone preview agreement check still uses them, and the "activity at least as long as the original" precondition is still expressed in words.

Nothing else changes. No identity or diarization code is touched, and there is no C ABI or example exposing this config.

## Test plan

`cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build && ctest --output-on-failure` — 31/31 pass. Same in a `Debug` build — 31/31 pass.

Three existing tests relied on the deleted rules and now install a predicate in the fixture instead:

- `test_preceding_speech_recovers_activity_without_inheritance`
- `test_following_speech_backfills_only_compatible_fragment`
- `test_following_speech_does_not_guess_from_mismatched_text` — kept its predicate so it still fails for the real reason rather than trivially

Two new tests pin the default: `test_activity_recovery_without_policy_keeps_original` and `test_following_recovery_without_policy_keeps_original`. Both drive the same MOSS script as the accepting cases with no predicate installed, assert the retry still ran (three MOSS calls), and assert the paragraph publishes with its original text and no activity label. Both were verified to fail against a temporarily reinstated accept-when-unset default.

## One thing that made this larger

`tests/test_meeting_transcription_track.cpp` checks everything through `assert`, and CI configures `Release` and `RelWithDebInfo` — both define `NDEBUG`, so every assertion in the file was compiling away and it passed without checking anything. The two new default tests would have been silently vacuous. The file now `#undef NDEBUG`s before `<cassert>`; with assertions live it passes in Release and Debug, 30 consecutive runs each. Other test files in the suite have the same problem and are left alone here.