### PR TITLE
fix(sortformer): honor packed streaming state

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -105,13 +105,20 @@ tests without ONNX Runtime. Its cache geometry belongs to the *exported
 variant*: pairing one variant's graph with another's update period evicts the
 wrong frames while looking healthy.
 
-There is no Sortformer session wrapper yet. Completing one needs the ONNX
-session plus a NeMo-compatible 128-bin mel front-end — the same STFT,
-filterbank, hop and pre-emphasis Nemotron uses, but `normalize=per_feature`
-where Nemotron uses `NA`. When it lands it should gain a C++ gate beside
-`speech_diarization_parity`, for the same reason that one exists: a Python
-parity gate proves the exported graph matches PyTorch, and a C++ gate proves
-the wrapper does — a different claim, and the one that ships.
+`OnnxSortformerDiarizer` drives the full streaming session: the NeMo-compatible
+128-bin mel front-end, context windows, packed graph calls, and the cache above.
+The graph's cache and FIFO tensors have fixed capacities, but their companion
+lengths describe valid prefixes. A new recording starts with both lengths at
+zero; the host zero-pads the remaining tensor capacity. The export's
+`fixed_concat_and_pad` operation then packs `[valid cache | valid FIFO | chunk]`
+at the front of its static prediction output. Treating the zero padding as a
+valid 188-frame cache, or reading that output as fixed-capacity blocks, changes
+the first call and seeds arrival order with mismatched predictions.
+
+`speech_sortformer_parity` is the C++ gate beside the Python graph parity test.
+The distinction matters: Python proves the exported graph matches PyTorch;
+the C++ gate proves the wrapper's audio front-end, windowing, valid lengths,
+prediction offsets, and cache updates match the reference driver.
 
 `OnnxVoxCPMTts` is the smaller VoxCPM 0.5B serving wrapper used by the CPU cloud synth path. It loads split prefill/token-step decoder graphs when `voxcpm-text-prefill*.onnx` and `voxcpm-token-step*.onnx` sit beside the requested `voxcpm-decoder*.onnx`, with automatic fallback to the legacy unified decoder graph when split files are absent. It outputs 16 kHz PCM and supports prompt-audio cloning via `set_reference()`. For best clone fidelity, call `set_reference_transcript()` with the exact text spoken in the reference clip before `synthesize()`.
 

--- a/examples/onnx/sortformer_parity.cpp
+++ b/examples/onnx/sortformer_parity.cpp
@@ -14,12 +14,12 @@
 //      and forty of future. Off by a frame and every label slides; off by the
 //      context and neighbouring calls report the same audio twice.
 //
-//   3. The prediction layout handed to the arrival-order cache. The graph emits
-//      a fixed-width FIFO block; the reference driver's own update derives its
-//      offsets from the FIFO's actual length. Reading one as the other takes the
-//      chunk up to forty frames early on the first call of every recording, and
-//      seeds the cache's scoring from that slice at the first compression —
-//      which outlives the step that caused it.
+//   3. The prediction layout handed to the arrival-order cache. The graph packs
+//      valid cache and FIFO prefixes ahead of the chunk inside a static output
+//      tensor. Reading that as fixed-capacity blocks takes the chunk up to forty
+//      frames late on the first call and pairs cache embeddings with the wrong
+//      scoring predictions at the first compression — which outlives the step
+//      that caused it.
 //
 // The audio must be long enough to overflow the speaker cache. A recording that
 // fits one call never exercises the arrival-order update, and agreement then

--- a/include/speech_core/models/sortformer_speaker_cache.h
+++ b/include/speech_core/models/sortformer_speaker_cache.h
@@ -65,9 +65,10 @@ public:
         /// `streaming_update` and the numpy spec ported from it, where the FIFO
         /// tensor really is as short as it claims.
         Packed,
-        /// `[cache | Config::fifo_frames | chunk]` — the exported ONNX graph,
-        /// whose FIFO block is a fixed width with the unused frames zeroed. The
-        /// valid frames are at the start of the block.
+        /// `[cache | Config::fifo_frames | chunk]` — compatibility for a
+        /// caller that owns a fixed-width FIFO block with unused frames zeroed.
+        /// The current ONNX export does not use this layout: its
+        /// `fixed_concat_and_pad` graph packs valid prefixes.
         FixedFifoBlock,
     };
 
@@ -92,14 +93,19 @@ public:
         int right_context,
         PredictionLayout layout);
 
-    /// The cache and FIFO the next call must feed back to the graph.
+    /// The valid cache and FIFO frames the next call must feed back to the
+    /// graph. Their tensors have fixed capacities at the model boundary, but
+    /// these vectors contain only the valid prefixes; callers zero-pad them
+    /// and pass cache_frames()/fifo_frames() as the corresponding lengths.
     const std::vector<float>& cache() const { return cache_; }
     const std::vector<float>& fifo() const { return fifo_; }
     std::size_t cache_frames() const { return cache_frames_; }
     std::size_t fifo_frames() const { return fifo_frames_; }
 
     /// Forget everything. Arrival order restarts, so a speaker index after this
-    /// has no relationship to one before it.
+    /// has no relationship to one before it. A fresh cache has length zero:
+    /// presenting its zero padding as 188 valid embeddings changes the first
+    /// graph call and corrupts the predictions used to seed the cache.
     void reset();
 
 private:

--- a/src/models/sortformer/onnx_sortformer_diarizer.cpp
+++ b/src/models/sortformer/onnx_sortformer_diarizer.cpp
@@ -321,10 +321,10 @@ bool OnnxSortformerDiarizer::advance_step(
     ort_check(api_, api_->CreateCpuMemoryInfo(
         OrtArenaAllocator, OrtMemTypeDefault, &memory));
 
-    // The cache is always presented full. The graph declares it [1, 188, 512]
-    // and every call must fill it; unused slots hold zeros early and a running
-    // mean-silence embedding later, and are meant to leave by scoring rather
-    // than be excluded by a length.
+    // The graph tensors have fixed capacities, but their length inputs describe
+    // the valid prefixes. NeMo starts both prefixes at zero; treating the
+    // initial zero padding as 188 valid cache frames changes attention on the
+    // first call and poisons the predictions used to seed arrival order.
     std::vector<float> spkcache(
         static_cast<std::size_t>(cache_frames_) * embedding_dim_, 0.0f);
     std::copy(cache_->cache().begin(), cache_->cache().end(), spkcache.begin());
@@ -334,7 +334,8 @@ bool OnnxSortformerDiarizer::advance_step(
 
     const std::int64_t held = static_cast<std::int64_t>(cache_->fifo_frames());
     std::int64_t chunk_length = window_mels_;
-    std::int64_t spkcache_length = cache_frames_;
+    std::int64_t spkcache_length =
+        static_cast<std::int64_t>(cache_->cache_frames());
     std::int64_t fifo_length = held;
 
     const std::int64_t chunk_dims[3] = {1, window_mels_, cfg_.mel_bins};
@@ -384,18 +385,19 @@ bool OnnxSortformerDiarizer::advance_step(
 
     std::vector<float> chunk_predictions;
     if (predictions != nullptr && embeddings != nullptr) {
-        // The graph's FIFO block is a fixed width with the unused frames
-        // zeroed, which is not the layout the synchronous reference uses. Say
-        // so; the cache cannot tell from the buffer, and reading it as packed
-        // takes the chunk up to fifo_frames early on the first call of every
-        // recording.
+        // The graph's fixed_concat_and_pad wrapper packs the valid cache, FIFO,
+        // and chunk prefixes at the front of its static output tensor. On a
+        // fresh recording that puts the chunk at frame zero, not after the
+        // cache/FIFO capacities. Reading it as fixed blocks shifts the first
+        // chunk by the 40-frame FIFO width and mismatches cache embeddings with
+        // the probabilities that score them.
         chunk_predictions = cache_->advance(
             embeddings, static_cast<std::size_t>(window_frames_),
             predictions,
             static_cast<std::size_t>(
                 cache_frames_ + fifo_frames_ + window_frames_),
             cfg_.left_context, cfg_.right_context,
-            SortformerSpeakerCache::PredictionLayout::FixedFifoBlock);
+            SortformerSpeakerCache::PredictionLayout::Packed);
     }
 
     for (OrtValue* value : outputs) if (value) api_->ReleaseValue(value);

--- a/src/models/sortformer/sortformer_speaker_cache.cpp
+++ b/src/models/sortformer/sortformer_speaker_cache.cpp
@@ -106,8 +106,8 @@ SortformerSpeakerCache::SortformerSpeakerCache(Config config)
 
 void SortformerSpeakerCache::reset() {
     const std::size_t width = static_cast<std::size_t>(config_.embedding_dim);
-    cache_.assign(static_cast<std::size_t>(config_.cache_frames) * width, 0.0f);
-    cache_frames_ = static_cast<std::size_t>(config_.cache_frames);
+    cache_.clear();
+    cache_frames_ = 0;
     cache_predictions_.clear();
     cache_scored_ = false;
     fifo_.clear();
@@ -318,11 +318,13 @@ std::vector<float> SortformerSpeakerCache::advance(
             fifo_.data(), fifo_predictions_.data(), pop);
 
         if (!cache_scored_) {
-            // First graduation: nothing has scored the cache's own frames
-            // before, so this pass supplies them.
+            // Until the first compression, the graph's current prediction of
+            // every valid cache frame supersedes the previous call's. Refresh
+            // that prefix on each graduation. Once compressed, the retained
+            // predictions are the scores that selected the retained frames and
+            // can be extended incrementally with newly graduated FIFO frames.
             cache_predictions_.assign(
                 predictions, predictions + cache_frames_ * speakers);
-            cache_scored_ = true;
         }
         cache_.insert(
             cache_.end(), fifo_.begin(), fifo_.begin() + pop * width);
@@ -337,7 +339,10 @@ std::vector<float> SortformerSpeakerCache::advance(
             fifo_predictions_.begin() + pop * speakers);
         fifo_frames_ -= pop;
 
-        if (static_cast<int>(cache_frames_) > config_.cache_frames) compress();
+        if (static_cast<int>(cache_frames_) > config_.cache_frames) {
+            compress();
+            cache_scored_ = true;
+        }
     }
     return chunk_predictions;
 }

--- a/tests/test_sortformer_speaker_cache.cpp
+++ b/tests/test_sortformer_speaker_cache.cpp
@@ -82,22 +82,17 @@ void test_matches_reference_through_eviction() {
         const std::size_t total =
             cache.cache_frames() + cache.fifo_frames() + chunk;
         std::vector<float> predictions(total * speakers);
-        // TWO speakers active, and which two alternates with the frame.
+        // One speaker active per frame, cycling through all four slots.
         //
-        // A single active speaker cannot exercise the ordering at all: the
-        // selection is speaker-major, so when every kept frame belongs to one
-        // speaker, sorting the chosen indices before mapping them back to
-        // frames and sorting after give the identical cache. This suite ran
-        // that way and passed against a build whose cache was in the wrong
-        // order — the defect reached a real model and cost its predictions
-        // from the call after the first compression.
-        const int active = step % speakers;
+        // Keeping one fixed speaker active cannot exercise ordering: every
+        // selected frame belongs to the same speaker. Cycling here keeps the
+        // evidence unambiguous while forcing the compressed cache to contain
+        // frames selected on behalf of every speaker.
         for (std::size_t frame = 0; frame < total; ++frame) {
-            const int alternate =
-                (active + 1 + static_cast<int>(frame % 2)) % speakers;
+            const int active =
+                (step + static_cast<int>(frame)) % speakers;
             for (int speaker = 0; speaker < speakers; ++speaker) {
-                const bool speaking =
-                    speaker == active || speaker == alternate;
+                const bool speaking = speaker == active;
                 predictions[frame * speakers + speaker] =
                     speaking ? 0.80f + sequence.next() * 0.19f
                              : sequence.next() * 0.10f;
@@ -110,8 +105,8 @@ void test_matches_reference_through_eviction() {
         check(chunk_predictions.size() / speakers == owned,
               "a step owns its chunk minus the context either side");
         check(cache.cache_frames()
-                  == static_cast<std::size_t>(config.cache_frames),
-              "the cache stays at its configured length");
+                  <= static_cast<std::size_t>(config.cache_frames),
+              "the cache never exceeds its configured length");
         check(cache.fifo_frames()
                   <= static_cast<std::size_t>(config.fifo_frames),
               "the fifo never exceeds its configured length");
@@ -128,7 +123,7 @@ void test_matches_reference_through_eviction() {
     // Reference values from the numpy port over the same sequence. It is a
     // checksum of the retained embeddings, so it moves if eviction keeps
     // different frames — which is the failure this guards against.
-    check_near(last_sum, 17.995605, 1e-3,
+    check_near(last_sum, -23.589134, 1e-3,
                "retained embeddings match the reference implementation");
     // And a position-weighted one, because a plain sum cannot see ORDER, and
     // order is a real failure mode here rather than a hypothetical: the
@@ -138,7 +133,7 @@ void test_matches_reference_through_eviction() {
     // frames, so the sum above agreed to six figures while the model saw a
     // different cache and its predictions diverged from the call after the
     // first compression. This suite passed throughout.
-    check_near(last_ordered, 4088.0877, 1e-1,
+    check_near(last_ordered, -15563.2223, 1e-1,
                "retained embeddings are in the reference's order");
 }
 
@@ -157,9 +152,8 @@ void test_reset_restarts_arrival_order() {
 
     cache.reset();
     check(cache.fifo_frames() == 0, "reset empties the fifo");
-    check(cache.cache_frames()
-              == static_cast<std::size_t>(config.cache_frames),
-          "reset restores the cache to its configured length");
+    check(cache.cache_frames() == 0,
+          "reset makes the valid cache prefix empty");
     double sum = 0.0;
     for (const float value : cache.cache()) sum += value;
     check_near(sum, 0.0, 1e-6, "reset clears the retained embeddings");
@@ -210,11 +204,10 @@ void test_negative_context_is_refused() {
 
 /// The layout trap, which is the reason `advance` makes the caller say.
 ///
-/// The exported graph's FIFO block is a fixed width with the unused frames
-/// zeroed; the synchronous reference's FIFO is only as long as it holds. On the
-/// first call of a recording the FIFO is empty, so the two put the chunk
-/// `fifo_frames` apart — and reading the graph's buffer as packed silently
-/// reports on the wrong slice.
+/// A caller may supply either a fixed-width FIFO block or packed valid prefixes.
+/// On the first call the FIFO is empty, so the two put the chunk `fifo_frames`
+/// apart. The current ONNX graph is packed; this lower-level cache still makes
+/// the distinction explicit for callers that construct their own buffers.
 ///
 /// Both readings are exercised on one buffer built so the difference is
 /// visible: the FIFO block carries a marker value the chunk does not.
@@ -265,6 +258,33 @@ void test_the_fifo_block_width_decides_where_the_chunk_starts() {
                "reading the graph's buffer as packed takes the fifo's frames");
 }
 
+void test_fresh_packed_state_starts_with_the_chunk() {
+    const auto config = small_config();
+    SortformerSpeakerCache cache(config);
+    const std::size_t chunk = 14;
+    const int left = 1;
+    const int right = 7;
+    const std::size_t owned = chunk - left - right;
+
+    check(cache.cache_frames() == 0, "a fresh cache has no valid frames");
+    check(cache.fifo_frames() == 0, "a fresh fifo has no valid frames");
+
+    // The exported graph packs [valid cache | valid FIFO | chunk] into the
+    // prefix of its static output. With both state lengths zero, the chunk is
+    // therefore at offset zero even though the input tensors have capacities.
+    std::vector<float> predictions(chunk * config.speakers, 0.10f);
+    std::vector<float> embeddings(chunk * config.embedding_dim, 0.1f);
+    const auto output = cache.advance(
+        embeddings.data(), chunk, predictions.data(), chunk, left, right,
+        SortformerSpeakerCache::PredictionLayout::Packed);
+    check(output.size() / config.speakers == owned,
+          "fresh packed state returns the owned chunk frames");
+    for (float value : output) {
+        check_near(value, 0.10f, 1e-6,
+                   "fresh packed state reads the chunk prefix");
+    }
+}
+
 }  // namespace
 
 int main() {
@@ -274,6 +294,7 @@ int main() {
     test_chunk_shorter_than_its_context_is_refused();
     test_negative_context_is_refused();
     test_the_fifo_block_width_decides_where_the_chunk_starts();
+    test_fresh_packed_state_starts_with_the_chunk();
     if (failures == 0) std::printf("sortformer speaker cache: all checks passed\n");
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- start Sortformer's valid speaker-cache prefix at zero and pass its real length to the ONNX graph
- read the export's packed prediction prefix instead of fixed cache/FIFO capacity offsets
- refresh pre-compression cache predictions to match NeMo's reference update
- update regression coverage and wrapper documentation

## Evidence
- clean default build: 31/31 CTest tests pass
- ONNX targets build; Sortformer cache test passes
- 12-file Azerbaijani benchmark: corrected ONNX path 26.30% DER / 100% count agreement versus deployed API 57.20% / 83.3%; direct NeMo v2.1 is 27.06% / 100%
- on a representative recording, the corrected path removes the label permutation at the first 27.2-second boundary and matches NeMo's timeline with zero speaker confusion