### PR TITLE
fix(supertonic): stop stranding sentence tails in their own chunk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,7 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_litert_voxcpm2_clone_cli"
            OR TEST_NAME STREQUAL "test_indic_mio_istft"
            OR TEST_NAME STREQUAL "test_indic_mio_tokenizer"
+           OR TEST_NAME STREQUAL "test_supertonic_tokenizer"
            OR TEST_NAME STREQUAL "test_litert_indic_mio"
            OR TEST_NAME STREQUAL "test_pocket_tts"
            OR TEST_NAME STREQUAL "test_pocket_tts_tokenizer"
@@ -923,6 +924,13 @@ if(SPEECH_CORE_BUILD_TESTS)
         target_compile_definitions(test_indic_mio_tokenizer PRIVATE
             SPEECH_CORE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/data")
         add_test(NAME test_indic_mio_tokenizer COMMAND test_indic_mio_tokenizer)
+    endif()
+
+    # SupertonicTokenizer chunking + window fitting (pure unit — no model bundle needed).
+    if(SPEECH_CORE_WITH_LITERT AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_supertonic_tokenizer.cpp)
+        add_executable(test_supertonic_tokenizer tests/test_supertonic_tokenizer.cpp)
+        target_link_libraries(test_supertonic_tokenizer PRIVATE speech_core_models_litert)
+        add_test(NAME test_supertonic_tokenizer COMMAND test_supertonic_tokenizer)
     endif()
 
     # Indic-Mio e2e smoke (skips when SPEECH_CORE_INDIC_MIO_BUNDLE unset).

--- a/docs/models.md
+++ b/docs/models.md
@@ -794,7 +794,12 @@ tts.synthesize("Bonjour tout le monde.", "fr", [](const float* samples, size_t l
   `set_speed()`, rather than cut mid-sentence. A piece that
   continues into the next one is tokenized with a trailing `,` instead of the usual sentence-
   final `.`, and the 0.3 s inter-chunk silence (`set_chunk_silence()`) is inserted only where a
-  sentence actually ends, never at a forced intra-sentence split. A piece too short to split
+  sentence actually ends, never at a forced intra-sentence split. Each piece also carries the
+  model's own utterance padding (~400 ms trailing, ~300 ms leading), so at a forced split the
+  seam is trimmed to 150 ms (`kSeamTailMs` + `kSeamHeadMs`), which reads as a short comma pause;
+  the second piece still restarts with sentence-initial prosody, since it is a separate
+  generation — the structural fix is an L=128 graph bucket (see follow-ups). A piece too
+  short to split
   that still overflows is trimmed to the window with a log line, as before.
 - `set_speed()` divides the predicted duration (default 1.05); `set_seed()` fixes the latent
   noise for reproducible output; `SUPERTONIC_LATENT_FRAMES` overrides the window only for

--- a/docs/models.md
+++ b/docs/models.md
@@ -747,6 +747,62 @@ tts.synthesize("नमस्ते, आज मौसम बहुत अच्�
   `tokenizer.json`, `config.json` (manifest: token offsets, stop ids, prompt
   template, bucket sizes); the model card documents the full host contract.
 
+## LiteRTSupertonicTts
+
+```cpp
+#include <speech_core/models/litert_supertonic_tts.h>
+
+speech_core::LiteRTSupertonicTts tts(
+    "/models/Supertonic-3-LiteRT/duration_predictor.tflite",
+    "/models/Supertonic-3-LiteRT/text_encoder.tflite",
+    "/models/Supertonic-3-LiteRT/vector_estimator.tflite",
+    "/models/Supertonic-3-LiteRT/vocoder.tflite",
+    "/models/Supertonic-3-LiteRT",                 // unicode_indexer.json + tts.json
+    "/models/Supertonic-3-LiteRT/voice_styles");   // F1..F5, M1..M5
+
+tts.set_voice("F1");
+tts.set_total_step(8);   // 5 fast · 8 default · 12 quality
+tts.synthesize("Bonjour tout le monde.", "fr", [](const float* samples, size_t length, bool is_final) {
+    // 44.1 kHz Float32 PCM, one callback per synthesized piece (plus 0.3 s silence between sentences).
+});
+```
+
+- SupertonicTTS-3 (99M), non-autoregressive flow matching, 31 languages, G2P-free:
+  the front-end is NFKD + cleanup + `<lang>…</lang>` wrap + a codepoint→id table
+  (`SupertonicTokenizer`, a port of upstream `helper.py::UnicodeProcessor`).
+  Bundle: [soniqo/Supertonic-3-LiteRT](https://huggingface.co/soniqo/Supertonic-3-LiteRT).
+  The C ABI is `supertonic_c.h` (`sc_supertonic_*`).
+- Four graphs per piece: `duration_predictor` → `text_encoder` → `vector_estimator` × `total_step` → `vocoder`.
+  The published graphs are **fixed-shape**: T = 128 text tokens and L = 64 latent frames
+  (64 × 3072 samples ≈ 4.46 s of audio). A dynamic-L export is blocked upstream
+  (`litert_torch` cannot lower the relpos attention + ConvNeXt stack with a symbolic L), so the
+  host has to keep every piece inside that window. The CoreML port in speech-swift has a dynamic
+  L and none of the chunking below.
+- **Chunking.** `SupertonicTokenizer::chunk()` packs sentences (terminal punctuation followed by
+  whitespace) greedily up to a raw-codepoint budget — `int(window_s × 14 chars/s × 0.9)` = 56
+  for the L=64 graph (6 chars/s for `ko`/`ja`). A sentence longer than the budget is kept whole
+  rather than word-packed at the budget, which used to strand its last word or two in a tiny
+  chunk (`"… sous les"` | `"arbres."`, issue #140). Every chunk is guaranteed to fit the 128-token
+  text length *after* NFKD and the language wrap (`wrapped_length()`); accented text expands
+  under NFKD, and a raw-codepoint cap alone let `process()` truncate such chunks silently.
+- **Window fitting.** `synthesize()` runs the duration predictor on each chunk as a preflight
+  (`SupertonicTokenizer::fit_to_window()`); only when the predicted audio overflows the window
+  is the chunk bisected — at the best sentence, clause, or word boundary, in balanced halves,
+  via the core `split_text_for_synthesis_retry()` — and each half measured again. An overflow
+  of at most 10% (`kWindowStretchMax`) is absorbed by tempo instead: the piece's duration is
+  clamped to the window so it is spoken slightly faster, the same host-side mechanism as
+  `set_speed()`, rather than cut mid-sentence. A piece that
+  continues into the next one is tokenized with a trailing `,` instead of the usual sentence-
+  final `.`, and the 0.3 s inter-chunk silence (`set_chunk_silence()`) is inserted only where a
+  sentence actually ends, never at a forced intra-sentence split. A piece too short to split
+  that still overflows is trimmed to the window with a log line, as before.
+- `set_speed()` divides the predicted duration (default 1.05); `set_seed()` fixes the latent
+  noise for reproducible output; `SUPERTONIC_LATENT_FRAMES` overrides the window only for
+  experiments against a re-exported graph.
+- Tests: `tests/test_supertonic_tokenizer.cpp` (built with `SPEECH_CORE_WITH_LITERT=ON`, no
+  bundle needed) pins the chunking, capacity, continuation-terminator, and window-fitting
+  behaviour, including the French paragraph from #140.
+
 ## LiteRTWeSpeakerEmbedding
 
 ```cpp

--- a/include/speech_core/models/litert_supertonic_tts.h
+++ b/include/speech_core/models/litert_supertonic_tts.h
@@ -33,8 +33,9 @@ namespace speech_core {
 /// count. A piece that overflows by a small margin (≤ kWindowStretchMax) is spoken slightly faster
 /// to fit instead of being cut (the same host-side mechanism as set_speed()). The four graphs run
 /// per piece and the trimmed PCM streams through the TTSChunkCallback; the inter-chunk silence
-/// (0.3 s) is inserted only where a sentence ends, and a piece that continues into the next one
-/// is tokenized with a trailing "," rather than a sentence-final ".".
+/// (0.3 s) is inserted only where a sentence ends. A piece that continues into the next one is
+/// tokenized with a trailing "," rather than a sentence-final ".", and the seam between the two
+/// is trimmed to a comma-length pause.
 ///
 /// Validated end-to-end against the ONNX reference at 66–82 dB mag-STFT SNR (en/de/ko); see the
 /// Runner repo's `speech-models/stmodels/controlled_ab.py`. Voice is a precomputed style pair
@@ -121,6 +122,11 @@ private:
     // tempo-fitted into the window (its duration is clamped, so it is spoken up to 10% faster)
     // rather than bisected mid-sentence. Beyond it the planner splits the text.
     static constexpr float kWindowStretchMax = 1.10f;
+    // At a forced intra-sentence split the model's own utterance padding on both pieces would
+    // leave a ~700 ms gap; the seam is trimmed to this much tail + head silence (150 ms total,
+    // chosen by ear against 250 ms).
+    static constexpr int kSeamTailMs = 100;
+    static constexpr int kSeamHeadMs = 50;
 
     int               total_step_      = 8;
     float             speed_           = 1.05f;

--- a/include/speech_core/models/litert_supertonic_tts.h
+++ b/include/speech_core/models/litert_supertonic_tts.h
@@ -26,8 +26,15 @@ namespace speech_core {
 ///   L = ceil(duration*44100/(512*6)); noisy = randn([1,144,L])*latent_mask; speed divides duration.
 ///
 /// Unlike VoxCPM2, this is **non-autoregressive**: a fixed `total_step` ODE loop (default 8), no stop
-/// logits, no KV cache. Each synthesize() splits text into ≤T-token chunks, runs the four graphs per
-/// chunk, and streams the trimmed PCM through the TTSChunkCallback (0.3 s silence between chunks).
+/// logits, no KV cache. The published graphs are fixed-shape (T = 128 text tokens, L = 64 latent
+/// frames ≈ 4.5 s), so synthesize() packs sentences into chunks, runs the duration predictor on each
+/// as a preflight, and bisects a chunk at its best sentence/clause/word boundary only when its
+/// predicted audio overflows the window — a long sentence is never word-packed at a character
+/// count. A piece that overflows by a small margin (≤ kWindowStretchMax) is spoken slightly faster
+/// to fit instead of being cut (the same host-side mechanism as set_speed()). The four graphs run
+/// per piece and the trimmed PCM streams through the TTSChunkCallback; the inter-chunk silence
+/// (0.3 s) is inserted only where a sentence ends, and a piece that continues into the next one
+/// is tokenized with a trailing "," rather than a sentence-final ".".
 ///
 /// Validated end-to-end against the ONNX reference at 66–82 dB mag-STFT SNR (en/de/ko); see the
 /// Runner repo's `speech-models/stmodels/controlled_ab.py`. Voice is a precomputed style pair
@@ -79,8 +86,18 @@ private:
         std::vector<float> style_dp;   // [1,8,16]   → 128
     };
 
-    // Synthesize one ≤T-token chunk into trimmed 44.1 kHz PCM. chunk_index decorrelates the noise.
-    std::vector<float> synth_chunk(const std::string& chunk, const std::string& language, size_t chunk_index);
+    // Tokenized piece + its predicted duration. The duration predictor is the first graph anyway,
+    // so it doubles as the fixed-window preflight (see synthesize()).
+    struct Prepared {
+        SupertonicTokenizer::Tokens tok;
+        float duration      = 0.0f;  // seconds after speed; 0 ⇒ nothing to synthesize
+        int   latent_frames = 0;     // L_true = ceil(int(duration * SR) / 3072)
+    };
+    Prepared prepare_chunk(const std::string& text, const std::string& language, bool continuation);
+
+    // text_encoder → vector_estimator × N → vocoder on a prepared piece → trimmed 44.1 kHz PCM.
+    // piece_index decorrelates the latent noise between the pieces of one utterance.
+    std::vector<float> synth_prepared(const Prepared& prepared, size_t piece_index);
     const VoiceStyle& current_voice() const;
     void destroy_graphs() noexcept;  // idempotent; used by the dtor and ctor-failure cleanup
 
@@ -100,6 +117,10 @@ private:
     static constexpr int kStyleTtlFloats = 50 * 256;  // 12800
     static constexpr int kStyleDpFloats  = 8 * 16;    // 128
     static constexpr int kSampleRate     = 44100;
+    // A piece whose predicted latent length overflows the fixed window by at most this ratio is
+    // tempo-fitted into the window (its duration is clamped, so it is spoken up to 10% faster)
+    // rather than bisected mid-sentence. Beyond it the planner splits the text.
+    static constexpr float kWindowStretchMax = 1.10f;
 
     int               total_step_      = 8;
     float             speed_           = 1.05f;

--- a/include/speech_core/models/supertonic_tokenizer.h
+++ b/include/speech_core/models/supertonic_tokenizer.h
@@ -1,10 +1,21 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <vector>
 
 namespace speech_core {
+
+/// One synthesis piece produced by `SupertonicTokenizer::fit_to_window()`.
+struct SupertonicPiece {
+    std::string text;                 ///< raw (not yet preprocessed) text of the piece
+    bool        continuation = false; ///< the sentence carries on in the next piece: the front-end
+                                      ///  terminates it with "," (continuation intonation), not "."
+    bool        pause_before = false; ///< a sentence boundary separates this piece from the previous
+                                      ///  one (host may insert its inter-chunk silence); false at a
+                                      ///  forced intra-sentence split and for the first piece
+};
 
 /// SupertonicTTS G2P-free text front-end — the part that, for Kokoro/espeak-class TTS, is the
 /// hardest and most GPL-entangled piece, and which Supertonic collapses to:
@@ -32,16 +43,35 @@ public:
     explicit SupertonicTokenizer(const std::string& unicode_indexer_path,
                                  const std::string& tts_json_path = {});
 
+    /// Construct from an in-memory `codepoint → id` table (the contents of unicode_indexer.json).
+    explicit SupertonicTokenizer(std::vector<int32_t> indexer);
+
     /// Whether `lang` (ISO code, e.g. "de", "ko") is in Supertonic's AVAILABLE_LANGS.
     bool supports(const std::string& lang) const;
 
-    /// Split free-form text into per-synthesis chunks. Caps each chunk so the wrapped, tokenized
-    /// form fits the exported fixed text length (`max_text_tokens`, default 128). Sentence-aware,
-    /// codepoint-counted; CJK uses a tighter cap. Mirrors `helper.py::_chunk_text`.
-    /// @param max_codepoints if > 0, an additional (tighter) per-chunk codepoint cap — used to keep a
-    ///        chunk's predicted audio within a fixed-shape graph's latent window.
+    /// Split free-form text into per-synthesis chunks. Mirrors `helper.py::_chunk_text`: sentences
+    /// (terminal punctuation followed by whitespace) are packed greedily up to `max_codepoints`
+    /// raw codepoints (0 ⇒ the model's text capacity). A sentence longer than that budget is
+    /// **not** word-packed at the budget — that strands its last word or two in a tiny chunk —
+    /// it is emitted whole so the caller can measure its real duration (`fit_to_window`) rather
+    /// than guess from a character count. Every emitted chunk fits the model's text capacity
+    /// after NFKD and the `<lang>` wrap (`wrapped_length() <= max_text_tokens()`); text that
+    /// cannot is split into balanced pieces at the best sentence/clause/word boundary.
+    /// Throws std::invalid_argument on an unsupported language.
     std::vector<std::string> chunk(const std::string& text, const std::string& lang,
                                    int max_codepoints = 0) const;
+
+    /// Fit one chunk into a fixed-length latent window. `latent_frames(text, continuation)` runs
+    /// the duration predictor on a candidate and returns its latent length in frames. While a
+    /// candidate exceeds `max_frames` it is split into two balanced pieces at the best boundary
+    /// (sentence > clause > word), each measured again. Pieces shorter than `min_codepoints`
+    /// are never produced (every piece costs a full fixed-shape graph run, so a two-word fragment
+    /// is not worth one); after `max_depth` splits, or when no split is possible, the overflowing
+    /// candidate is returned as-is for the caller to truncate.
+    static std::vector<SupertonicPiece> fit_to_window(
+        const std::string& chunk,
+        const std::function<int(const std::string& text, bool continuation)>& latent_frames,
+        int max_frames, int min_codepoints = 12, int max_depth = 6);
 
     /// Result of tokenizing one chunk for the fixed-T graphs.
     struct Tokens {
@@ -50,15 +80,26 @@ public:
     };
 
     /// Full front-end for one chunk: NFKD + cleanup + `<lang>` wrap + tokenize, then right-pad ids
-    /// to `text_t` (with 0) and build the float mask. Throws std::invalid_argument on bad language.
-    Tokens process(const std::string& text, const std::string& lang, int text_t = 128) const;
+    /// to `text_t` (with 0) and build the float mask. A chunk without terminal punctuation gets
+    /// "." appended — or "," when `continuation` is set, so a fragment that continues in the next
+    /// chunk is rendered with continuation rather than terminal intonation.
+    /// Throws std::invalid_argument on bad language.
+    Tokens process(const std::string& text, const std::string& lang, int text_t = 128,
+                   bool continuation = false) const;
+
+    /// Token count of the wrapped, preprocessed form of `text` (what `process()` emits before
+    /// padding; it must not exceed `max_text_tokens()` or `process()` truncates).
+    int wrapped_length(const std::string& text, const std::string& lang) const;
 
     /// Largest wrapped+tokenized length the front-end will emit before padding (== text_t).
     int max_text_tokens() const { return max_text_tokens_; }
 
 private:
-    std::string preprocess(const std::string& text, const std::string& lang) const;  // NFKD + clean + wrap
+    std::string preprocess(const std::string& text, const std::string& lang,
+                           bool continuation) const;  // NFKD + clean + wrap
     int32_t     lookup(uint32_t codepoint) const;
+    void        emit_within_capacity(const std::string& text, const std::string& lang,
+                                     std::vector<std::string>& out) const;
 
     std::vector<int32_t> indexer_;          // [65536]
     int                  max_text_tokens_ = 128;

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <random>
 #include <stdexcept>
 
@@ -178,52 +179,92 @@ void LiteRTSupertonicTts::synthesize(const std::string& text,
         seed_used_ = rd();
     }
 
-    // Keep each chunk's predicted audio within the fixed latent window (L frames). The chars/sec is a
-    // conservative heuristic; because dynamic-L is blocked upstream (see graph_latent_frames()), this
-    // cap is the truncation guard. Any residual overflow is logged + trimmed in synth_chunk().
-    const double window_s = static_cast<double>(graph_latent_frames()) * kChunkSamples / kSampleRate;
+    // The fixed latent window (L frames) bounds each piece's audio. A chars/sec heuristic only
+    // decides which short sentences share a chunk; a longer sentence is kept whole by chunk(),
+    // measured below with the duration predictor, and bisected at its best boundary only if it
+    // really overflows — never word-packed at a character count (#140). A residual overflow (a
+    // piece too short to split further) is logged + trimmed in synth_prepared().
+    const int L = graph_latent_frames();
+    const double window_s = static_cast<double>(L) * kChunkSamples / kSampleRate;
     const bool cjk = (language == "ko" || language == "ja");
-    const int dur_cap = std::max(8, static_cast<int>(window_s * (cjk ? 6 : 14) * 0.9));
-    const std::vector<std::string> chunks = tokenizer_->chunk(text, language, dur_cap);
+    const int budget = std::max(8, static_cast<int>(window_s * (cjk ? 6 : 14) * 0.9));
+    const std::vector<std::string> chunks = tokenizer_->chunk(text, language, budget);
     const int silence = static_cast<int>(chunk_silence_s_ * kSampleRate);
 
+    // Preflight cache: a candidate that fits is synthesized from that prediction, not measured twice.
+    std::map<std::string, Prepared> prepared;
+    auto key = [](const std::string& t, bool continuation) {
+        return std::string(continuation ? "," : ".") + t;
+    };
+    // A small overflow is absorbed by tempo (synth_prepared clamps the duration to the window);
+    // only a larger one makes the planner split the text.
+    const int max_frames = static_cast<int>(L * kWindowStretchMax);
+    auto measure = [&](const std::string& t, bool continuation) -> int {
+        if (cancelled_.load()) return 0;  // "fits"; the loop below exits before synthesizing
+        auto it = prepared.find(key(t, continuation));
+        if (it == prepared.end())
+            it = prepared.emplace(key(t, continuation), prepare_chunk(t, language, continuation)).first;
+        const int frames = it->second.latent_frames;
+        if (frames > max_frames)
+            LOGI("Supertonic: candidate needs L=%d > %d (window %d + stretch); splitting", frames, max_frames, L);
+        return frames;
+    };
+
+    size_t piece_index = 0;
     for (size_t ci = 0; ci < chunks.size(); ++ci) {
         if (cancelled_.load()) return;
-        std::vector<float> pcm = synth_chunk(chunks[ci], language, ci);
-        const bool is_final = (ci + 1 == chunks.size());
+        prepared.clear();
+        const std::vector<SupertonicPiece> pieces =
+            SupertonicTokenizer::fit_to_window(chunks[ci], measure, max_frames);
+        for (size_t pi = 0; pi < pieces.size(); ++pi) {
+            if (cancelled_.load()) return;
+            const SupertonicPiece& piece = pieces[pi];
+            auto it = prepared.find(key(piece.text, piece.continuation));
+            const Prepared p = it != prepared.end()
+                ? std::move(it->second)
+                : prepare_chunk(piece.text, language, piece.continuation);
+            // Never log synthesis input: callers may send private or sensitive text.
+            LOGI("Supertonic: chunk %zu/%zu piece %zu/%zu: L=%d/%d%s%s%s",
+                 ci + 1, chunks.size(), pi + 1, pieces.size(), p.latent_frames, L,
+                 p.latent_frames > L ? " (tempo-fit)" : "",
+                 piece.continuation ? " (continues)" : "", piece.pause_before ? " (pause)" : "");
+            std::vector<float> pcm = synth_prepared(p, piece_index++);
+            if (cancelled_.load()) return;
 
-        if (ci > 0 && silence > 0) {
-            std::vector<float> sil(static_cast<size_t>(silence), 0.0f);
-            on_chunk(sil.data(), sil.size(), false);
+            const bool is_final = (ci + 1 == chunks.size()) && (pi + 1 == pieces.size());
+            // Silence only where a sentence ends: between chunks, and between pieces whose cut
+            // landed on a sentence boundary — never inside a sentence the window forced apart.
+            const bool pause = (pi == 0) ? (ci > 0) : piece.pause_before;
+            if (pause && silence > 0) {
+                std::vector<float> sil(static_cast<size_t>(silence), 0.0f);
+                on_chunk(sil.data(), sil.size(), false);
+            }
+            on_chunk(pcm.data(), pcm.size(), is_final);
         }
-        on_chunk(pcm.data(), pcm.size(), is_final);
     }
 }
 
-std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
-                                                    const std::string& language,
-                                                    size_t chunk_index) {
+LiteRTSupertonicTts::Prepared LiteRTSupertonicTts::prepare_chunk(const std::string& text,
+                                                                 const std::string& language,
+                                                                 bool continuation) {
     LiteRtEnvironment env = LiteRTEngine::get().env();
     const VoiceStyle& voice = current_voice();
 
-    // --- tokenize → fixed-T ids + mask ---
-    const SupertonicTokenizer::Tokens tok = tokenizer_->process(chunk, language, kTextT);
+    Prepared p;
+    p.tok = tokenizer_->process(text, language, kTextT, continuation);
 
     // The exported LiteRT graphs take text_ids as INT64 (ai_edge_torch traces ids with torch.long;
     // the CoreML export is int32 via a wrapper, but LiteRT stays int64 — confirmed against the
     // published .tflite signatures). Widen the i32 tokenizer ids into an i64 input buffer.
-    const std::vector<int64_t> ids64(tok.ids.begin(), tok.ids.end());
-    const LiteRtRankedTensorType t_ids   = make_type(kLiteRtElementTypeInt64,   {1, kTextT});
-    const LiteRtRankedTensorType t_mask  = make_type(kLiteRtElementTypeFloat32, {1, 1, kTextT});
-    const LiteRtRankedTensorType t_ttl   = make_type(kLiteRtElementTypeFloat32, {1, 50, 256});
-    const LiteRtRankedTensorType t_dp    = make_type(kLiteRtElementTypeFloat32, {1, 8, 16});
-    const LiteRtRankedTensorType t_emb   = make_type(kLiteRtElementTypeFloat32, {1, 256, kTextT});
-    const LiteRtRankedTensorType t_dur   = make_type(kLiteRtElementTypeFloat32, {1});
+    const std::vector<int64_t> ids64(p.tok.ids.begin(), p.tok.ids.end());
+    const LiteRtRankedTensorType t_ids  = make_type(kLiteRtElementTypeInt64,   {1, kTextT});
+    const LiteRtRankedTensorType t_mask = make_type(kLiteRtElementTypeFloat32, {1, 1, kTextT});
+    const LiteRtRankedTensorType t_dp   = make_type(kLiteRtElementTypeFloat32, {1, 8, 16});
+    const LiteRtRankedTensorType t_dur  = make_type(kLiteRtElementTypeFloat32, {1});
 
     LiteRtHostBuffer in_ids (env, t_ids,  ids64.size() * sizeof(int64_t), ids64.data());
-    LiteRtHostBuffer in_mask(env, t_mask, tok.mask.size() * sizeof(float),   tok.mask.data());
-    LiteRtHostBuffer in_ttl (env, t_ttl,  voice.style_ttl.size() * sizeof(float), voice.style_ttl.data());
-    LiteRtHostBuffer in_dp  (env, t_dp,   voice.style_dp.size()  * sizeof(float), voice.style_dp.data());
+    LiteRtHostBuffer in_mask(env, t_mask, p.tok.mask.size() * sizeof(float), p.tok.mask.data());
+    LiteRtHostBuffer in_dp  (env, t_dp,   voice.style_dp.size() * sizeof(float), voice.style_dp.data());
 
     // --- 1) duration_predictor → duration[1] ---
     // LiteRtRunCompiledModel binds ins[] by the graph's tensor-INDEX order, which the ai_edge_torch
@@ -239,7 +280,31 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
         out.read(&duration, sizeof(float));
     }
     duration /= speed_;
-    if (!(duration > 0.0f) || std::isnan(duration)) return {};
+    if (!(duration > 0.0f) || std::isnan(duration)) return p;  // nothing to synthesize
+
+    // --- latent geometry: L_true = ceil(int(dur*SR) / 3072) ---
+    // Match the reference (infer.py): truncate dur*SR to integer samples BEFORE the ceil.
+    const long long wav_len = static_cast<long long>(duration * kSampleRate);
+    p.duration      = duration;
+    p.latent_frames = static_cast<int>((wav_len + kChunkSamples - 1) / kChunkSamples);
+    return p;
+}
+
+std::vector<float> LiteRTSupertonicTts::synth_prepared(const Prepared& p, size_t piece_index) {
+    if (!(p.duration > 0.0f)) return {};
+
+    LiteRtEnvironment env = LiteRTEngine::get().env();
+    const VoiceStyle& voice = current_voice();
+
+    const std::vector<int64_t> ids64(p.tok.ids.begin(), p.tok.ids.end());
+    const LiteRtRankedTensorType t_ids  = make_type(kLiteRtElementTypeInt64,   {1, kTextT});
+    const LiteRtRankedTensorType t_mask = make_type(kLiteRtElementTypeFloat32, {1, 1, kTextT});
+    const LiteRtRankedTensorType t_ttl  = make_type(kLiteRtElementTypeFloat32, {1, 50, 256});
+    const LiteRtRankedTensorType t_emb  = make_type(kLiteRtElementTypeFloat32, {1, 256, kTextT});
+
+    LiteRtHostBuffer in_ids (env, t_ids,  ids64.size() * sizeof(int64_t), ids64.data());
+    LiteRtHostBuffer in_mask(env, t_mask, p.tok.mask.size() * sizeof(float), p.tok.mask.data());
+    LiteRtHostBuffer in_ttl (env, t_ttl,  voice.style_ttl.size() * sizeof(float), voice.style_ttl.data());
 
     // --- 2) text_encoder → text_emb[1,256,T] ---
     // Introspected tensor-index order of text_encoder.tflite: [text_mask, text_ids, style_ttl].
@@ -253,26 +318,31 @@ std::vector<float> LiteRTSupertonicTts::synth_chunk(const std::string& chunk,
         out.read(text_emb.data(), text_emb.size() * sizeof(float));
     }
 
-    // --- latent geometry: L_true = ceil(int(dur*SR) / 3072); graph runs at fixed L ---
+    // --- latent window: the graph runs at fixed L; L_true valid frames inside it ---
     const int chunk_size = kChunkSamples;  // 512 * 6 = 3072
-    // Match the reference (infer.py): truncate dur*SR to integer samples BEFORE the ceil.
-    const long long wav_len = static_cast<long long>(duration * kSampleRate);
-    const int L_true = static_cast<int>((wav_len + chunk_size - 1) / chunk_size);
-    const int L      = graph_latent_frames();
-    const int L_fill = std::min(std::max(L_true, 1), L);  // valid frames inside the fixed window
-    if (L_true > L) {
-        LOGE("Supertonic: chunk needs L=%d frames > fixed graph L=%d; audio truncated to %.2fs "
-             "(shorten the chunk; dynamic L is blocked upstream).",
-             L_true, L, static_cast<double>(chunk_size) * L / kSampleRate);
+    const int L          = graph_latent_frames();
+    const double window_s = static_cast<double>(chunk_size) * L / kSampleRate;
+    int   L_true   = p.latent_frames;
+    float duration = p.duration;
+    if (L_true > L && L_true <= static_cast<int>(L * kWindowStretchMax)) {
+        // Tempo-fit: clamp the duration to the window so the piece is spoken slightly faster (the
+        // model fills exactly L frames) instead of cutting the sentence.
+        duration = static_cast<float>(window_s);
+        L_true   = L;
+    } else if (L_true > L) {
+        LOGE("Supertonic: piece needs L=%d frames > fixed graph L=%d and cannot be split further; "
+             "audio truncated to %.2fs (dynamic L is blocked upstream).",
+             L_true, L, window_s);
     }
+    const int L_fill = std::min(std::max(L_true, 1), L);  // valid frames inside the fixed window
 
     // latent_mask[1,1,L]: 1.0 for the first L_fill frames, else 0.
     std::vector<float> latent_mask(static_cast<size_t>(L), 0.0f);
     for (int t = 0; t < L_fill; ++t) latent_mask[t] = 1.0f;
 
-    // noisy[1,144,L] = randn * latent_mask (row-major c*L + t). Mix the chunk index into the seed so
-    // multi-chunk utterances draw distinct noise per chunk (the reference advances one shared RNG).
-    std::mt19937 rng(seed_used_ + 0x9E3779B9u * static_cast<uint32_t>(chunk_index + 1));
+    // noisy[1,144,L] = randn * latent_mask (row-major c*L + t). Mix the piece index into the seed so
+    // multi-piece utterances draw distinct noise per piece (the reference advances one shared RNG).
+    std::mt19937 rng(seed_used_ + 0x9E3779B9u * static_cast<uint32_t>(piece_index + 1));
     std::normal_distribution<float> nd(0.0f, 1.0f);
     std::vector<float> xt(static_cast<size_t>(kLatentChannels) * L);
     for (int c = 0; c < kLatentChannels; ++c)

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -92,6 +92,32 @@ void load_style(const std::string& path, std::vector<float>& ttl, std::vector<fl
     dp  = extract_style(text, "style_dp");
 }
 
+// Near-silence gate for the seam trims below (-46 dBFS; the vocoder's silence floor is well under it).
+constexpr float kSeamSilenceGate = 0.005f;
+
+size_t leading_silence(const std::vector<float>& pcm) {
+    size_t i = 0;
+    while (i < pcm.size() && std::fabs(pcm[i]) < kSeamSilenceGate) ++i;
+    return i;
+}
+
+size_t trailing_silence(const std::vector<float>& pcm) {
+    size_t n = 0;
+    while (n < pcm.size() && std::fabs(pcm[pcm.size() - 1 - n]) < kSeamSilenceGate) ++n;
+    return n;
+}
+
+// Cut leading / trailing near-silence beyond `keep` samples.
+void trim_head(std::vector<float>& pcm, size_t keep) {
+    const size_t s = leading_silence(pcm);
+    if (s > keep) pcm.erase(pcm.begin(), pcm.begin() + static_cast<std::ptrdiff_t>(s - keep));
+}
+
+void trim_tail(std::vector<float>& pcm, size_t keep) {
+    const size_t s = trailing_silence(pcm);
+    if (s > keep) pcm.resize(pcm.size() - (s - keep));
+}
+
 }  // namespace
 
 LiteRTSupertonicTts::LiteRTSupertonicTts(const std::string& duration_path,
@@ -230,6 +256,17 @@ void LiteRTSupertonicTts::synthesize(const std::string& text,
                  piece.continuation ? " (continues)" : "", piece.pause_before ? " (pause)" : "");
             std::vector<float> pcm = synth_prepared(p, piece_index++);
             if (cancelled_.load()) return;
+
+            // A forced split lands mid-sentence, but every piece carries the model's own utterance
+            // padding — ~400 ms of trailing and ~250–380 ms of leading silence — so the raw seam is
+            // ~700 ms of dead air. Trim both sides down to a short comma-length gap (150 ms; the
+            // model's own comma pause is ~250 ms, but the second piece restarts with sentence-
+            // initial emphasis, and a tighter seam reads as more connected). Sentence boundaries
+            // keep their padding.
+            if (piece.continuation)
+                trim_tail(pcm, static_cast<size_t>(kSeamTailMs * kSampleRate / 1000));
+            if (pi > 0 && !piece.pause_before)
+                trim_head(pcm, static_cast<size_t>(kSeamHeadMs * kSampleRate / 1000));
 
             const bool is_final = (ci + 1 == chunks.size()) && (pi + 1 == pieces.size());
             // Silence only where a sentence ends: between chunks, and between pieces whose cut

--- a/src/models/litert/supertonic_tokenizer.cpp
+++ b/src/models/litert/supertonic_tokenizer.cpp
@@ -1,14 +1,17 @@
 #include "speech_core/models/supertonic_tokenizer.h"
 
 #include "speech_core/util/json.h"
+#include "speech_core/util/text_chunker.h"
 
 #include <utf8proc.h>
 
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <stdexcept>
 #include <unordered_set>
+#include <utility>
 
 namespace speech_core {
 namespace {
@@ -141,6 +144,55 @@ bool ends_with_terminal(const std::vector<char32_t>& v) {
     return kTerm.find(v.back()) != std::u32string::npos;
 }
 
+
+// Sentence terminals for chunk boundaries. helper.py::_chunk_text splits on `(?<=[.!?])\s+`; the
+// CJK forms are included so ja/ko text gets sentence-level packing too.
+const std::u32string& sentence_terminals() {
+    static const std::u32string kTerm = U".!?…。！？";
+    return kTerm;
+}
+
+size_t count_codepoints(const std::string& s) {
+    size_t n = 0;
+    for (unsigned char c : s)
+        if ((c & 0xC0) != 0x80) ++n;
+    return n;
+}
+
+bool ends_with_sentence_terminal(const std::string& s) {
+    const std::vector<char32_t> v = utf8_to_u32(s);
+    return !v.empty() && sentence_terminals().find(v.back()) != std::u32string::npos;
+}
+
+// Smallest piece the balanced splitters may produce (codepoints). Matches the chunk() budget floor.
+constexpr int kMinPieceCodepoints = 8;
+
+// Bisect `text` while `latent_frames` says it overflows the window (see fit_to_window()).
+void fit_recursive(const std::string& text,
+                   const std::function<int(const std::string&, bool)>& latent_frames,
+                   int max_frames, int min_codepoints, int max_depth, int depth,
+                   bool continuation, std::vector<SupertonicPiece>& out) {
+    if (latent_frames(text, continuation) <= max_frames || depth >= max_depth) {
+        out.push_back({text, continuation, false});
+        return;
+    }
+    const size_t n = count_codepoints(text);
+    std::vector<std::string> halves;
+    if (n >= 2 * static_cast<size_t>(min_codepoints))
+        halves = split_text_for_synthesis_retry(text, count_codepoints,
+                                                static_cast<size_t>(min_codepoints), n - 1);
+    if (halves.size() != 2) {  // too short to split: hand it back for the caller to truncate
+        out.push_back({text, continuation, false});
+        return;
+    }
+    // The left half continues into the right one unless the cut landed on a sentence boundary
+    // (then it keeps its own terminal punctuation and the host may pause after it).
+    fit_recursive(halves[0], latent_frames, max_frames, min_codepoints, max_depth, depth + 1,
+                  !ends_with_sentence_terminal(halves[0]), out);
+    fit_recursive(halves[1], latent_frames, max_frames, min_codepoints, max_depth, depth + 1,
+                  continuation, out);
+}
+
 }  // namespace
 
 SupertonicTokenizer::SupertonicTokenizer(const std::string& unicode_indexer_path,
@@ -168,6 +220,12 @@ SupertonicTokenizer::SupertonicTokenizer(const std::string& unicode_indexer_path
         throw std::runtime_error("Supertonic: unicode_indexer.json parsed empty");
 }
 
+SupertonicTokenizer::SupertonicTokenizer(std::vector<int32_t> indexer)
+    : indexer_(std::move(indexer)) {
+    if (indexer_.empty())
+        throw std::runtime_error("Supertonic: unicode indexer table is empty");
+}
+
 bool SupertonicTokenizer::supports(const std::string& lang) const {
     return available_langs().count(lang) != 0;
 }
@@ -177,7 +235,8 @@ int32_t SupertonicTokenizer::lookup(uint32_t cp) const {
     return kUnknownId;
 }
 
-std::string SupertonicTokenizer::preprocess(const std::string& text, const std::string& lang) const {
+std::string SupertonicTokenizer::preprocess(const std::string& text, const std::string& lang,
+                                            bool continuation) const {
     // 1) NFKD.
     std::string s = nfkd(text);
 
@@ -211,7 +270,9 @@ std::string SupertonicTokenizer::preprocess(const std::string& text, const std::
     while (s.find("''")   != std::string::npos) replace_all(s, "''", "'");
     while (s.find("``")   != std::string::npos) replace_all(s, "``", "`");
 
-    // 6) collapse whitespace + trim, then 7) ensure terminal punctuation.
+    // 6) collapse whitespace + trim, then 7) ensure terminal punctuation. helper.py always closes
+    // with "."; a fragment that continues in the next chunk gets "," instead so the model renders
+    // continuation intonation rather than a sentence-final fall (#140).
     {
         std::vector<char32_t> in = utf8_to_u32(s);
         std::vector<char32_t> out;
@@ -228,7 +289,7 @@ std::string SupertonicTokenizer::preprocess(const std::string& text, const std::
         }
         while (!out.empty() && out.front() == ' ') out.erase(out.begin());
         while (!out.empty() && out.back() == ' ')  out.pop_back();
-        if (!ends_with_terminal(out)) out.push_back('.');
+        if (!ends_with_terminal(out)) out.push_back(continuation ? ',' : '.');
         s = u32_to_utf8(out);
     }
 
@@ -239,8 +300,9 @@ std::string SupertonicTokenizer::preprocess(const std::string& text, const std::
 }
 
 SupertonicTokenizer::Tokens
-SupertonicTokenizer::process(const std::string& text, const std::string& lang, int text_t) const {
-    const std::string wrapped = preprocess(text, lang);
+SupertonicTokenizer::process(const std::string& text, const std::string& lang, int text_t,
+                             bool continuation) const {
+    const std::string wrapped = preprocess(text, lang, continuation);
     const std::vector<char32_t> cps = utf8_to_u32(wrapped);
 
     Tokens t;
@@ -254,72 +316,99 @@ SupertonicTokenizer::process(const std::string& text, const std::string& lang, i
     return t;
 }
 
+int SupertonicTokenizer::wrapped_length(const std::string& text, const std::string& lang) const {
+    return static_cast<int>(utf8_to_u32(preprocess(text, lang, false)).size());
+}
+
 std::vector<std::string>
 SupertonicTokenizer::chunk(const std::string& text, const std::string& lang, int max_codepoints) const {
-    // Cap so the wrapped, tokenized form fits the exported fixed text length (max_text_tokens_).
+    // Raw-codepoint packing budget (helper.py's max_len). Default: what the wrapped form can hold;
     // tag overhead = len("<lang>") + len("</lang>") = 2*lang + 5.
-    int cap = max_text_tokens_ - (2 * static_cast<int>(lang.size()) + 5) - 1;
-    if (max_codepoints > 0 && max_codepoints < cap) cap = max_codepoints;  // fixed-window duration cap
-    if (cap < 8) cap = 8;
+    int budget = max_text_tokens_ - (2 * static_cast<int>(lang.size()) + 5) - 1;
+    if (max_codepoints > 0 && max_codepoints < budget) budget = max_codepoints;
+    if (budget < kMinPieceCodepoints) budget = kMinPieceCodepoints;
 
     const std::vector<char32_t> cps = utf8_to_u32(text);
 
     // Sentence-ish split at terminal punctuation followed by whitespace (faithful subset of
     // helper.py::_chunk_text; the abbreviation-guard regex there is a refinement — boundary
-    // differences only shift where the 0.3 s inter-chunk silence lands, not parity).
-    static const std::u32string kTerm = U".!?…。！？";
+    // differences only shift where the inter-chunk silence lands, not parity).
     std::vector<std::vector<char32_t>> sentences;
     std::vector<char32_t> cur;
+    auto push_sentence = [&]() {
+        size_t a = 0, b = cur.size();
+        while (a < b && is_ws(cur[a])) ++a;
+        while (b > a && is_ws(cur[b - 1])) --b;
+        if (b > a) sentences.emplace_back(cur.begin() + a, cur.begin() + b);
+        cur.clear();
+    };
     for (size_t i = 0; i < cps.size(); ++i) {
         cur.push_back(cps[i]);
-        const bool term    = kTerm.find(cps[i]) != std::u32string::npos;
-        const bool nextws  = (i + 1 < cps.size()) && is_ws(cps[i + 1]);
-        if (term && nextws) { sentences.push_back(cur); cur.clear(); }
+        const bool term   = sentence_terminals().find(cps[i]) != std::u32string::npos;
+        const bool nextws = (i + 1 < cps.size()) && is_ws(cps[i + 1]);
+        if (term && nextws) push_sentence();
     }
-    if (!cur.empty()) sentences.push_back(cur);
+    push_sentence();
 
     std::vector<std::string> out;
     std::vector<char32_t> chunk_cps;
     auto flush = [&]() {
-        size_t a = 0, b = chunk_cps.size();
-        while (a < b && chunk_cps[a] == ' ') ++a;
-        while (b > a && chunk_cps[b - 1] == ' ') --b;
-        if (b > a) out.push_back(u32_to_utf8(std::vector<char32_t>(chunk_cps.begin() + a,
-                                                                   chunk_cps.begin() + b)));
+        if (!chunk_cps.empty()) emit_within_capacity(u32_to_utf8(chunk_cps), lang, out);
         chunk_cps.clear();
     };
     auto fits = [&](int extra) {
-        return static_cast<int>(chunk_cps.size()) + (chunk_cps.empty() ? 0 : 1) + extra <= cap;
-    };
-    auto append_unit = [&](const std::vector<char32_t>& u) {
-        if (!chunk_cps.empty()) chunk_cps.push_back(' ');
-        chunk_cps.insert(chunk_cps.end(), u.begin(), u.end());
+        return static_cast<int>(chunk_cps.size()) + (chunk_cps.empty() ? 0 : 1) + extra <= budget;
     };
 
-    for (auto& sent : sentences) {
-        if (static_cast<int>(sent.size()) <= cap) {
+    for (const auto& sent : sentences) {
+        if (static_cast<int>(sent.size()) <= budget) {
             if (!fits(static_cast<int>(sent.size()))) flush();
-            append_unit(sent);
+            if (!chunk_cps.empty()) chunk_cps.push_back(' ');
+            chunk_cps.insert(chunk_cps.end(), sent.begin(), sent.end());
             continue;
         }
-        // Oversize sentence: hard-split on word boundaries (and pathologically long tokens).
+        // Longer than the packing budget: keep it whole. Word-packing it at the budget strands the
+        // last word or two of a 57–62-codepoint sentence in its own chunk ("... sous les" |
+        // "arbres.", #140). The caller measures the sentence's real duration and only splits it —
+        // in balanced halves at the best boundary — when it overflows the window (fit_to_window).
         flush();
-        std::vector<char32_t> word;
-        auto push_word = [&]() {
-            if (word.empty()) return;
-            if (!fits(static_cast<int>(word.size()))) flush();
-            append_unit(word);
-            word.clear();
-        };
-        for (char32_t c : sent) {
-            if (is_ws(c)) { push_word(); continue; }
-            word.push_back(c);
-            if (static_cast<int>(word.size()) >= cap) push_word();
-        }
-        push_word();
+        emit_within_capacity(u32_to_utf8(sent), lang, out);
     }
     flush();
     if (out.empty()) out.emplace_back();  // degenerate input → one empty chunk
+    return out;
+}
+
+// Emit `text` as one chunk when its wrapped form fits max_text_tokens_ — process() would otherwise
+// truncate it silently, and NFKD adds a codepoint per accented letter, so a raw-codepoint budget
+// alone cannot guarantee this. Otherwise bisect at the best sentence/clause/word boundary until
+// every piece fits.
+void SupertonicTokenizer::emit_within_capacity(const std::string& text, const std::string& lang,
+                                               std::vector<std::string>& out) const {
+    if (wrapped_length(text, lang) <= max_text_tokens_) {
+        out.push_back(text);
+        return;
+    }
+    const size_t n = count_codepoints(text);
+    std::vector<std::string> halves;
+    if (n >= 2 * static_cast<size_t>(kMinPieceCodepoints))
+        halves = split_text_for_synthesis_retry(text, count_codepoints, kMinPieceCodepoints, n - 1);
+    if (halves.size() != 2) {  // nothing to cut on; process() truncates this one
+        out.push_back(text);
+        return;
+    }
+    emit_within_capacity(halves[0], lang, out);
+    emit_within_capacity(halves[1], lang, out);
+}
+
+std::vector<SupertonicPiece> SupertonicTokenizer::fit_to_window(
+    const std::string& chunk,
+    const std::function<int(const std::string& text, bool continuation)>& latent_frames,
+    int max_frames, int min_codepoints, int max_depth) {
+    std::vector<SupertonicPiece> out;
+    if (min_codepoints < 1) min_codepoints = 1;
+    fit_recursive(chunk, latent_frames, max_frames, min_codepoints, max_depth, 0, false, out);
+    for (size_t i = 1; i < out.size(); ++i) out[i].pause_before = !out[i - 1].continuation;
     return out;
 }
 

--- a/tests/test_supertonic_tokenizer.cpp
+++ b/tests/test_supertonic_tokenizer.cpp
@@ -1,0 +1,351 @@
+// SupertonicTokenizer chunking + window fitting. Pins the text front-end regressions from #140:
+// greedy word-packing stranded the last word of a 57–62-codepoint sentence in its own chunk, the
+// fragment was tokenized with a sentence-final "." and followed by 0.3 s of silence, and NFKD
+// growth could push a chunk past the fixed text length so process() truncated it silently.
+#include "speech_core/models/supertonic_tokenizer.h"
+
+#include <cassert>
+#include <cstdio>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+// Identity table: id == codepoint across the BMP, so token ids read back as characters.
+SupertonicTokenizer make_tokenizer() {
+    std::vector<int32_t> table(0x10000);
+    std::iota(table.begin(), table.end(), 0);
+    return SupertonicTokenizer(std::move(table));
+}
+
+size_t codepoints(const std::string& s) {
+    size_t n = 0;
+    for (unsigned char c : s)
+        if ((c & 0xC0) != 0x80) ++n;
+    return n;
+}
+
+// Collapse whitespace runs to one space (chunk boundaries trim the newline/space between sentences).
+std::string squash(const std::string& s) {
+    std::string out;
+    bool ws = false;
+    for (char c : s) {
+        const bool w = (c == ' ' || c == '\n' || c == '\t' || c == '\r');
+        if (w) { if (!ws && !out.empty()) out.push_back(' '); ws = true; }
+        else   { out.push_back(c); ws = false; }
+    }
+    while (!out.empty() && out.back() == ' ') out.pop_back();
+    return out;
+}
+
+std::string join(const std::vector<std::string>& v) {
+    std::string out;
+    for (const auto& s : v) { if (!out.empty()) out += ' '; out += s; }
+    return out;
+}
+
+std::string join(const std::vector<SupertonicPiece>& v) {
+    std::vector<std::string> t;
+    for (const auto& p : v) t.push_back(p.text);
+    return join(t);
+}
+
+bool contains(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+// The report's French paragraph, verbatim (line breaks as an LLM reply would carry them).
+const char* kIssueText =
+    "Bien sûr ! Voici une petite histoire de vacances d'été en 10 phrases :\n"
+    "Cet été, j'ai passé mes vacances à la campagne. J'ai loué une petite maison près d'un lac "
+    "magnifique. Chaque matin, je me levais tôt pour faire une longue promenade. J'ai beaucoup nagé "
+    "dans l'eau fraîche et claire. J'ai aussi passé du temps à lire des livres sous les arbres. Un "
+    "après-midi, j'ai aidé mes voisins à jardiner. Nous avons mangé des fruits frais cueillis dans "
+    "le jardin. Le soir, je regardais les étoiles depuis ma terrasse. C'était un été très calme et "
+    "reposant. Je suis revenu à la ville avec beaucoup de souvenirs heureux.\n"
+    "Est-ce que tu veux que je traduise ce texte ou que je te raconte une autre histoire ?";
+
+const std::vector<std::string> kIssueSentences = {
+    "Bien sûr !",
+    "Voici une petite histoire de vacances d'été en 10 phrases :",
+    "Cet été, j'ai passé mes vacances à la campagne.",
+    "J'ai loué une petite maison près d'un lac magnifique.",
+    "Chaque matin, je me levais tôt pour faire une longue promenade.",
+    "J'ai beaucoup nagé dans l'eau fraîche et claire.",
+    "J'ai aussi passé du temps à lire des livres sous les arbres.",
+    "Un après-midi, j'ai aidé mes voisins à jardiner.",
+    "Nous avons mangé des fruits frais cueillis dans le jardin.",
+    "Le soir, je regardais les étoiles depuis ma terrasse.",
+    "C'était un été très calme et reposant.",
+    "Je suis revenu à la ville avec beaucoup de souvenirs heureux.",
+    "Est-ce que tu veux que je traduise ce texte ou que je te raconte une autre histoire ?",
+};
+
+// The packing budget LiteRTSupertonicTts derives for the published L=64 graph:
+// int(64 * 3072 / 44100 s * 14 chars/s * 0.9) = 56 codepoints.
+constexpr int kBudgetFr = 56;
+
+// Stand-in for the duration predictor: one latent frame per codepoint (a frame is ~70 ms; the
+// published 64-frame window holds ~4.5 s ≈ 60 codepoints of French).
+int fake_frames(const std::string& t, bool /*continuation*/) {
+    return static_cast<int>(codepoints(t));
+}
+
+// ---- chunk() ----
+
+void test_issue_140_sentences_stay_whole() {
+    auto tok = make_tokenizer();
+    const auto chunks = tok.chunk(kIssueText, "fr", kBudgetFr);
+
+    // Every sentence of the paragraph fits the text capacity, so none may be cut: each one appears
+    // intact inside exactly one chunk (the old word-packer cut five of them at the budget).
+    for (const auto& s : kIssueSentences) {
+        int found = 0;
+        for (const auto& c : chunks) if (contains(c, s)) ++found;
+        if (found != 1) std::printf("    sentence not whole: %s\n", s.c_str());
+        assert(found == 1);
+    }
+    // The stranded fragments the report lists must not exist as chunks.
+    for (const char* orphan : {"arbres.", "jardin.", "heureux.", "promenade.", "campagne.",
+                               "phrases :", "raconte une autre histoire ?"}) {
+        for (const auto& c : chunks) assert(c != orphan);
+    }
+    // Every chunk still fits the model's text length after NFKD + <fr> wrap.
+    for (const auto& c : chunks) assert(tok.wrapped_length(c, "fr") <= tok.max_text_tokens());
+    // Nothing lost or reordered.
+    assert(squash(join(chunks)) == squash(kIssueText));
+    std::printf("  PASS: issue_140_sentences_stay_whole\n");
+}
+
+void test_short_sentences_still_pack() {
+    // helper.py parity: sentences share a chunk while `len(cur) + 1 + len(s) <= max_len`.
+    auto tok = make_tokenizer();
+    const auto chunks = tok.chunk("Un. Deux. Trois quatre cinq.", "fr", 12);
+    assert(chunks.size() == 2);
+    assert(chunks[0] == "Un. Deux.");           // 3 + 1 + 5 = 9 ≤ 12
+    assert(chunks[1] == "Trois quatre cinq.");  // 9 + 1 + 18 > 12
+    // Exactly at the budget still packs (the old code charged a phantom leading space).
+    const auto exact = tok.chunk("Un. Deux.", "fr", 9);
+    assert(exact.size() == 1 && exact[0] == "Un. Deux.");
+    std::printf("  PASS: short_sentences_still_pack\n");
+}
+
+void test_sentence_over_budget_kept_whole() {
+    auto tok = make_tokenizer();
+    const std::string s = "J'ai aussi passé du temps à lire des livres sous les arbres.";  // 60 > 56
+    assert(codepoints(s) > kBudgetFr);
+    const auto chunks = tok.chunk(s, "fr", kBudgetFr);
+    assert(chunks.size() == 1);
+    assert(chunks[0] == s);
+    // ...and it does not glue onto a preceding short sentence either.
+    const auto two = tok.chunk("Bien sûr ! " + s, "fr", kBudgetFr);
+    assert(two.size() == 2 && two[0] == "Bien sûr !" && two[1] == s);
+    std::printf("  PASS: sentence_over_budget_kept_whole\n");
+}
+
+void test_sentence_over_capacity_splits_balanced() {
+    // Six 43-codepoint clauses = one 269-codepoint sentence, far past the 128-token text length.
+    // It must be cut — but at commas, in balanced pieces, never leaving a stub.
+    auto tok = make_tokenizer();
+    const std::string clause = "the quick brown fox jumps over the lazy dog";
+    std::string s;
+    for (int i = 0; i < 6; ++i) { s += clause; s += (i == 5 ? "." : ", "); }
+    const auto chunks = tok.chunk(s, "en", 0);
+    assert(chunks.size() >= 3);
+    for (const auto& c : chunks) {
+        assert(tok.wrapped_length(c, "en") <= tok.max_text_tokens());
+        assert(codepoints(c) >= 40);
+        assert(c.back() == ',' || c.back() == '.');  // clause boundaries, not mid-phrase
+    }
+    assert(squash(join(chunks)) == s);
+    std::printf("  PASS: sentence_over_capacity_splits_balanced\n");
+}
+
+void test_nfkd_growth_respects_text_capacity() {
+    // 19 × "élève": 114 raw codepoints — under the old 118 raw-codepoint cap — but NFKD splits each
+    // accent off (é → e + ◌́), so the wrapped form is 161 tokens and process() would have silently
+    // dropped the end of the sentence.
+    auto tok = make_tokenizer();
+    std::string s;
+    for (int i = 0; i < 19; ++i) { s += "élève"; s += (i == 18 ? "." : " "); }
+    assert(codepoints(s) <= 118);
+    assert(tok.wrapped_length(s, "fr") > tok.max_text_tokens());
+
+    const auto chunks = tok.chunk(s, "fr", 0);
+    assert(chunks.size() >= 2);
+    for (const auto& c : chunks) {
+        const int wrapped = tok.wrapped_length(c, "fr");
+        assert(wrapped <= tok.max_text_tokens());
+        const auto t = tok.process(c, "fr", tok.max_text_tokens());
+        int real = 0;
+        for (float m : t.mask) if (m > 0.0f) ++real;
+        assert(real == wrapped);  // nothing truncated
+    }
+    assert(squash(join(chunks)) == s);
+    std::printf("  PASS: nfkd_growth_respects_text_capacity\n");
+}
+
+void test_empty_and_unsupported_language() {
+    auto tok = make_tokenizer();
+    const auto empty = tok.chunk("", "fr", kBudgetFr);
+    assert(empty.size() == 1 && empty[0].empty());
+    bool threw = false;
+    try { tok.chunk("Hallo.", "xx", kBudgetFr); } catch (const std::invalid_argument&) { threw = true; }
+    assert(threw);
+    std::printf("  PASS: empty_and_unsupported_language\n");
+}
+
+// ---- process() ----
+
+void test_process_terminator_follows_continuation() {
+    auto tok = make_tokenizer();
+    // Wrapped form is "<fr>" + body + "</fr>": the body's last character sits 6 before the end.
+    auto last_body_char = [&](const SupertonicTokenizer::Tokens& t) {
+        int n = 0;
+        for (float m : t.mask) if (m > 0.0f) ++n;
+        return t.ids[static_cast<size_t>(n - 6)];
+    };
+    assert(last_body_char(tok.process("bonjour tout le monde", "fr", 128, false)) == '.');
+    assert(last_body_char(tok.process("bonjour tout le monde", "fr", 128, true))  == ',');
+    // Existing terminal punctuation is left alone either way.
+    assert(last_body_char(tok.process("ça va ?", "fr", 128, true))   == '?');
+    assert(last_body_char(tok.process("d'abord :", "fr", 128, true)) == ':');
+    assert(last_body_char(tok.process("d'abord :", "fr", 128, false)) == ':');
+    std::printf("  PASS: process_terminator_follows_continuation\n");
+}
+
+// ---- fit_to_window() ----
+
+void test_fit_fits_untouched() {
+    const std::string s = "Cet été, j'ai passé mes vacances à la campagne.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(s, fake_frames, 64);
+    assert(pieces.size() == 1);
+    assert(pieces[0].text == s);
+    assert(!pieces[0].continuation);
+    assert(!pieces[0].pause_before);
+    std::printf("  PASS: fit_fits_untouched\n");
+}
+
+void test_fit_overflow_bisects_at_word_boundary() {
+    // "... sous les" | "arbres." (#140): a 60-codepoint sentence over a 50-frame window must come
+    // apart near its middle, on a word boundary, with the left half marked as continuing and no
+    // pause before the right half.
+    const std::string s = "J'ai aussi passé du temps à lire des livres sous les arbres.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(s, fake_frames, 50);
+    assert(pieces.size() == 2);
+    assert(codepoints(pieces[0].text) >= 20 && codepoints(pieces[1].text) >= 20);
+    assert(pieces[1].text != "arbres.");
+    assert(pieces[0].continuation);
+    assert(!pieces[1].continuation);
+    assert(!pieces[1].pause_before);
+    // Words intact: the left piece is a prefix of the sentence that ends right before a space.
+    assert(s.compare(0, pieces[0].text.size(), pieces[0].text) == 0);
+    assert(s[pieces[0].text.size()] == ' ');
+    assert(join(pieces) == s);
+    std::printf("  PASS: fit_overflow_bisects_at_word_boundary\n");
+}
+
+void test_fit_prefers_clause_boundary() {
+    const std::string s = "Chaque matin, je me levais tôt pour faire une longue promenade.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(s, fake_frames, 55);
+    assert(pieces.size() == 2);
+    assert(pieces[0].text == "Chaque matin,");
+    assert(pieces[1].text == "je me levais tôt pour faire une longue promenade.");
+    assert(pieces[0].continuation);   // "," is not a sentence end
+    assert(!pieces[1].pause_before);
+    std::printf("  PASS: fit_prefers_clause_boundary\n");
+}
+
+void test_fit_sentence_boundary_keeps_pause() {
+    // Two packed sentences that overflow together split at ". ": the left keeps its own "." and
+    // the right is flagged for the inter-sentence pause.
+    const std::string a = "Cet été, j'ai passé mes vacances à la campagne.";
+    const std::string b = "J'ai loué une petite maison près d'un lac.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(a + " " + b, fake_frames, 64);
+    assert(pieces.size() == 2);
+    assert(pieces[0].text == a);
+    assert(pieces[1].text == b);
+    assert(!pieces[0].continuation);
+    assert(pieces[1].pause_before);
+    std::printf("  PASS: fit_sentence_boundary_keeps_pause\n");
+}
+
+void test_fit_colon_newline_boundary() {
+    // The report's first stranded fragment: "... en 10" | "phrases :". The lead-in and the first
+    // story sentence form one 107-codepoint "sentence" (":" is not a sentence terminal) that must
+    // come apart at the colon, not at a character count.
+    const std::string lead  = "Voici une petite histoire de vacances d'été en 10 phrases :";
+    const std::string first = "Cet été, j'ai passé mes vacances à la campagne.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(lead + "\n" + first, fake_frames, 64);
+    assert(pieces.size() == 2);
+    assert(pieces[0].text == lead);
+    assert(pieces[1].text == first);
+    std::printf("  PASS: fit_colon_newline_boundary\n");
+}
+
+void test_fit_measures_with_the_continuation_flag() {
+    // The predictor must see the same continuation flag the synthesizer will tokenize with (the
+    // trailing "," changes the ids), and every returned piece must have been measured as such.
+    std::vector<std::pair<std::string, bool>> calls;
+    auto recording = [&](const std::string& t, bool c) {
+        calls.emplace_back(t, c);
+        return static_cast<int>(codepoints(t));
+    };
+    const std::string s = "J'ai aussi passé du temps à lire des livres sous les arbres.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(s, recording, 50);
+    assert(pieces.size() == 2);
+    for (const auto& p : pieces) {
+        bool seen = false;
+        for (const auto& c : calls) if (c.first == p.text && c.second == p.continuation) seen = true;
+        assert(seen);
+    }
+    assert(calls.front().first == s && !calls.front().second);
+    std::printf("  PASS: fit_measures_with_the_continuation_flag\n");
+}
+
+void test_fit_too_short_returned_for_truncation() {
+    // Under 2 × min_codepoints there is nothing to bisect: hand the piece back unchanged.
+    const auto pieces = SupertonicTokenizer::fit_to_window("Bien sûr !", fake_frames, 4);
+    assert(pieces.size() == 1);
+    assert(pieces[0].text == "Bien sûr !");
+    std::printf("  PASS: fit_too_short_returned_for_truncation\n");
+}
+
+void test_fit_depth_bound_terminates() {
+    auto never_fits = [](const std::string&, bool) { return 1 << 20; };
+    std::string s;
+    for (int i = 0; i < 40; ++i) s += "word ";
+    s += "end.";
+    const auto pieces = SupertonicTokenizer::fit_to_window(s, never_fits, 64, 8, 3);
+    assert(!pieces.empty() && pieces.size() <= 8);  // 2^3
+    for (const auto& p : pieces) assert(codepoints(p.text) >= 8);
+    assert(join(pieces) == s);
+    std::printf("  PASS: fit_depth_bound_terminates\n");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("test_supertonic_tokenizer\n");
+    test_issue_140_sentences_stay_whole();
+    test_short_sentences_still_pack();
+    test_sentence_over_budget_kept_whole();
+    test_sentence_over_capacity_splits_balanced();
+    test_nfkd_growth_respects_text_capacity();
+    test_empty_and_unsupported_language();
+    test_process_terminator_follows_continuation();
+    test_fit_fits_untouched();
+    test_fit_overflow_bisects_at_word_boundary();
+    test_fit_prefers_clause_boundary();
+    test_fit_sentence_boundary_keeps_pause();
+    test_fit_colon_newline_boundary();
+    test_fit_measures_with_the_continuation_flag();
+    test_fit_too_short_returned_for_truncation();
+    test_fit_depth_bound_terminates();
+    std::printf("ALL PASSED\n");
+    return 0;
+}

--- a/tests/test_supertonic_tokenizer.cpp
+++ b/tests/test_supertonic_tokenizer.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <cstdio>
 #include <numeric>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
## Summary

Fixes #140. `LiteRTSupertonicTts` broke sentences of 57–62 codepoints right before their last word or two ("… sous les" | "arbres."), tokenized the fragment with a sentence-final "." and inserted 0.3 s of silence before the orphaned word.

Root cause: the published LiteRT graphs are fixed-shape (L = 64 latent frames ≈ 4.46 s), and the host kept every chunk inside that window with a chars/sec guess — 56 codepoints for non-CJK text. `SupertonicTokenizer::chunk()` word-packed any longer sentence greedily at that cap, so the remnant was almost always the final word.

## What changed

**`SupertonicTokenizer`**
- `chunk()` keeps a sentence longer than the packing budget whole (short sentences still pack exactly like upstream `helper.py::_chunk_text`). Only text that exceeds the 128-token text length is bisected here, in balanced halves at the best sentence/clause/word boundary.
- That capacity is now measured on the wrapped, NFKD form (`wrapped_length()`). NFKD adds a codepoint per accented letter, so the old raw-codepoint cap let `process()` truncate accented chunks silently — e.g. 19 × "élève" is 114 raw codepoints but 161 tokens.
- New `fit_to_window()` planner: given a frame predictor, it bisects an overflowing chunk with the core `split_text_for_synthesis_retry()` (the same helper Kokoro uses for its fixed window), marks left pieces as continuation, and records where a real sentence boundary sits.
- `process(…, continuation=true)` closes a fragment with "," instead of "."; in-memory constructor for tests.

**`LiteRTSupertonicTts::synthesize()`**
- The duration predictor (already the first graph) is the preflight: a chunk is split only when its *measured* audio overflows the window. An overflow of at most 10% (`kWindowStretchMax`) is absorbed by clamping the duration to the window — the same host-side mechanism as `set_speed()` — instead of cutting the sentence.
- The 0.3 s silence is inserted only where a sentence ends, never at a forced intra-sentence split. At such a seam the model's own utterance padding (~400 ms tail + ~300 ms head) is trimmed to 150 ms so the split reads as a short comma pause.
- No callbacks after `cancel()`; one privacy-safe log line per piece (frames vs. window, no text).

Docs: new `LiteRTSupertonicTts` section in `docs/models.md`. README untouched.

## Test plan

- [x] New `tests/test_supertonic_tokenizer.cpp` (15 cases, `SPEECH_CORE_WITH_LITERT=ON`, no bundle needed): the paragraph from #140 with every sentence intact and none of the reported orphan chunks; packing parity; over-budget sentence kept whole; over-capacity balanced split; NFKD capacity; "," vs "." terminator; planner boundaries (word, clause, sentence, colon+newline), continuation/pause flags, too-short and depth-bound cases.
- [x] `ctest`: default 32/32, LiteRT 39/39, ONNX 41/41.
- [x] Real bundle (`soniqo/Supertonic-3-LiteRT`, seed 1234), the paragraph from #140 in `fr`:

  | | before | after |
  |---|---|---|
  | pieces synthesized | 19 | 14 |
  | forced intra-sentence splits | 6 | 1 (the 85-char final question, L=79) |
  | 0.3 s silences inserted | 18 | 11 |
  | total audio | 58.1 s | 50.8 s |

  Every previously orphaned sentence now synthesizes whole (L=61–65/64); the two L=65 pieces are tempo-fitted (1.6% faster).
- [x] `ja` (no whitespace after 。), `de`, `en` paragraphs: no truncation, all pieces within the window.
- [x] Listening check (en/de): orphan breaks gone; the 150 ms seam was preferred over 250 ms. What remains at a forced split is prosodic — the second piece is a separate generation and restarts with sentence-initial emphasis — which only a longer latent window can fix (follow-up below).

## Follow-ups (not in this PR)

- Export an L=128 latent bucket (~9 s) in speech-models next to the L=64 graphs and let the host pick the bucket per piece; sentences up to ~120 codepoints then synthesize in one pass and forced splits only remain for run-on sentences.
- speech-swift's mirrored `chunk()` has the same NFKD-capacity truncation; its CoreML export has dynamic L so nothing else applies.
- The core splitter ranks only ASCII `.!?` / `,;:`; teaching it `。！？、` would give ja/ko clause-aware cuts (today they get balanced character cuts, as the old greedy 24-codepoint cuts did).
- A word-boundary split can land after a function word ("… histoire de | vacances"); a short-word tie-break in the core splitter would help Kokoro too.
