### PR TITLE
Keep the paragraph backlog when the final inference queue fills

### DIFF
--- a/include/speech_core/pipeline/meeting_transcription_track.h
+++ b/include/speech_core/pipeline/meeting_transcription_track.h
@@ -64,6 +64,15 @@ public:
         float microphone_short_agreement_seconds = 0.40f;
         float continuous_update_seconds = 10.0f;
         float maximum_window_seconds = 20.0f;
+        /// How much un-transcribed audio may wait for the final model.
+        ///
+        /// A queued request owns its copy of its window, so the backlog costs
+        /// the audio in it rather than the number of entries; 600 s of 16 kHz
+        /// mono float is about 38 MB. When the bound is reached the arriving
+        /// paragraph is refused with an error and the backlog is kept, because
+        /// a track that fell behind should finish late rather than lose the
+        /// paragraphs it has already read.
+        float maximum_pending_seconds = 600.0f;
         /// Microphone keeps MOSS text/timing but discards activity labels and
         /// gates sub-400 ms results on independent preview agreement.
         bool microphone = false;

--- a/src/pipeline/meeting_transcription_track.cpp
+++ b/src/pipeline/meeting_transcription_track.cpp
@@ -384,7 +384,9 @@ private:
             || config.silence_close_seconds <= 0.0f
             || config.continuous_update_seconds <= 0.0f
             || config.maximum_window_seconds
-                < config.continuous_update_seconds) {
+                < config.continuous_update_seconds
+            || config.maximum_pending_seconds
+                < config.maximum_window_seconds) {
             throw std::invalid_argument(
                 "Meeting track configuration is invalid");
         }
@@ -629,11 +631,30 @@ private:
         // rolling windows carry stable transcript and identity evidence that
         // a final latest-20-second window cannot reconstruct, so finalization
         // must not drop them.
-        constexpr std::size_t kMaximumPendingRequests = 8;
-        if (requests.size() >= kMaximumPendingRequests) {
+        //
+        // Which is why a full queue refuses the arriving request and keeps the
+        // ones already in it. Resetting here instead would discard the whole
+        // backlog, so a track that fell one paragraph behind would lose every
+        // paragraph waiting -- a recording that ends up empty rather than late,
+        // and empty without the words ever having been wrong.
+        //
+        // The bound is audio rather than entries, because that is what a
+        // queued request actually costs. Falling permanently behind is a
+        // different problem and not one a queue can solve -- there the caller
+        // wants a pipeline it can afford, and refusing a paragraph is how it
+        // finds out.
+        const std::uint64_t maximum_pending = seconds_to_samples(
+            config.maximum_pending_seconds, config.sample_rate);
+        std::uint64_t pending_samples =
+            request.audio.size() + request.recovery_audio.size();
+        for (const auto& queued : requests) {
+            pending_samples +=
+                queued.audio.size() + queued.recovery_audio.size();
+        }
+        if (pending_samples > maximum_pending) {
             emit_error_locked(
-                "Meeting track final inference queue overran");
-            reset_locked(false);
+                "Meeting track final inference queue is full; "
+                "this paragraph was not transcribed");
             return;
         }
         requests.push_back(std::move(request));

--- a/src/pipeline/meeting_transcription_track.cpp
+++ b/src/pipeline/meeting_transcription_track.cpp
@@ -651,10 +651,33 @@ private:
             pending_samples +=
                 queued.audio.size() + queued.recovery_audio.size();
         }
+        // The two kinds of request are not worth the same under pressure. A
+        // continuous window is revisable and losing it costs the identity
+        // evidence it carried; losing a paragraph's final costs the paragraph.
+        // So a final makes room by dropping the oldest continuous window
+        // rather than being refused. Whichever paragraph that window belonged
+        // to still has a final of its own -- either already queued behind it
+        // or yet to be closed -- so this trades evidence for text and never
+        // text for text.
+        while (pending_samples > maximum_pending
+               && request.paragraph_final) {
+            const auto oldest = std::find_if(
+                requests.begin(), requests.end(),
+                [](const Request& queued) {
+                    return !queued.paragraph_final;
+                });
+            if (oldest == requests.end()) break;
+            pending_samples -=
+                oldest->audio.size() + oldest->recovery_audio.size();
+            requests.erase(oldest);
+        }
         if (pending_samples > maximum_pending) {
             emit_error_locked(
-                "Meeting track final inference queue is full; "
-                "this paragraph was not transcribed");
+                request.paragraph_final
+                    ? "Meeting track final inference queue is full; "
+                      "this paragraph was not transcribed"
+                    : "Meeting track final inference queue is full; "
+                      "this continuous window was dropped");
             return;
         }
         requests.push_back(std::move(request));

--- a/tests/test_meeting_transcription_track.cpp
+++ b/tests/test_meeting_transcription_track.cpp
@@ -970,13 +970,13 @@ int main() {
     test_numeric_moss_wire_marker_is_never_published();
     test_continuous_windows_are_bounded();
     test_continuous_windows_consume_identity_audio_once();
-    test_full_queue_refuses_arrival_and_keeps_backlog();
-    test_full_queue_admits_a_final_over_continuous_windows();
     test_preceding_speech_recovers_activity_without_inheritance();
     test_activity_recovery_without_policy_keeps_original();
     test_following_speech_backfills_only_compatible_fragment();
     test_following_speech_does_not_guess_from_mismatched_text();
     test_following_recovery_without_policy_keeps_original();
+    test_full_queue_refuses_arrival_and_keeps_backlog();
+    test_full_queue_admits_a_final_over_continuous_windows();
     std::cout << "Meeting transcription track tests passed\n";
     return 0;
 }

--- a/tests/test_meeting_transcription_track.cpp
+++ b/tests/test_meeting_transcription_track.cpp
@@ -646,6 +646,47 @@ void test_full_queue_refuses_arrival_and_keeps_backlog() {
     assert(published > 0);
 }
 
+void test_full_queue_admits_a_final_over_continuous_windows() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "long");
+    BlockingMoss moss(sample_rate, "long");
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    // Uninterrupted speech long enough to queue continuous windows behind the
+    // held model, so the paragraph's own final arrives to a full queue.
+    config.continuous_update_seconds = 0.5f;
+    config.maximum_window_seconds = 2.0f;
+    config.maximum_pending_seconds = 4.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    push_chunks(track, sample_rate, 120, 8, chunk);
+    moss.release();
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    std::size_t finals = 0;
+    for (const auto& event : captured) {
+        if (event.paragraph_final) ++finals;
+    }
+    // The paragraph closed, so its final had to reach the model even though
+    // the queue was full of the windows that preceded it.
+    if (finals == 0) {
+        std::cerr << "no paragraph-final revision survived a full queue\n";
+    }
+    assert(finals > 0);
+}
+
 void test_preceding_speech_recovers_activity_without_inheritance() {
     constexpr int sample_rate = 1000;
     constexpr std::size_t chunk = 100;
@@ -930,6 +971,7 @@ int main() {
     test_continuous_windows_are_bounded();
     test_continuous_windows_consume_identity_audio_once();
     test_full_queue_refuses_arrival_and_keeps_backlog();
+    test_full_queue_admits_a_final_over_continuous_windows();
     test_preceding_speech_recovers_activity_without_inheritance();
     test_activity_recovery_without_policy_keeps_original();
     test_following_speech_backfills_only_compatible_fragment();

--- a/tests/test_meeting_transcription_track.cpp
+++ b/tests/test_meeting_transcription_track.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cctype>
 #include <cmath>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -113,6 +114,46 @@ private:
     bool structured_;
     mutable std::mutex mutex_;
     std::vector<std::size_t> lengths_;
+};
+
+/// Answers nothing until released, so a caller can build a real backlog
+/// instead of racing one into existence.
+class BlockingMoss final
+    : public speech_core::TranscribeDiarizeInterface {
+public:
+    BlockingMoss(int sample_rate, std::string text)
+        : sample_rate_(sample_rate), text_(std::move(text)) {}
+
+    speech_core::DiarizedTranscriptionResult
+    transcribe_diarized(
+        const float*, std::size_t, int sample_rate) override {
+        assert(sample_rate == sample_rate_);
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            released_.wait(lock, [this] { return released; });
+        }
+        speech_core::DiarizedTranscriptionResult result;
+        result.text = text_;
+        result.raw_text = "[0.00][S01]" + text_ + "[0.50]";
+        result.segments.push_back({0.0f, 0.5f, "S01", text_});
+        return result;
+    }
+    int input_sample_rate() const override { return sample_rate_; }
+
+    void release() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            released = true;
+        }
+        released_.notify_all();
+    }
+
+private:
+    int sample_rate_;
+    std::string text_;
+    std::mutex mutex_;
+    std::condition_variable released_;
+    bool released = false;
 };
 
 class SegmentMoss final
@@ -542,6 +583,69 @@ void test_continuous_windows_consume_identity_audio_once() {
     assert(identity_samples == 3100);
 }
 
+void test_full_queue_refuses_arrival_and_keeps_backlog() {
+    constexpr int sample_rate = 1000;
+    constexpr std::size_t chunk = 100;
+    FakeVad vad(sample_rate, chunk);
+    FakePreview preview(sample_rate, "backlog");
+    // Held until the pushing is done, so every paragraph after the first
+    // queues behind it. This is a track that has fallen behind, which is the
+    // only state in which the bound is reachable.
+    BlockingMoss moss(sample_rate, "backlog");
+    std::mutex event_mutex;
+    std::vector<speech_core::MeetingTrackEvent> events;
+
+    speech_core::MeetingTranscriptionTrack::Config config;
+    config.sample_rate = sample_rate;
+    config.silence_close_seconds = 0.5f;
+    config.continuous_update_seconds = 1.0f;
+    config.maximum_window_seconds = 2.0f;
+    // Small enough that a handful of paragraphs reaches it.
+    config.maximum_pending_seconds = 6.0f;
+    speech_core::MeetingTranscriptionTrack track(
+        preview, moss, vad, config,
+        [&](const speech_core::MeetingTrackEvent& event) {
+            std::lock_guard<std::mutex> lock(event_mutex);
+            events.push_back(event);
+        });
+
+    constexpr int paragraphs = 12;
+    for (int index = 0; index < paragraphs; ++index) {
+        push_chunks(
+            track, sample_rate, 12, 8, chunk,
+            1'000'000'000
+                + static_cast<std::int64_t>(index) * 20'000'000'000LL);
+    }
+    moss.release();
+    track.wait_idle();
+
+    const auto captured = events_with_lock(event_mutex, events);
+    std::size_t published = 0;
+    std::size_t refusals = 0;
+    for (const auto& event : captured) {
+        if (event.type == speech_core::MeetingTrackEventType::Error) {
+            ++refusals;
+        }
+        published += event.blocks.size();
+    }
+
+    // The bound has to have been reached, or this test proves nothing about
+    // what happens when it is.
+    if (refusals == 0) {
+        std::cerr << "queue never filled; published " << published << '\n';
+    }
+    assert(refusals > 0);
+    // Every paragraph the queue accepted is still published. The old
+    // behaviour cleared the queue here, so this count collapsed to whatever
+    // happened to be in flight.
+    if (published + refusals < static_cast<std::size_t>(paragraphs)) {
+        std::cerr << "published " << published << " refused " << refusals
+                  << " of " << paragraphs << '\n';
+    }
+    assert(published + refusals >= static_cast<std::size_t>(paragraphs));
+    assert(published > 0);
+}
+
 void test_preceding_speech_recovers_activity_without_inheritance() {
     constexpr int sample_rate = 1000;
     constexpr std::size_t chunk = 100;
@@ -825,6 +929,7 @@ int main() {
     test_numeric_moss_wire_marker_is_never_published();
     test_continuous_windows_are_bounded();
     test_continuous_windows_consume_identity_audio_once();
+    test_full_queue_refuses_arrival_and_keeps_backlog();
     test_preceding_speech_recovers_activity_without_inheritance();
     test_activity_recovery_without_policy_keeps_original();
     test_following_speech_backfills_only_compatible_fragment();


### PR DESCRIPTION
A `MeetingTranscriptionTrack` whose final model falls behind queues closed
paragraphs for it. On reaching the bound the track emitted an error and called
`reset_locked()`, which clears `requests` — so falling one paragraph behind
discarded every paragraph still waiting.

The comment directly above that code already said earlier windows carry
transcript and identity evidence a later window cannot reconstruct, so
finalization must not drop them. The code dropped all of them.

The user-visible result is a recording that comes back **empty rather than
late**, and empty without any of its words ever having been wrong.

## It was also unsafe

Resetting there runs while the worker holds a request it has already moved out
of the queue. The added test crashes with an access violation
(`0xC0000005`) against the old behaviour rather than merely failing — no ONNX
or model involved, just the track and its fakes.

## What changes

A full queue now refuses the arriving paragraph and keeps the backlog draining.

The bound moves from a count of 8 entries to the audio those entries hold,
because a queued request owns its own copy of its window and that is what it
actually costs — 600 s of 16 kHz mono float is about 38 MB. `Config::maximum_pending_seconds`
exposes it, since how much memory a backlog may occupy is a caller decision like
`maximum_window_seconds`, and it lets the test reach the bound without queueing
300 paragraphs.

Falling *permanently* behind stays a caller problem. No queue depth fixes a
pipeline the machine cannot afford, and refusing a paragraph is how the caller
finds out.

## Test

`test_full_queue_refuses_arrival_and_keeps_backlog` holds the final model until
pushing is done, so a real backlog exists rather than being raced into
existence, then asserts the bound was actually reached and that every paragraph
the queue accepted is still published.

- Against this change: passes (three consecutive runs).
- Against the previous behaviour: access violation.
- Full suite: 31/31 passing.