### PR TITLE
Let wait_idle mean publishing has finished

### DIFF
--- a/include/speech_core/pipeline/meeting_transcription_track.h
+++ b/include/speech_core/pipeline/meeting_transcription_track.h
@@ -135,7 +135,12 @@ public:
     /// Discard revisable work and reset VAD/ASR state without publishing it.
     void cancel();
 
-    /// Wait until every already queued final inference has completed.
+    /// Wait until every already queued final inference has completed AND its
+    /// events have been delivered, so what was published can be read after
+    /// this returns.
+    ///
+    /// Never call this, or `finish()`, from the event callback: the track is
+    /// not idle while a callback is running, so it would wait on itself.
     void wait_idle();
 
 private:

--- a/src/pipeline/meeting_transcription_track.cpp
+++ b/src/pipeline/meeting_transcription_track.cpp
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <cctype>
 #include <deque>
+#include <functional>
 #include <limits>
 #include <mutex>
 #include <stdexcept>
@@ -18,6 +19,19 @@ namespace speech_core {
 namespace {
 
 using Clock = std::chrono::steady_clock;
+
+/// Runs its action when the enclosing scope ends, however it ends.
+class ScopeExit {
+public:
+    explicit ScopeExit(std::function<void()> action)
+        : action_(std::move(action)) {}
+    ~ScopeExit() { action_(); }
+    ScopeExit(const ScopeExit&) = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+private:
+    std::function<void()> action_;
+};
 
 std::size_t seconds_to_samples(float seconds, int sample_rate) {
     if (!std::isfinite(seconds) || seconds < 0.0f || sample_rate <= 0) {
@@ -805,6 +819,20 @@ private:
                 worker_busy = true;
             }
 
+            // The track counts as idle only once this request has finished
+            // publishing, which is why the flag is cleared here rather than
+            // as soon as inference returns. A caller that waits for idle and
+            // then reads what was published would otherwise race the last
+            // paragraph out of its own transcript -- the events are emitted
+            // outside the lock, so clearing the flag first lets wait_idle
+            // return while they are still on their way. Every exit from this
+            // iteration goes through the guard, including the early ones.
+            const ScopeExit finish_request([this] {
+                std::lock_guard<std::mutex> lock(mutex);
+                worker_busy = false;
+                if (requests.empty()) idle_cv.notify_all();
+            });
+
             MeetingTrackEvent event;
             std::optional<MeetingTrackEvent>
                 following_recovery;
@@ -850,8 +878,6 @@ private:
             {
                 std::lock_guard<std::mutex> lock(mutex);
                 publish = request.generation == generation;
-                worker_busy = false;
-                if (requests.empty()) idle_cv.notify_all();
             }
             if (publish
                 && (event.type != MeetingTrackEventType::Revision


### PR DESCRIPTION
`MeetingTranscriptionTrack`'s worker cleared `worker_busy` and notified
`idle_cv` **before** emitting the request's events, and events are emitted
outside the lock:

```cpp
{
    std::lock_guard<std::mutex> lock(mutex);
    publish = request.generation == generation;
    worker_busy = false;                      // <-- idle already
    if (requests.empty()) idle_cv.notify_all();
}
if (publish && ...) {
    emit_unlocked(event);                     // <-- still delivering
}
```

So `wait_idle()` could return while the last paragraph was still on its way to
the callback. A caller that waits for idle and then reads what was published
can miss it — which for a recording means a paragraph that was transcribed
correctly, and then simply wasn't there.

The flag now clears through a scope guard at the end of the iteration, after
every emission and on the early-exit paths too, so idle means what the name
says. Emission stays outside the lock.

## How it was found

It surfaced in CI as the pre-existing
`test_following_speech_backfills_only_compatible_fragment` counting one
revision short, under the sanitizer job only. Reordering the suite made CI go
green — but that was luck, not a fix: the race still reproduces locally with
that ordering in place.

Measured with an AddressSanitizer build of the track tests, slow enough to open
the window reliably:

| | failures |
|---|---|
| before | 4 / 15 |
| after | 0 / 30 |

Full suite 31/31.

## Note

This makes an existing flaky test reliable rather than adding a new test for
it. A test that reproduces the race on demand would have to control when the
callback runs relative to `wait_idle`, which means a hook the class does not
have; the sanitizer build is the reproduction, and it is recorded above rather
than committed as a timing-dependent test that would be flaky in the other
direction.