### PR TITLE
fix(sortformer): include <cstdint> for std::int64_t

### DIFF
--- a/include/speech_core/models/onnx_sortformer_diarizer.h
+++ b/include/speech_core/models/onnx_sortformer_diarizer.h
@@ -4,6 +4,7 @@
 
 #include <onnxruntime_c_api.h>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
`onnx_sortformer_diarizer.h` declares `window_features(std::int64_t)` without including `<cstdint>`.

Toolchains that pull it in transitively build fine — which is why it merged. The GCC in speech-cloud's pipeline image does not, so **every speech-cloud build linking `speech_core_models` has been broken since #132**:

```
onnx_sortformer_diarizer.h:122:40: error: 'std::int64_t' has not been declared
onnx_sortformer_diarizer.cpp:140:20: error: no declaration matches
  'std::vector<float> OnnxSortformerDiarizer::window_features(int64_t) const'
```

The `.cpp` already includes `<cstdint>`, which is why the mismatch surfaced as a declaration mismatch rather than an unknown type.

Found while wiring Sortformer into speech-cloud's pipeline worker (soniqo/speech-cloud#74). It currently fails `Build and Push Pipeline Worker Image` on speech-cloud master, so no pipeline deploy can happen until this lands.