### PR TITLE
feat(models): list the Sortformer diarizer in the stenograf model set

### DIFF
--- a/scripts/download_models.ps1
+++ b/scripts/download_models.ps1
@@ -72,6 +72,12 @@ $stenografFiles = @(
     "MOSS-Transcribe-Diarize-0.9B-ONNX-INT8-ENC/vocab.json",
     "ReDimNet2-B6-ONNX-FP32/ReDimNet2B6.onnx",
     "ReDimNet2-B6-ONNX-FP32/config.json",
+    # Only the light transcription pipeline loads this, and which pipeline runs
+    # is not known until a session has tried the CUDA provider. It is listed
+    # here because the application asks for the manifest a second time when it
+    # turns out to need it, and already-present files are skipped.
+    "Sortformer-Diarization-4spk-ONNX/sortformer-default.onnx",
+    "Sortformer-Diarization-4spk-ONNX/config.json",
     "LocalVQE-v1.4-AEC-200K-ONNX-FP32/LocalVQEAECResidualMask.onnx",
     "LocalVQE-v1.4-AEC-200K-ONNX-FP32/LocalVQEAECFrontend.json",
     "LocalVQE-v1.4-AEC-200K-ONNX-FP32/config.json"


### PR DESCRIPTION
The streaming Sortformer diarizer fills the speaker slot on the light
transcription pipeline, so a machine running that pipeline needs it and a
machine running the joint one never loads it.

Which of the two runs is only known after a session has tried the CUDA
provider, which is later than a first-run download happens. Listing the model
here rather than gating it keeps that decision on the application side: it asks
for the manifest again once it knows, and files already on disk are skipped, so
the second pass costs a walk over the list rather than the bundle again.

Manifest only — no C++ target reads this file, so there is nothing in the build
to regress. Verified: the script parses clean, and both files resolve HTTP 200
at `soniqo/Sortformer-Diarization-4spk-ONNX`.
