### PR TITLE
Name the NeMo function the speaker cache was ported from

### DIFF
--- a/include/speech_core/models/sortformer_speaker_cache.h
+++ b/include/speech_core/models/sortformer_speaker_cache.h
@@ -20,9 +20,30 @@ namespace speech_core {
 /// still runs, still emits four plausible probabilities per frame, and simply
 /// stops meaning the same person.
 ///
-/// Ported from NeMo's `SortformerModules.streaming_update_async`. Batch is one:
-/// this serves a single recording, and a batch axis would only obscure the
-/// arithmetic.
+/// Ported from NeMo's `SortformerModules.streaming_update` -- the synchronous
+/// one. The async variant is a different algorithm, not a batched wrapper: it
+/// carries `spkcache_lengths` and reads each batch item's predictions at its
+/// own valid offset. Batch is one here: this serves a single recording, and a
+/// batch axis would only obscure the arithmetic.
+///
+/// One deliberate departure. NeMo grows the cache from empty; the exported
+/// graph cannot, because `spkcache` is declared [1, 188, 512] and every call
+/// must fill it. So the cache starts as `cache_frames` zero frames and every
+/// slot is treated as live, which is the async variant's fixed-buffer
+/// representation driven by the synchronous variant's arithmetic. The padding
+/// leaves on its own: a zero embedding scores as non-speech, `disable_low_scores`
+/// sends it to negative infinity, and the first compression replaces it with
+/// mean silence. That argument holds for predictions a real graph produces and
+/// not for arbitrary ones, so a harness that feeds every frame confident speech
+/// will see the padding survive and should not read that as a defect.
+///
+/// Checked against NeMo 2.7.3 driven on identical input, at both the streaming
+/// variant's periods and the shipped default's: worst relative cache difference
+/// 4.9e-07 and 5.0e-06 respectively, which is float32 accumulation over 96,256
+/// values. Give NeMo the same zero-prefilled cache when repeating this, and call
+/// `.eval()` first -- `_compress_spkcache` takes `permute_spk=self.training`,
+/// and an nn.Module defaults to training mode, so a stock instance permutes
+/// speakers at random and matches nothing.
 class SortformerSpeakerCache {
 public:
     struct Config {


### PR DESCRIPTION
The header credited `SortformerModules.streaming_update_async`. The code is the
synchronous `streaming_update`. The two are not a batched pair — the async
variant carries `spkcache_lengths` and reads each batch item's predictions at
its own valid offset — so a reader checking this against the named function
finds a length argument missing here and reasonably concludes the port dropped
it.

It also records the one place the port deliberately leaves NeMo, because it
looks like exactly that omission: the cache is a fixed zero-filled buffer,
since the exported graph declares `spkcache` as `[1, 188, 512]` and every call
must fill it, where NeMo grows it from empty. The padding leaves by scoring
rather than by a length — a zero embedding is non-speech, `disable_low_scores`
sends it to `-inf`, and the first compression replaces it with mean silence.
That argument holds for predictions a real graph produces, not for arbitrary
ones, so a harness feeding every frame confident speech will see the padding
survive and should not read that as a defect.

## Measurement

Driven on identical input against NeMo 2.7.3, worst relative cache difference
over 24 steps:

| variant | periods | worst rel |
|---|---|---|
| streaming | `chunk 6, rc 7, period 32` | 4.9e-07 |
| default (shipped) | `chunk 340, rc 40, period 188` | 5.0e-06 |

That is float32 accumulation over 96,256 values, and matches the level at which
the C++ and numpy ports already agreed with each other.

Two things make repeating this silently meaningless, so they are in the header:
NeMo must start from the same zero-prefilled cache, or step zero is not the
same question; and it must be in eval mode, because `_compress_spkcache` takes
`permute_spk=self.training` and a stock `nn.Module` is in training mode, so a
fresh instance permutes speakers at random and agrees with nothing.

Comment-only. Verified the header still compiles and the cache produces
byte-identical output at the shipped config.