### PR TITLE
Stop the Whisper download script dying without HF_TOKEN

### DIFF
--- a/scripts/download_whisper_onnx.sh
+++ b/scripts/download_whisper_onnx.sh
@@ -41,7 +41,12 @@ download() {
     return
   fi
   echo "download ${REPO}/${name}"
-  if ! curl -L --fail --retry 3 "${AUTH_ARGS[@]}" -o "${out}.part" "$url"; then
+  # Expanding an empty array is an "unbound variable" error under set -u in
+  # bash 3.2, which is what /bin/bash still is on macOS — so without HF_TOKEN
+  # set, this script used to die on its first download. The +"${...}" form
+  # expands to nothing instead.
+  if ! curl -L --fail --retry 3 ${AUTH_ARGS[@]+"${AUTH_ARGS[@]}"} \
+       -o "${out}.part" "$url"; then
     rm -f "${out}.part"
     if [ "$required" = "1" ]; then
       exit 1


### PR DESCRIPTION
## Summary

`scripts/download_whisper_onnx.sh` aborts on its first download for anyone who
has not set `HF_TOKEN` — which is everyone fetching the public bundles.

`AUTH_ARGS` stays empty when there is no token, and expanding an empty array is
an "unbound variable" error under `set -u` in bash 3.2, still what `/bin/bash`
is on macOS:

```
$ /bin/bash -c 'set -u; ARGS=(); echo "${ARGS[@]}"'
/bin/bash: ARGS[@]: unbound variable
```

## What changed

One line in the `download()` helper, using the `${ARGS[@]+"${ARGS[@]}"}` form,
which expands to nothing when the array is empty instead of erroring. No change
in behaviour when `HF_TOKEN` is set.

`download_whisper_onnx.sh` was the only script carrying the pattern.

## Test plan

- `bash -n scripts/download_whisper_onnx.sh` — clean
- `env -u HF_TOKEN /bin/bash scripts/download_whisper_onnx.sh small int8 /tmp/wh`
  under bash 3.2.57: fails on `main` with `AUTH_ARGS[@]: unbound variable`,
  downloads normally with this change