### PR TITLE
Stop a throwing backend from taking the host process down

### DIFF
--- a/include/speech_core/pipeline/voice_pipeline.h
+++ b/include/speech_core/pipeline/voice_pipeline.h
@@ -174,7 +174,13 @@ private:
     bool cancel_pending_ = false;
     bool cancel_shutdown_ = false;
 
+    /// Thread entry. Runs worker_loop_impl and converts anything it throws
+    /// into an Error event — a backend that raises must not abort the host
+    /// process, which for an embedded SDK means taking the whole app with it.
     void worker_loop();
+    void worker_loop_impl();
+    /// Reports a worker that has stopped and marks the pipeline not running.
+    void fail_worker(const std::string& message);
     void cancel_loop();
     void on_turn_event(const TurnEvent& event);
     void process_utterance(const std::string& transcript,

--- a/src/pipeline/voice_pipeline.cpp
+++ b/src/pipeline/voice_pipeline.cpp
@@ -192,6 +192,35 @@ void VoicePipeline::push_audio(const float* samples, size_t count) {
 }
 
 void VoicePipeline::worker_loop() {
+    // Every backend call below reaches third-party runtimes that report
+    // failure by throwing — ORT does this for a graph whose inputs do not
+    // match what the wrapper feeds it. Letting that escape a std::thread
+    // entry point calls std::terminate, so an SDK consumer loses its whole
+    // process to a model problem it could otherwise have handled.
+    try {
+        worker_loop_impl();
+    } catch (const std::exception& e) {
+        fail_worker(std::string("speech worker stopped: ") + e.what());
+    } catch (...) {
+        fail_worker("speech worker stopped: unknown error");
+    }
+}
+
+void VoicePipeline::fail_worker(const std::string& message) {
+    // Deliberately not emit_error: that drops anything whose generation is no
+    // longer current, and a worker that has died is worth reporting whichever
+    // turn it belonged to. The worker is gone once this returns, so the state
+    // has to say so — otherwise is_running() keeps claiming a live pipeline.
+    running_.store(false);
+    state_.store(State::Idle);
+
+    PipelineEvent error;
+    error.type = EventType::Error;
+    error.text = message;
+    if (on_event_) on_event_(error);
+}
+
+void VoicePipeline::worker_loop_impl() {
     // Warm up STT model — first inference is slow due to Neural Engine/GPU
     // cold start. Running a dummy transcription brings latency from ~3s to <1s.
     if (config_.warmup_stt) {

--- a/tests/test_pipeline_e2e.cpp
+++ b/tests/test_pipeline_e2e.cpp
@@ -449,6 +449,46 @@ void test_stt_error_propagation() {
     printf("  PASS: stt_error_propagation\n");
 }
 
+/// Warm-up runs a transcribe before any audio arrives, so it is the first call
+/// to touch a model and the one a truncated download fails on. test_stt_warmup
+/// covers the succeeding case and test_stt_error_propagation covers a throwing
+/// STT during an utterance, where the worker already guards it — the crossing
+/// of the two was what nothing covered. Unguarded, warm-up throws out of the
+/// worker thread's entry point, which is std::terminate: the host application
+/// dies rather than seeing an error it could handle.
+void test_stt_warmup_error_does_not_terminate() {
+    MockSTT stt;
+    MockTTS tts;
+    MockVAD vad;
+
+    stt.should_throw = true;
+
+    auto config = test_config();
+    config.warmup_stt = true;
+    config.mode = AgentConfig::Mode::Echo;
+
+    EventLog log;
+    VoicePipeline pipeline(stt, tts, nullptr, vad, config,
+        [&log](const PipelineEvent& e) { log.on_event(e); });
+
+    pipeline.start();
+
+    // No audio is pushed, so there is no utterance to wait on — the failure
+    // happens on the worker thread as soon as it starts.
+    for (int i = 0; i < 200 && !log.has(EventType::Error); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    assert(stt.call_count == 1);
+    assert(log.has(EventType::Error));
+    assert(log.text_for(EventType::Error).find("STT") != std::string::npos);
+    // A worker that has stopped must not keep claiming to run.
+    assert(!pipeline.is_running());
+
+    pipeline.stop();
+    printf("  PASS: stt_warmup_error_does_not_terminate\n");
+}
+
 void test_llm_error_propagation() {
     MockSTT stt;
     MockTTS tts;
@@ -3867,6 +3907,7 @@ int main() {
     test_transcribe_only_mode();
     test_push_text_bypasses_stt();
     test_stt_error_propagation();
+    test_stt_warmup_error_does_not_terminate();
     test_llm_error_propagation();
     test_tts_error_propagation();
     test_interruption();


### PR DESCRIPTION
## What

`VoicePipeline::worker_loop` is a `std::thread` entry point with no exception guard around its warm-up transcribe. ORT signals a graph whose inputs disagree with what the wrapper feeds it by throwing, and a truncated or re-exported bundle produces exactly that. Escaping a thread entry point, it calls `std::terminate` — an application embedding the SDK loses its whole process to a model problem it could have handled.

Observed on a Galaxy S23 Ultra as SIGABRT 307 ms after `start()`, before any audio was pushed:

```
Abort message: 'terminating due to uncaught exception of type std::runtime_error:
  ORT: Unexpected input data type. Actual: (tensor(int64)) , expected: (tensor(float))'
  #06 ort_check(OrtApi const*, OrtStatus*)
  #07 speech_core::OnnxCanaryStt::transcribe(float const*, unsigned long, int)+2136
  #08 speech_core::VoicePipeline::worker_loop()+208
```

Warm-up is the first call to touch a model, which is why it surfaced there — and why this is reachable on every STT backend, not only Canary.

## The gap this closes

The utterance path already guards `transcribe`, and `test_stt_error_propagation` covers it. Warm-up did not, and `test_stt_warmup` only covers the succeeding case. The crossing of the two — warm-up *and* a throwing backend — was untested, so the one call that runs before any audio and against a possibly-corrupt file had no coverage.

`fail_worker` deliberately bypasses `emit_error`'s current-turn check: a worker that has died is worth reporting whichever turn it belonged to. It also clears `running_` so `is_running()` stops claiming a live pipeline after the worker is gone.

## Verification

- `test_stt_warmup_error_does_not_terminate` added. Confirmed it aborts the test binary without the fix and passes with it.
- `ctest`: **31/31 passed**, including the existing warm-up and error-propagation tests.

## Note

This does not explain *why* the tensor types disagreed — that crash has not reproduced since, and the app data from the runs that produced it is gone. What it guarantees is that the next occurrence arrives as a `SpeechEvent.Error` with a readable message instead of a tombstone.