### PR TITLE
feat(sortformer): stream diarization through ONNX Runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/whisper/onnx_whisper_stt.cpp
         src/models/canary/onnx_canary_stt.cpp
         src/models/pyannote/onnx_pyannote_segmentation.cpp
+        src/models/sortformer/onnx_sortformer_diarizer.cpp
         src/models/redimnet/onnx_redimnet_speaker_embedding.cpp
         src/models/wespeaker/onnx_wespeaker_embedding.cpp
     )
@@ -266,6 +267,15 @@ if(SPEECH_CORE_WITH_ONNX)
         target_link_libraries(speech_diarization_parity PRIVATE speech_core_models)
         if(MSVC)
             target_compile_definitions(speech_diarization_parity PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+
+        # The same claim for streaming Sortformer, where three things can be
+        # wrong on their own while the graph stays perfect: the mel front-end,
+        # the windowing, and which layout the prediction block is read in.
+        add_executable(speech_sortformer_parity examples/onnx/sortformer_parity.cpp)
+        target_link_libraries(speech_sortformer_parity PRIVATE speech_core_models)
+        if(MSVC)
+            target_compile_definitions(speech_sortformer_parity PRIVATE _USE_MATH_DEFINES NOMINMAX)
         endif()
     endif()
 endif()

--- a/examples/onnx/sortformer_parity.cpp
+++ b/examples/onnx/sortformer_parity.cpp
@@ -1,0 +1,177 @@
+// C++ gate for the streaming Sortformer wrapper.
+//
+// The Python parity in the consuming app's docs proves the exported GRAPH
+// matches PyTorch. This proves the C++ WRAPPER matches the reference driver —
+// a different claim, and the one that ships. Three things can only break here,
+// and each is silent:
+//
+//   1. The mel front-end. It is NeMo's `AudioToMelSpectrogramPreprocessor`,
+//      whose window is centred inside a wider FFT and whose padding is constant
+//      rather than reflect. Neither is visible in the config. Features that are
+//      subtly off produce confident, wrong speaker probabilities.
+//
+//   2. The windowing. A call owns 340 encoder frames and sees one frame of past
+//      and forty of future. Off by a frame and every label slides; off by the
+//      context and neighbouring calls report the same audio twice.
+//
+//   3. The prediction layout handed to the arrival-order cache. The graph emits
+//      a fixed-width FIFO block; the reference driver's own update derives its
+//      offsets from the FIFO's actual length. Reading one as the other takes the
+//      chunk up to forty frames early on the first call of every recording, and
+//      seeds the cache's scoring from that slice at the first compression —
+//      which outlives the step that caused it.
+//
+// The audio must be long enough to overflow the speaker cache. A recording that
+// fits one call never exercises the arrival-order update, and agreement then
+// means only that one forward pass agreed.
+//
+// Usage: speech_sortformer_parity <sortformer.onnx> <audio.f32> <reference.f32>
+//        (raw f32 mono @ 16 kHz; the reference is [frames x speakers] f32)
+
+#include "speech_core/models/onnx_sortformer_diarizer.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<float> read_f32(const std::string& path) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input) {
+        std::fprintf(stderr, "cannot open %s\n", path.c_str());
+        std::exit(2);
+    }
+    const std::streamsize bytes = input.tellg();
+    input.seekg(0);
+    std::vector<float> values(static_cast<std::size_t>(bytes) / sizeof(float));
+    input.read(reinterpret_cast<char*>(values.data()), bytes);
+    return values;
+}
+
+/// Audio arrives from a capture callback in small blocks, never in one piece,
+/// so it is fed that way here. A wrapper that only works when handed the whole
+/// recording would pass a kinder test and fail in the product.
+constexpr std::size_t kBlockSamples = 1600;  // 100 ms
+
+constexpr float kActive = 0.5f;
+constexpr double kMaxMeanError = 1e-4;
+constexpr double kMinAgreement = 0.999;
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        std::fprintf(
+            stderr,
+            "usage: speech_sortformer_parity <model.onnx> <audio.f32> "
+            "<reference.f32>\n");
+        return 2;
+    }
+    const std::vector<float> audio = read_f32(argv[2]);
+    const std::vector<float> reference = read_f32(argv[3]);
+
+    speech_core::OnnxSortformerDiarizer diarizer(argv[1], false);
+    const std::size_t speakers =
+        static_cast<std::size_t>(diarizer.speakers());
+    std::printf(
+        "audio %.1f s, %d speakers, %d frames per call, %.3f s per frame\n",
+        static_cast<double>(audio.size()) / 16000.0, diarizer.speakers(),
+        diarizer.chunk_frames(), static_cast<double>(diarizer.frame_seconds()));
+
+    std::vector<float> activity;
+    for (std::size_t offset = 0; offset < audio.size();
+         offset += kBlockSamples) {
+        const std::size_t count =
+            std::min(kBlockSamples, audio.size() - offset);
+        const std::vector<float> produced =
+            diarizer.push_audio(audio.data() + offset, count);
+        activity.insert(activity.end(), produced.begin(), produced.end());
+    }
+    const std::vector<float> tail = diarizer.end_stream();
+    activity.insert(activity.end(), tail.begin(), tail.end());
+
+    const std::size_t frames = activity.size() / speakers;
+    const std::size_t reference_frames = reference.size() / speakers;
+    std::printf(
+        "frames: wrapper %zu, reference %zu\n", frames, reference_frames);
+    if (frames != reference_frames) {
+        std::fprintf(
+            stderr,
+            "FAIL: frame counts differ. The windowing does not match the "
+            "reference driver, so nothing below is comparable.\n");
+        return 1;
+    }
+    if (frames == 0) {
+        std::fprintf(stderr, "FAIL: no frames produced\n");
+        return 1;
+    }
+
+    double total_error = 0.0;
+    double worst = 0.0;
+    std::size_t agreed = 0;
+    for (std::size_t index = 0; index < activity.size(); ++index) {
+        const double error =
+            std::fabs(static_cast<double>(activity[index])
+                      - static_cast<double>(reference[index]));
+        total_error += error;
+        if (error > worst) worst = error;
+        if ((activity[index] > kActive) == (reference[index] > kActive)) {
+            ++agreed;
+        }
+    }
+    const double mean_error =
+        total_error / static_cast<double>(activity.size());
+    const double agreement =
+        static_cast<double>(agreed) / static_cast<double>(activity.size());
+    std::printf(
+        "mean abs error %.8f  max %.6f  decision agreement %.6f\n",
+        mean_error, worst, agreement);
+
+    // A cache that never overflowed would agree trivially. Say how much of the
+    // recording ran, so a shortened fixture cannot quietly weaken the gate.
+    std::printf(
+        "calls %zu (the arrival-order update runs from the first onwards)\n",
+        frames / static_cast<std::size_t>(diarizer.chunk_frames()));
+
+    // Per-call agreement, because where a run diverges says what is wrong. A
+    // first call that already disagrees is the front-end or the windowing; one
+    // that agrees and then drifts is the arrival-order cache.
+    const std::size_t per_call =
+        static_cast<std::size_t>(diarizer.chunk_frames()) * speakers;
+    for (std::size_t start = 0, call = 0; start < activity.size();
+         start += per_call, ++call) {
+        const std::size_t stop = std::min(start + per_call, activity.size());
+        double error = 0.0;
+        std::size_t same = 0;
+        for (std::size_t index = start; index < stop; ++index) {
+            error += std::fabs(static_cast<double>(activity[index])
+                               - static_cast<double>(reference[index]));
+            if ((activity[index] > kActive) == (reference[index] > kActive)) {
+                ++same;
+            }
+        }
+        const double count = static_cast<double>(stop - start);
+        std::printf(
+            "  call %zu: mean %.6f agreement %.4f\n",
+            call, error / count, static_cast<double>(same) / count);
+    }
+    if (argc > 4) {
+        std::ofstream dump(argv[4], std::ios::binary);
+        dump.write(reinterpret_cast<const char*>(activity.data()),
+                   static_cast<std::streamsize>(activity.size()
+                                                * sizeof(float)));
+    }
+
+    if (mean_error > kMaxMeanError || agreement < kMinAgreement) {
+        std::fprintf(
+            stderr,
+            "FAIL: the wrapper does not reproduce the reference driver\n");
+        return 1;
+    }
+    std::printf("sortformer wrapper parity: passed\n");
+    return 0;
+}

--- a/include/speech_core/models/onnx_sortformer_diarizer.h
+++ b/include/speech_core/models/onnx_sortformer_diarizer.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "speech_core/models/sortformer_speaker_cache.h"
+
+#include <onnxruntime_c_api.h>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Streaming Sortformer diarization via ONNX Runtime.
+///
+/// Answers *who spoke when* as a continuous per-frame timeline, and nothing
+/// else. It produces no speaker embeddings, so naming a voice remains a
+/// separate question for an identity encoder — the same division a caller
+/// already has with any joint transcribe-diarize model.
+///
+/// Matches soniqo/Sortformer-Diarization-4spk-ONNX, the `default` export:
+///
+///   in:  chunk[1, 3048, 128]  spkcache[1, 188, 512]  fifo[1, 40, 512]
+///   out: spkcache_fifo_chunk_preds[1, 609, 4]
+///        chunk_pre_encode_embs[1, 381, 512]
+///
+/// 609 = 188 cache + 40 fifo + 381 window frames, and 3048 = 381 x 8. One call
+/// consumes 340 encoder frames — 27.2 s — of new audio and needs 40 more frames
+/// of audio after them, so a label is about 30 s behind the microphone. That
+/// latency is the design: labels are meant to reach text some other model has
+/// already displayed.
+///
+/// ## Why this is a stream and not a function
+///
+/// Arrival order is per *stream*. The speaker cache is what makes index 2 mean
+/// the same person in minute one and minute forty, and it is built up call by
+/// call. Constructing one of these per utterance, or calling `reset()` between
+/// paragraphs, restarts the numbering and throws away the entire advantage this
+/// model has over a window-local segmenter — after paying for its download and
+/// its arrival-order bookkeeping. Feed one instance the whole recording and ask
+/// it about time ranges afterwards.
+///
+/// ## What is deliberately absent
+///
+/// No threshold, and no notion of a turn, a segment or a speaker label. This
+/// returns probabilities. Deciding what counts as active speech, and how a
+/// range of frames becomes somebody's turn, is a product judgement with a
+/// measured constant behind it; an engine that invented one would be making
+/// that decision on the application's behalf, in the repository least able to
+/// tell when it had changed.
+///
+/// Not thread-safe — one per recording, driven from one thread.
+class OnnxSortformerDiarizer {
+public:
+    struct Config {
+        int sample_rate = 16000;
+
+        /// Encoder frames the model needs either side of the frames a call
+        /// reports on. They belong to neighbouring calls; publishing them would
+        /// report the same audio twice.
+        int left_context = 1;
+        int right_context = 40;
+
+        /// Mel frames per encoder frame, and the mel hop. Together these fix
+        /// how much wall-clock one output frame covers: 8 x 10 ms = 80 ms.
+        int subsampling = 8;
+        int mel_hop = 160;
+        int mel_bins = 128;
+        int n_fft = 512;
+        int win_length = 400;
+
+        /// The arrival-order cache's own parameters. Its defaults belong to
+        /// this exported variant; pairing one variant's graph with another's
+        /// periods evicts the wrong frames while looking healthy.
+        SortformerSpeakerCache::Config cache;
+    };
+
+    /// `hw_accel` selects a hardware execution provider where one is available.
+    /// The geometry is read from the graph rather than assumed — a bundle
+    /// exported at a different chunk length would otherwise be driven with this
+    /// one's windowing and produce confident nonsense.
+    explicit OnnxSortformerDiarizer(
+        const std::string& model_path, bool hw_accel = true);
+    ~OnnxSortformerDiarizer();
+
+    OnnxSortformerDiarizer(const OnnxSortformerDiarizer&) = delete;
+    OnnxSortformerDiarizer& operator=(const OnnxSortformerDiarizer&) = delete;
+
+    /// Feed 16 kHz mono PCM in arrival order.
+    ///
+    /// Returns whatever frames became final during this call, as
+    /// `[frames x speakers]` probabilities in chronological order — usually
+    /// nothing, then 340 frames at once when enough audio has arrived. Append
+    /// them; frame `i` of the recording covers
+    /// `[i * frame_seconds(), (i + 1) * frame_seconds())`.
+    std::vector<float> push_audio(const float* samples, std::size_t length);
+
+    /// Finalise the tail. The remaining audio is padded to a full window, so
+    /// the last frames see zeros where the recording simply stopped.
+    ///
+    /// Returns the frames that padding made final.
+    std::vector<float> end_stream();
+
+    /// Forget everything. Arrival order restarts, so a speaker index after this
+    /// has no relationship to one before it.
+    void reset();
+
+    int speakers() const { return speakers_; }
+    /// Wall-clock covered by one output frame.
+    float frame_seconds() const;
+    /// Encoder frames finalised so far, which is also the timeline's length.
+    std::size_t frames_emitted() const { return frames_emitted_; }
+
+    /// Encoder frames one call reports on — read from the graph.
+    int chunk_frames() const { return chunk_frames_; }
+
+private:
+    /// Run one call for step `step_`, or return false if `flush` is false and
+    /// the audio it needs has not arrived.
+    bool advance_step(bool flush, std::vector<float>& out);
+
+    /// Mel for the window this step needs, zero-filled outside the recording.
+    std::vector<float> window_features(std::int64_t first_frame) const;
+
+    const OrtApi* api_ = nullptr;
+    OrtSession* session_ = nullptr;
+
+    Config cfg_;
+    /// Built after the graph has been read, because its widths come from the
+    /// graph rather than from this class's defaults.
+    std::unique_ptr<SortformerSpeakerCache> cache_;
+
+    /// Read from the graph, never assumed.
+    int window_frames_ = 0;   // 381
+    int window_mels_ = 0;     // 3048
+    int chunk_frames_ = 0;    // 340 = window - left - right
+    int speakers_ = 0;        // 4
+    int embedding_dim_ = 0;   // 512
+    int cache_frames_ = 0;    // 188
+    int fifo_frames_ = 0;     // 40
+
+    /// Audio still needed by a future step, and where it starts. Trimmed as
+    /// steps complete so a long recording does not accumulate.
+    std::vector<float> audio_;
+    std::size_t audio_start_sample_ = 0;
+    std::size_t samples_seen_ = 0;
+
+    std::size_t step_ = 0;
+    std::size_t frames_emitted_ = 0;
+    bool finished_ = false;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/models/sortformer_speaker_cache.h
+++ b/include/speech_core/models/sortformer_speaker_cache.h
@@ -47,22 +47,50 @@ public:
 
     explicit SortformerSpeakerCache(Config config);
 
+    /// Where a buffer of predictions puts the FIFO.
+    ///
+    /// Predictions always cover [cache | fifo | chunk], but the middle section
+    /// has two widths in circulation and they are indistinguishable from the
+    /// buffer itself.
+    ///
+    /// Choosing wrong is quiet, which is why the caller has to say rather than
+    /// be assumed to have normalised one into the other. A FIFO holding fewer
+    /// frames than its block is wide — the first call of every recording — puts
+    /// the chunk up to `fifo_frames` earlier than the reader expects, so it
+    /// reports on the wrong slice and, worse, seeds the cache's own scoring
+    /// predictions from it at the first compression. That outlives the step
+    /// that caused it, and nothing anywhere reports an error.
+    enum class PredictionLayout {
+        /// `[cache | fifo_frames() | chunk]` — NeMo's synchronous
+        /// `streaming_update` and the numpy spec ported from it, where the FIFO
+        /// tensor really is as short as it claims.
+        Packed,
+        /// `[cache | Config::fifo_frames | chunk]` — the exported ONNX graph,
+        /// whose FIFO block is a fixed width with the unused frames zeroed. The
+        /// valid frames are at the start of the block.
+        FixedFifoBlock,
+    };
+
     /// Advance one step and return this chunk's predictions.
     ///
-    /// `predictions` covers [cache + fifo + chunk] exactly as the graph emitted
-    /// it. `chunk_embeddings` is the graph's per-chunk output, which is what
-    /// enters the FIFO and eventually the cache.
+    /// `chunk_embeddings` is the graph's per-chunk output, which is what enters
+    /// the FIFO and eventually the cache.
     ///
     /// `left_context` and `right_context` are in encoder frames: the chunk
     /// carries context either side that the model needed but that this step
     /// does not own, and including it would publish the same audio twice.
+    ///
+    /// There is deliberately no default `layout`. Both callers are real, the
+    /// wrong one is silent, and a default would pick for whichever was written
+    /// second.
     std::vector<float> advance(
         const float* chunk_embeddings,
         std::size_t chunk_frames,
         const float* predictions,
         std::size_t prediction_frames,
         int left_context,
-        int right_context);
+        int right_context,
+        PredictionLayout layout);
 
     /// The cache and FIFO the next call must feed back to the graph.
     const std::vector<float>& cache() const { return cache_; }

--- a/src/models/sortformer/onnx_sortformer_diarizer.cpp
+++ b/src/models/sortformer/onnx_sortformer_diarizer.cpp
@@ -1,0 +1,357 @@
+#include "speech_core/models/onnx_sortformer_diarizer.h"
+
+#include "speech_core/audio/mel.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace speech_core {
+namespace {
+
+/// Read a tensor's shape from the session, by index, for inputs or outputs.
+std::vector<std::int64_t> tensor_shape(
+    const OrtApi* api, OrtSession* session, std::size_t index, bool input) {
+    OrtTypeInfo* info = nullptr;
+    ort_check(api, input
+        ? api->SessionGetInputTypeInfo(session, index, &info)
+        : api->SessionGetOutputTypeInfo(session, index, &info));
+    const OrtTensorTypeAndShapeInfo* shape = nullptr;
+    ort_check(api, api->CastTypeInfoToTensorInfo(info, &shape));
+    std::size_t dims = 0;
+    api->GetDimensionsCount(shape, &dims);
+    std::vector<std::int64_t> out(dims);
+    api->GetDimensions(shape, out.data(), dims);
+    api->ReleaseTypeInfo(info);
+    return out;
+}
+
+[[noreturn]] void wrong_shape(const char* what) {
+    throw std::runtime_error(
+        std::string("Sortformer ONNX: unexpected ") + what
+        + ". This wrapper drives the `default` export's windowing; a bundle "
+          "exported at another chunk length would be fed the wrong geometry "
+          "and answer confidently rather than fail.");
+}
+
+/// The graph's mel front-end, settled by diffing against features dumped from
+/// the checkpoint's own preprocessor rather than read off its config. Two of
+/// these are invisible in the config: `torch.stft` centres the 400-sample
+/// window inside the 512-point FFT, and NeMo pads constant rather than
+/// reflect. Guessing either gives features the model answers confidently and
+/// wrongly, with nothing in the pipeline to notice.
+constexpr bool kSlaneyNorm = true;
+constexpr bool kCenter = true;
+constexpr bool kTorchStftLayout = true;
+constexpr bool kCenterPadZeros = true;
+constexpr bool kSymmetricWindow = true;
+constexpr float kPreEmphasis = 0.97f;
+
+/// `log(x + 2^-24)`, which the reference's own minimum confirms at -16.6355.
+const float kLogFloor = std::ldexp(1.0f, -24);
+
+/// Mel frames of real audio needed either side of a window so that centring is
+/// exact rather than padded: a frame spans n_fft/2 = 256 samples each way,
+/// which is 1.6 hops.
+constexpr std::int64_t kCentringMargin = 2;
+
+}  // namespace
+
+OnnxSortformerDiarizer::OnnxSortformerDiarizer(
+    const std::string& model_path, bool hw_accel) {
+    api_ = OnnxEngine::get().api();
+    session_ = OnnxEngine::get().load(model_path, hw_accel);
+
+    // Every dimension below is READ FROM THE GRAPH. The windowing this class
+    // performs is derived from them, so a mismatch has to be a refusal here
+    // rather than a subtly wrong timeline later.
+    const auto chunk = tensor_shape(api_, session_, 0, true);
+    const auto spkcache = tensor_shape(api_, session_, 2, true);
+    const auto fifo = tensor_shape(api_, session_, 4, true);
+    const auto preds = tensor_shape(api_, session_, 0, false);
+    const auto embeddings = tensor_shape(api_, session_, 1, false);
+
+    if (chunk.size() != 3 || spkcache.size() != 3 || fifo.size() != 3
+        || preds.size() != 3 || embeddings.size() != 3) {
+        wrong_shape("tensor rank");
+    }
+
+    window_mels_ = static_cast<int>(chunk[1]);
+    cfg_.mel_bins = static_cast<int>(chunk[2]);
+    cache_frames_ = static_cast<int>(spkcache[1]);
+    embedding_dim_ = static_cast<int>(spkcache[2]);
+    fifo_frames_ = static_cast<int>(fifo[1]);
+    speakers_ = static_cast<int>(preds[2]);
+    window_frames_ = static_cast<int>(embeddings[1]);
+
+    if (window_mels_ <= 0 || window_frames_ <= 0 || speakers_ <= 0
+        || cache_frames_ <= 0 || fifo_frames_ <= 0 || embedding_dim_ <= 0) {
+        wrong_shape("a dynamic dimension where this export pins one");
+    }
+    if (window_mels_ != window_frames_ * cfg_.subsampling) {
+        wrong_shape("mel frames per encoder frame");
+    }
+    if (fifo[2] != spkcache[2] || embeddings[2] != spkcache[2]) {
+        wrong_shape("embedding width");
+    }
+    // The prediction block covers the cache, the FIFO and the whole window
+    // including its context. Anything else means the offsets this class hands
+    // the cache would land in the wrong section.
+    if (preds[1] != cache_frames_ + fifo_frames_ + window_frames_) {
+        wrong_shape("prediction block length");
+    }
+
+    chunk_frames_ =
+        window_frames_ - cfg_.left_context - cfg_.right_context;
+    if (chunk_frames_ <= 0) wrong_shape("context wider than the window");
+
+    cfg_.cache.speakers = speakers_;
+    cfg_.cache.cache_frames = cache_frames_;
+    cfg_.cache.fifo_frames = fifo_frames_;
+    cfg_.cache.embedding_dim = embedding_dim_;
+    cache_ = std::make_unique<SortformerSpeakerCache>(cfg_.cache);
+}
+
+OnnxSortformerDiarizer::~OnnxSortformerDiarizer() {
+    if (session_) api_->ReleaseSession(session_);
+}
+
+float OnnxSortformerDiarizer::frame_seconds() const {
+    return static_cast<float>(cfg_.subsampling)
+        * static_cast<float>(cfg_.mel_hop)
+        / static_cast<float>(cfg_.sample_rate);
+}
+
+void OnnxSortformerDiarizer::reset() {
+    cache_->reset();
+    audio_.clear();
+    audio_start_sample_ = 0;
+    samples_seen_ = 0;
+    step_ = 0;
+    frames_emitted_ = 0;
+    finished_ = false;
+}
+
+std::vector<float> OnnxSortformerDiarizer::window_features(
+    std::int64_t first_frame) const {
+    const std::int64_t bins = cfg_.mel_bins;
+    const std::int64_t hop = cfg_.mel_hop;
+    std::vector<float> window(
+        static_cast<std::size_t>(window_mels_) * static_cast<std::size_t>(bins),
+        0.0f);
+
+    // Mel frames this window covers, and the part of them the recording
+    // actually has. A window reaches before the first sample on the first step
+    // and past the last on the final one; both are zeros, which is what a whole
+    // -recording front-end would produce there too.
+    const std::int64_t want_lo = first_frame * cfg_.subsampling;
+    const std::int64_t want_hi = want_lo + window_mels_;
+    const std::int64_t have = static_cast<std::int64_t>(samples_seen_ / hop);
+    const std::int64_t lo = std::max<std::int64_t>(want_lo, 0);
+    const std::int64_t hi = std::min<std::int64_t>(want_hi, have);
+    if (hi <= lo) return window;
+
+    // Hand the front-end a margin of real audio either side so its own centring
+    // padding never stands in for samples the recording has.
+    const std::int64_t from = std::max<std::int64_t>(lo - kCentringMargin, 0) * hop;
+    const std::int64_t to = std::min<std::int64_t>(
+        (hi + kCentringMargin) * hop, static_cast<std::int64_t>(samples_seen_));
+    if (to <= from) return window;
+
+    const std::size_t offset =
+        static_cast<std::size_t>(from) - audio_start_sample_;
+    const std::size_t count = static_cast<std::size_t>(to - from);
+    if (offset + count > audio_.size()) return window;
+
+    // Pre-emphasis is the caller's job for this front-end, as it is for the
+    // other NeMo-derived wrappers here. Its one-sample memory is taken from the
+    // real previous sample where there is one, so a window boundary does not
+    // become a discontinuity.
+    std::vector<float> pcm(audio_.begin() + offset,
+                           audio_.begin() + offset + count);
+    float previous = offset > 0 ? audio_[offset - 1] : 0.0f;
+    for (std::size_t index = 0; index < pcm.size(); ++index) {
+        const float current = pcm[index];
+        pcm[index] = current - kPreEmphasis * previous;
+        previous = current;
+    }
+
+    const std::vector<float> mel = audio::mel_spectrogram(
+        pcm.data(), pcm.size(), cfg_.sample_rate, cfg_.n_fft, cfg_.mel_hop,
+        cfg_.win_length, cfg_.mel_bins, kSlaneyNorm, kLogFloor, kCenter,
+        kTorchStftLayout, kCenterPadZeros, kSymmetricWindow);
+    if (mel.empty()) return window;
+    const std::int64_t produced =
+        static_cast<std::int64_t>(mel.size()) / bins;
+    const std::int64_t base = from / hop;
+
+    // mel_spectrogram is [bins, frames]; the graph wants [frames, bins].
+    for (std::int64_t frame = lo; frame < hi; ++frame) {
+        const std::int64_t source = frame - base;
+        if (source < 0 || source >= produced) continue;
+        const std::int64_t slot = frame - want_lo;
+        for (std::int64_t bin = 0; bin < bins; ++bin) {
+            window[static_cast<std::size_t>(slot * bins + bin)] =
+                mel[static_cast<std::size_t>(bin * produced + source)];
+        }
+    }
+    return window;
+}
+
+bool OnnxSortformerDiarizer::advance_step(
+    bool flush, std::vector<float>& out) {
+    const std::int64_t hop = cfg_.mel_hop;
+    const std::int64_t first_frame =
+        static_cast<std::int64_t>(step_) * chunk_frames_ - cfg_.left_context;
+    const std::int64_t want_hi =
+        (first_frame + window_frames_) * cfg_.subsampling;
+
+    if (!flush) {
+        // Wait until the whole window, plus the centring margin, has arrived.
+        const std::int64_t needed = (want_hi + kCentringMargin) * hop;
+        if (static_cast<std::int64_t>(samples_seen_) < needed) return false;
+    } else {
+        // On the final pass, only steps that own real audio are worth running.
+        const std::int64_t have =
+            static_cast<std::int64_t>(samples_seen_ / hop) / cfg_.subsampling;
+        if (static_cast<std::int64_t>(step_) * chunk_frames_ >= have) {
+            return false;
+        }
+    }
+
+    const std::vector<float> window = window_features(first_frame);
+
+    OrtMemoryInfo* memory = nullptr;
+    ort_check(api_, api_->CreateCpuMemoryInfo(
+        OrtArenaAllocator, OrtMemTypeDefault, &memory));
+
+    // The cache is always presented full. The graph declares it [1, 188, 512]
+    // and every call must fill it; unused slots hold zeros early and a running
+    // mean-silence embedding later, and are meant to leave by scoring rather
+    // than be excluded by a length.
+    std::vector<float> spkcache(
+        static_cast<std::size_t>(cache_frames_) * embedding_dim_, 0.0f);
+    std::copy(cache_->cache().begin(), cache_->cache().end(), spkcache.begin());
+    std::vector<float> fifo(
+        static_cast<std::size_t>(fifo_frames_) * embedding_dim_, 0.0f);
+    std::copy(cache_->fifo().begin(), cache_->fifo().end(), fifo.begin());
+
+    const std::int64_t held = static_cast<std::int64_t>(cache_->fifo_frames());
+    std::int64_t chunk_length = window_mels_;
+    std::int64_t spkcache_length = cache_frames_;
+    std::int64_t fifo_length = held;
+
+    const std::int64_t chunk_dims[3] = {1, window_mels_, cfg_.mel_bins};
+    const std::int64_t cache_dims[3] = {1, cache_frames_, embedding_dim_};
+    const std::int64_t fifo_dims[3] = {1, fifo_frames_, embedding_dim_};
+    const std::int64_t scalar_dims[1] = {1};
+
+    OrtValue* inputs[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    auto make_float = [&](int slot, std::vector<float>& data,
+                          const std::int64_t* dims, std::size_t rank) {
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            memory, data.data(), data.size() * sizeof(float), dims, rank,
+            ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &inputs[slot]));
+    };
+    auto make_int = [&](int slot, std::int64_t& value) {
+        ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+            memory, &value, sizeof(value), scalar_dims, 1,
+            ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &inputs[slot]));
+    };
+    std::vector<float> mutable_window = window;
+    make_float(0, mutable_window, chunk_dims, 3);
+    make_int(1, chunk_length);
+    make_float(2, spkcache, cache_dims, 3);
+    make_int(3, spkcache_length);
+    make_float(4, fifo, fifo_dims, 3);
+    make_int(5, fifo_length);
+
+    const char* input_names[6] = {
+        "chunk", "chunk_lengths", "spkcache", "spkcache_lengths",
+        "fifo", "fifo_lengths"};
+    const char* output_names[3] = {
+        "spkcache_fifo_chunk_preds", "chunk_pre_encode_embs",
+        "chunk_pre_encode_lengths"};
+    OrtValue* outputs[3] = {nullptr, nullptr, nullptr};
+
+    OrtStatus* status = api_->Run(
+        session_, nullptr, input_names, inputs, 6, output_names, 3, outputs);
+
+    float* predictions = nullptr;
+    float* embeddings = nullptr;
+    if (status == nullptr) {
+        api_->GetTensorMutableData(outputs[0],
+                                   reinterpret_cast<void**>(&predictions));
+        api_->GetTensorMutableData(outputs[1],
+                                   reinterpret_cast<void**>(&embeddings));
+    }
+
+    std::vector<float> chunk_predictions;
+    if (predictions != nullptr && embeddings != nullptr) {
+        // The graph's FIFO block is a fixed width with the unused frames
+        // zeroed, which is not the layout the synchronous reference uses. Say
+        // so; the cache cannot tell from the buffer, and reading it as packed
+        // takes the chunk up to fifo_frames early on the first call of every
+        // recording.
+        chunk_predictions = cache_->advance(
+            embeddings, static_cast<std::size_t>(window_frames_),
+            predictions,
+            static_cast<std::size_t>(
+                cache_frames_ + fifo_frames_ + window_frames_),
+            cfg_.left_context, cfg_.right_context,
+            SortformerSpeakerCache::PredictionLayout::FixedFifoBlock);
+    }
+
+    for (OrtValue* value : outputs) if (value) api_->ReleaseValue(value);
+    for (OrtValue* value : inputs) if (value) api_->ReleaseValue(value);
+    api_->ReleaseMemoryInfo(memory);
+    if (status != nullptr) {
+        ort_check(api_, status);
+    }
+
+    out.insert(out.end(), chunk_predictions.begin(), chunk_predictions.end());
+    frames_emitted_ += chunk_predictions.size()
+        / static_cast<std::size_t>(speakers_);
+    ++step_;
+
+    // Audio before the next window's margin can go. A recording is hours long
+    // and a window is half a minute of it.
+    const std::int64_t next_first =
+        static_cast<std::int64_t>(step_) * chunk_frames_ - cfg_.left_context;
+    const std::int64_t keep_from = std::max<std::int64_t>(
+        (next_first * cfg_.subsampling - kCentringMargin) * hop, 0);
+    if (static_cast<std::size_t>(keep_from) > audio_start_sample_) {
+        const std::size_t drop =
+            static_cast<std::size_t>(keep_from) - audio_start_sample_;
+        if (drop < audio_.size()) {
+            audio_.erase(audio_.begin(), audio_.begin() + drop);
+            audio_start_sample_ += drop;
+        }
+    }
+    return true;
+}
+
+std::vector<float> OnnxSortformerDiarizer::push_audio(
+    const float* samples, std::size_t length) {
+    std::vector<float> out;
+    if (finished_ || samples == nullptr || length == 0) return out;
+    audio_.insert(audio_.end(), samples, samples + length);
+    samples_seen_ += length;
+    while (advance_step(false, out)) {}
+    return out;
+}
+
+std::vector<float> OnnxSortformerDiarizer::end_stream() {
+    std::vector<float> out;
+    if (finished_) return out;
+    finished_ = true;
+    while (advance_step(true, out)) {}
+    return out;
+}
+
+}  // namespace speech_core

--- a/src/models/sortformer/sortformer_speaker_cache.cpp
+++ b/src/models/sortformer/sortformer_speaker_cache.cpp
@@ -201,15 +201,29 @@ void SortformerSpeakerCache::compress() {
         [&](std::size_t a, std::size_t b) { return score_of(a) > score_of(b); });
     candidates.resize(take);
 
+    // Order the SELECTED indices, then map them back to frames — not the other
+    // way round. Selection is speaker-major, so sorting after the modulo gives
+    // strict chronological order while sorting before it groups by speaker and
+    // stays chronological only within each speaker. The reference does the
+    // latter, and the difference is invisible to any check that sums the cache:
+    // it holds exactly the same frames either way. What changes is the order
+    // the model sees them in, and from the call after the first compression its
+    // predictions diverge and never recover.
+    constexpr std::size_t kDisabledSlot =
+        std::numeric_limits<std::size_t>::max();
     std::vector<std::size_t> chosen;
     chosen.reserve(take);
     for (const std::size_t flat : candidates) {
-        // A disabled score means the slot has no frame worth keeping, and is
-        // filled with mean silence instead.
+        // A disabled score means the slot has no frame worth keeping. The
+        // sentinel sorts last, exactly as the reference's placeholder index
+        // does, so those slots land at the end and take mean silence.
         chosen.push_back(
-            score_of(flat) == kNegativeInfinity ? padded : flat % padded);
+            score_of(flat) == kNegativeInfinity ? kDisabledSlot : flat);
     }
     std::sort(chosen.begin(), chosen.end());
+    for (std::size_t& slot : chosen) {
+        slot = slot == kDisabledSlot ? padded : slot % padded;
+    }
 
     std::vector<float> next_cache(static_cast<std::size_t>(keep) * width, 0.0f);
     std::vector<float> next_predictions(
@@ -240,7 +254,8 @@ std::vector<float> SortformerSpeakerCache::advance(
     const float* predictions,
     std::size_t prediction_frames,
     int left_context,
-    int right_context) {
+    int right_context,
+    PredictionLayout layout) {
     const std::size_t width = static_cast<std::size_t>(config_.embedding_dim);
     const int speakers = config_.speakers;
     // A chunk shorter than its own context would make this subtraction wrap,
@@ -257,8 +272,16 @@ std::vector<float> SortformerSpeakerCache::advance(
     // Predictions arrive as [cache + fifo + chunk]. The FIFO's slice is the
     // model's latest opinion of frames already queued, which is what scores
     // them when they graduate into the cache.
+    //
+    // Only the width of the middle section is in question, and only the caller
+    // knows it. The valid FIFO frames sit at the start of that section either
+    // way, so the read below is the same; what moves is where the chunk begins.
+    const std::size_t fifo_block =
+        layout == PredictionLayout::FixedFifoBlock
+            ? static_cast<std::size_t>(config_.fifo_frames)
+            : fifo_frames_;
     const std::size_t fifo_offset = cache_frames_;
-    const std::size_t chunk_offset = cache_frames_ + fifo_frames_;
+    const std::size_t chunk_offset = cache_frames_ + fifo_block;
     if (prediction_frames < chunk_offset + chunk_frames) return {};
 
     fifo_predictions_.assign(

--- a/tests/test_sortformer_speaker_cache.cpp
+++ b/tests/test_sortformer_speaker_cache.cpp
@@ -73,6 +73,7 @@ void test_matches_reference_through_eviction() {
         static_cast<std::size_t>(chunk - left - right);
 
     double last_sum = 0.0;
+    double last_ordered = 0.0;
     for (int step = 0; step < 24; ++step) {
         std::vector<float> embeddings(
             static_cast<std::size_t>(chunk) * width);
@@ -81,17 +82,31 @@ void test_matches_reference_through_eviction() {
         const std::size_t total =
             cache.cache_frames() + cache.fifo_frames() + chunk;
         std::vector<float> predictions(total * speakers);
+        // TWO speakers active, and which two alternates with the frame.
+        //
+        // A single active speaker cannot exercise the ordering at all: the
+        // selection is speaker-major, so when every kept frame belongs to one
+        // speaker, sorting the chosen indices before mapping them back to
+        // frames and sorting after give the identical cache. This suite ran
+        // that way and passed against a build whose cache was in the wrong
+        // order — the defect reached a real model and cost its predictions
+        // from the call after the first compression.
         const int active = step % speakers;
         for (std::size_t frame = 0; frame < total; ++frame) {
+            const int alternate =
+                (active + 1 + static_cast<int>(frame % 2)) % speakers;
             for (int speaker = 0; speaker < speakers; ++speaker) {
+                const bool speaking =
+                    speaker == active || speaker == alternate;
                 predictions[frame * speakers + speaker] =
-                    speaker == active ? 0.80f + sequence.next() * 0.19f
-                                      : sequence.next() * 0.10f;
+                    speaking ? 0.80f + sequence.next() * 0.19f
+                             : sequence.next() * 0.10f;
             }
         }
 
         const auto chunk_predictions = cache.advance(
-            embeddings.data(), chunk, predictions.data(), total, left, right);
+            embeddings.data(), chunk, predictions.data(), total, left, right,
+            SortformerSpeakerCache::PredictionLayout::Packed);
         check(chunk_predictions.size() / speakers == owned,
               "a step owns its chunk minus the context either side");
         check(cache.cache_frames()
@@ -102,13 +117,29 @@ void test_matches_reference_through_eviction() {
               "the fifo never exceeds its configured length");
 
         last_sum = 0.0;
-        for (const float value : cache.cache()) last_sum += value;
+        last_ordered = 0.0;
+        std::size_t position = 0;
+        for (const float value : cache.cache()) {
+            last_sum += value;
+            last_ordered +=
+                static_cast<double>(position++ % 9973) * value;
+        }
     }
-    // Reference value from the numpy port over the same sequence. It is a
+    // Reference values from the numpy port over the same sequence. It is a
     // checksum of the retained embeddings, so it moves if eviction keeps
     // different frames — which is the failure this guards against.
-    check_near(last_sum, 0.810773, 1e-3,
+    check_near(last_sum, 17.995605, 1e-3,
                "retained embeddings match the reference implementation");
+    // And a position-weighted one, because a plain sum cannot see ORDER, and
+    // order is a real failure mode here rather than a hypothetical: the
+    // selection is speaker-major, so sorting the chosen indices before mapping
+    // them back to frames gives strict chronological order while sorting after
+    // gives the reference's speaker-major order. Both keep exactly the same
+    // frames, so the sum above agreed to six figures while the model saw a
+    // different cache and its predictions diverged from the call after the
+    // first compression. This suite passed throughout.
+    check_near(last_ordered, 4088.0877, 1e-1,
+               "retained embeddings are in the reference's order");
 }
 
 void test_reset_restarts_arrival_order() {
@@ -119,7 +150,9 @@ void test_reset_restarts_arrival_order() {
     std::vector<float> embeddings(14 * config.embedding_dim, 0.5f);
     const std::size_t total = cache.cache_frames() + cache.fifo_frames() + 14;
     std::vector<float> predictions(total * config.speakers, 0.9f);
-    cache.advance(embeddings.data(), 14, predictions.data(), total, 1, 7);
+    cache.advance(
+        embeddings.data(), 14, predictions.data(), total, 1, 7,
+        SortformerSpeakerCache::PredictionLayout::Packed);
     check(cache.fifo_frames() > 0, "a step leaves work in the fifo");
 
     cache.reset();
@@ -142,7 +175,8 @@ void test_short_predictions_are_refused() {
     // better than indexing past the end of it.
     std::vector<float> predictions(4 * config.speakers, 0.5f);
     const auto out = cache.advance(
-        embeddings.data(), 14, predictions.data(), 4, 1, 7);
+        embeddings.data(), 14, predictions.data(), 4, 1, 7,
+        SortformerSpeakerCache::PredictionLayout::Packed);
     check(out.empty(), "predictions shorter than the state are refused");
 }
 
@@ -156,7 +190,8 @@ void test_chunk_shorter_than_its_context_is_refused() {
     const std::size_t total = cache.cache_frames() + cache.fifo_frames() + 6;
     std::vector<float> predictions(total * config.speakers, 0.5f);
     const auto out = cache.advance(
-        embeddings.data(), 6, predictions.data(), total, 1, 7);
+        embeddings.data(), 6, predictions.data(), total, 1, 7,
+        SortformerSpeakerCache::PredictionLayout::Packed);
     check(out.empty(), "a chunk shorter than its context is refused");
     check(cache.fifo_frames() == 0, "a refused chunk leaves no state behind");
 }
@@ -168,8 +203,66 @@ void test_negative_context_is_refused() {
     const std::size_t total = cache.cache_frames() + cache.fifo_frames() + 14;
     std::vector<float> predictions(total * config.speakers, 0.5f);
     const auto out = cache.advance(
-        embeddings.data(), 14, predictions.data(), total, -1, 7);
+        embeddings.data(), 14, predictions.data(), total, -1, 7,
+        SortformerSpeakerCache::PredictionLayout::Packed);
     check(out.empty(), "negative context is refused");
+}
+
+/// The layout trap, which is the reason `advance` makes the caller say.
+///
+/// The exported graph's FIFO block is a fixed width with the unused frames
+/// zeroed; the synchronous reference's FIFO is only as long as it holds. On the
+/// first call of a recording the FIFO is empty, so the two put the chunk
+/// `fifo_frames` apart — and reading the graph's buffer as packed silently
+/// reports on the wrong slice.
+///
+/// Both readings are exercised on one buffer built so the difference is
+/// visible: the FIFO block carries a marker value the chunk does not.
+void test_the_fifo_block_width_decides_where_the_chunk_starts() {
+    const auto config = small_config();
+    SortformerSpeakerCache cache(config);
+    const std::size_t chunk = 14;
+    const int left = 1;
+    const int right = 7;
+    const std::size_t owned = chunk - left - right;
+
+    check(cache.fifo_frames() == 0, "a fresh cache holds nothing in its fifo");
+
+    // [cache | fifo block, all marker | chunk], as the graph emits it.
+    const std::size_t block =
+        cache.cache_frames() + static_cast<std::size_t>(config.fifo_frames)
+        + chunk;
+    std::vector<float> predictions(block * config.speakers, 0.25f);
+    const std::size_t fifo_start = cache.cache_frames() * config.speakers;
+    const std::size_t chunk_start =
+        (cache.cache_frames() + config.fifo_frames) * config.speakers;
+    for (std::size_t index = fifo_start; index < chunk_start; ++index) {
+        predictions[index] = 0.99f;
+    }
+    for (std::size_t index = chunk_start;
+         index < block * config.speakers; ++index) {
+        predictions[index] = 0.10f;
+    }
+    std::vector<float> embeddings(chunk * config.embedding_dim, 0.1f);
+
+    const auto graph_reading = cache.advance(
+        embeddings.data(), chunk, predictions.data(), block, left, right,
+        SortformerSpeakerCache::PredictionLayout::FixedFifoBlock);
+    check(graph_reading.size() / config.speakers == owned,
+          "the graph reading owns its chunk minus the context");
+    for (float value : graph_reading) {
+        check_near(value, 0.10f, 1e-6, "the graph reading lands in the chunk");
+    }
+
+    // The same buffer read as packed starts the chunk where the FIFO block
+    // does, so it reports the marker instead — which is the defect, reproduced.
+    SortformerSpeakerCache other(config);
+    const auto packed_reading = other.advance(
+        embeddings.data(), chunk, predictions.data(), block, left, right,
+        SortformerSpeakerCache::PredictionLayout::Packed);
+    check(!packed_reading.empty(), "the packed reading still returns a chunk");
+    check_near(packed_reading.front(), 0.99f, 1e-6,
+               "reading the graph's buffer as packed takes the fifo's frames");
 }
 
 }  // namespace
@@ -180,6 +273,7 @@ int main() {
     test_short_predictions_are_refused();
     test_chunk_shorter_than_its_context_is_refused();
     test_negative_context_is_refused();
+    test_the_fifo_block_width_decides_where_the_chunk_starts();
     if (failures == 0) std::printf("sortformer speaker cache: all checks passed\n");
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Adds the ONNX Runtime session wrapper for streaming Sortformer diarization — the only piece that was missing. The arrival-order speaker cache has been here since #126, and the mel front-end turned out to need no new code at all, but nothing loaded or ran the graph.

Along the way the parity gate found **two defects in the merged speaker cache**, both silent, both reaching real predictions.

## What changed

**`OnnxSortformerDiarizer`** (new). Takes 16 kHz PCM in arrival order, returns a continuous per-frame speaker timeline. One call consumes 340 encoder frames — 27.2 s — and needs 40 frames of audio after them, so a label lands about 30 s behind the microphone.

It is a stream rather than a function on purpose: arrival order is per stream, and constructing one per utterance restarts the numbering and discards the whole advantage this model has over a window-local segmenter.

It deliberately has **no threshold** and no notion of a turn or a speaker label. That is a product judgement with a measured constant behind it, and an engine inventing one would make that decision in the repository least able to notice when it changed.

Every dimension is read from the graph and disagreements are refused at construction — a bundle exported at another chunk length would otherwise be driven with this one's windowing and answer confidently rather than fail.

**The mel front-end needed no new code.** `audio::mel_spectrogram` already reproduces NeMo's `AudioToMelSpectrogramPreprocessor` exactly, with `slaney_norm`, `center`, `torch_stft_layout`, `center_pad_zeros` and `symmetric_torch_window` all on:

| flags | mean abs err | cells within 0.01 |
|---|---|---|
| all five on | **0.000002** | **100%** |
| reflect padding instead of zeros | 0.001354 | 99.57% |
| periodic window instead of symmetric | 0.007074 | 84.94% |
| HTK mel scale instead of Slaney | 3.46 | 11% |

Found by sweeping all sixteen combinations against features dumped from the checkpoint's own preprocessor, rather than reading the config — two of those flags are invisible in it.

## Two defects in the merged speaker cache

**1. The prediction layout was undefined in practice.** The header said predictions arrive "exactly as the graph emitted it", while the implementation derived its offsets from the FIFO's *actual* length — which is what NeMo's synchronous path does, and not what the graph emits. The graph's FIFO block is a fixed width with unused frames zeroed, so the two disagree by that width whenever the FIFO is not full: the first call of every recording. A caller following the header reports on the wrong slice and seeds the cache's own scoring from it at the first compression, which outlives the step that caused it.

`advance` now takes an explicit `PredictionLayout` with **no default**. Both callers are real, and the wrong one is quiet.

**2. The compression put the retained frames in the wrong order.** Selection is speaker-major. Taking the modulo before the sort gives strict chronological order; the reference sorts the selected indices and maps back afterwards, giving speaker-major order that is chronological only within a speaker.

The cache holds **exactly the same frames** either way, so every existing check agreed — and the model saw a different cache. Measured end to end against the reference driver:

| call | before | after |
|---|---|---|
| 0 | agreement 1.0000 | 1.0000 |
| 1 | 0.6993 | 1.0000 |
| 2 | 0.8647 | 1.0000 |
| 3 | 0.7588 | 1.0000 |
| 4 | 0.7985 | 1.0000 |

## Gates

**`speech_sortformer_parity`** (new, beside `speech_diarization_parity`). The existing Python parity proves the exported *graph* matches PyTorch; this proves the *wrapper* does, which is a different claim and the one that ships. Three things can be wrong on their own while the graph stays perfect: the mel front-end, the windowing, and which layout the prediction block is read in.

Over 132 s of real two-speaker audio, fed in 100 ms blocks as a capture callback would:

```
mean abs error 0.00000039  max 0.000010  decision agreement 1.000000
calls 5 (the arrival-order update runs from the first onwards)
```

It reports per call, because where a run diverges says what is wrong — a first call that already disagrees is the front-end or the windowing; one that agrees and then drifts is the cache. The fixture must overflow the cache: a recording that fits one call never exercises the arrival-order update at all.

**`test_sortformer_speaker_cache`** now drives **two** active speakers. With one, speaker-major and chronological order are identical, so the suite could not see the ordering defect and passed against it for its whole life. It also checks a position-weighted checksum beside the plain sum, since a sum cannot see order at all. Both reference values come from the numpy port of NeMo's own update, not from this implementation.

Verified the new fixture actually catches the defect: with the old ordering restored it fails `retained embeddings are in the reference's order (got -2448.317406, want 4088.087700)` while the sum check still passes.

## Test plan

- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DSPEECH_CORE_BUILD_TESTS=ON` → `test_sortformer_speaker_cache` passes.
- `cmake -B build -DSPEECH_CORE_WITH_ONNX=ON -DORT_DIR=...` → `speech_sortformer_parity` passes against `soniqo/Sortformer-Diarization-4spk-ONNX` (default variant) and the numpy reference.
