### PR TITLE
Add TTSInterface::set_voice with an empty-id reset

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -93,6 +93,7 @@ public:
         const std::string& language,
         const TtsSynthesisOptions& options,
         TTSChunkCallback on_chunk);
+    virtual void set_voice(const std::string& voice_id) {}
     virtual int output_sample_rate() const = 0;
     virtual void cancel() {}
 };
@@ -104,6 +105,8 @@ using TTSChunkCallback = std::function<void(
 The callback is invoked for each audio chunk during synthesis. `is_final=true` marks the last chunk. Implementations that aren't streaming-capable can emit a single chunk with `is_final=true`.
 
 `synthesize()` is the streaming API and is not deprecated. `synthesize_with_options()` is the uniform delivery/post-processing API for all TTS implementations through the base default. `Streaming` with no post-processing delegates to `synthesize()`. `Buffered` accumulates all PCM for the submitted text input, applies the requested offline post-processing chain, then invokes the callback once with `is_final=true`. Any offline post-processing belongs on the complete buffered result, not on individual streaming chunks or internal text chunks. Models only need to override `synthesize_with_options()` when they need custom buffering around internal decoder chunks. `VoicePipeline` currently calls `synthesize()` unless a future pipeline config threads synthesis options through.
+
+`set_voice()` selects a backend voice preset for subsequent `synthesize()` calls — Supertonic `F1`…`F5` / `M1`…`M5`, Kokoro `af_heart`, `ff_siwis`, … An empty id restores the backend default (and, for Kokoro, re-arms the language-driven voice switch); unknown ids throw `std::invalid_argument`. The base default is a no-op so fixed-voice backends (Pocket, VoxCPM, …) need no override. It is not synchronized against `synthesize()` — a host that offers a per-call voice (speech-android's `synthesize(text, language, voice)`) wraps `set_voice(id)` → `synthesize()` → `set_voice("")` under its own lock.
 
 **Reference implementations:** `KokoroTts` (Kokoro 82M via ONNX Runtime;
 sentence/chunk-split output with a final marker) and `LiteRTKokoroTts` (the

--- a/docs/models.md
+++ b/docs/models.md
@@ -1210,7 +1210,9 @@ fewer split/retries are more important than the shorter graph's latency.
 - 24 kHz Float32 output
 - One callback per safe internal text chunk; `is_final=true` marks the final one
 - Auto-switches voice on language change (en → af_heart, fr → ff_siwis, …)
-  until `set_voice()` selects an explicit persistent voice
+  until `set_voice()` selects an explicit persistent voice; `set_voice("")`
+  restores `af_heart` and re-arms the auto-switch, and unknown voices throw
+  `std::invalid_argument`
 - Phonemizer: GPL-free three-tier (dict + suffix stemming + rule-based G2P), no eSpeak dependency. See `kokoro_phonemizer.h` + `kokoro_multilingual.h`.
 - Unsafe length, non-finite PCM, or numerical instability triggers bounded split/retry; output is never clamped or silently dropped
 - Output post-processing: trailing-silence trim, 5 ms fade-in / 10 ms fade-out at the speech boundary

--- a/include/speech_core/interfaces.h
+++ b/include/speech_core/interfaces.h
@@ -179,6 +179,15 @@ public:
         const TtsSynthesisOptions& options,
         TTSChunkCallback on_chunk);
 
+    /// Select a backend voice preset for subsequent synthesis calls, e.g.
+    /// Supertonic `F1`…`F5` / `M1`…`M5` or Kokoro `af_heart`, `ff_siwis`.
+    /// An empty id restores the backend default (for Kokoro this also
+    /// re-arms the language-driven voice switch). Unknown ids throw
+    /// std::invalid_argument. Backends with a single fixed voice keep this
+    /// no-op default. Not synchronized against synthesize(): callers
+    /// serialize both on one instance.
+    virtual void set_voice(const std::string& /*voice_id*/) {}
+
     /// Output sample rate in Hz.
     virtual int output_sample_rate() const = 0;
 

--- a/include/speech_core/models/kokoro_tts.h
+++ b/include/speech_core/models/kokoro_tts.h
@@ -66,7 +66,10 @@ public:
 
     /// Select an explicit voice for subsequent synthesis calls. Once set,
     /// language changes no longer replace it with a language-default voice.
-    void set_voice(const std::string& name);
+    /// An empty name restores `af_heart` and re-arms the language-driven
+    /// auto-switch. Throws std::invalid_argument when `<name>.bin` is not in
+    /// the voices directory.
+    void set_voice(const std::string& name) override;
     /// Set the model duration scalar used by the next synthesis. Values match
     /// the OpenAI speech API range: 0.25 (slowest) through 4.0 (fastest).
     void set_speed(float speed);
@@ -74,7 +77,9 @@ public:
 private:
     enum class ChunkResult { Emitted, RetrySmaller, Cancelled };
 
-    std::vector<float> load_voice_embedding(const std::string& name);
+    /// Reads `<name>.bin` into [out]. Returns false (leaving [out] untouched)
+    /// when the file is missing.
+    bool load_voice_embedding(const std::string& name, std::vector<float>& out);
     void auto_switch_voice(const std::string& language);
     bool synthesize_with_retry(const std::string& text,
                                const TTSChunkCallback& on_chunk,

--- a/include/speech_core/models/litert_kokoro_tts.h
+++ b/include/speech_core/models/litert_kokoro_tts.h
@@ -50,7 +50,11 @@ public:
     int output_sample_rate() const override { return 24000; }
     void cancel() override;
 
-    void set_voice(const std::string& name);
+    /// Select an explicit voice; language changes then no longer replace it.
+    /// An empty name restores `af_heart` and re-arms the language auto-switch.
+    /// Throws std::invalid_argument when `<name>.bin` is not in the voices
+    /// directory.
+    void set_voice(const std::string& name) override;
     void set_speed(float speed);
     void set_seed(uint32_t seed) { seed_ = seed; }
 
@@ -116,6 +120,7 @@ private:
     std::vector<float> voice_embedding_;
     std::string voices_dir_;
     std::string current_lang_;
+    bool voice_overridden_ = false;
     float speed_ = 1.0f;
     uint32_t seed_ = 0;
     uint32_t seed_used_ = 0;

--- a/include/speech_core/models/litert_supertonic_tts.h
+++ b/include/speech_core/models/litert_supertonic_tts.h
@@ -53,8 +53,10 @@ public:
     int output_sample_rate() const override { return 44100; }
     void cancel() override;
 
-    /// Select the voice (e.g. "F1", "M3"). Default "F1". Throws if unknown.
-    void set_voice(const std::string& voice_id);
+    /// Select the voice (e.g. "F1", "M3"). Default "F1" (or the first loaded
+    /// style when F1 is absent); an empty id restores that default. Throws
+    /// std::invalid_argument if unknown.
+    void set_voice(const std::string& voice_id) override;
 
     /// Flow-matching ODE steps: 5 (fast) · 8 (default) · 12 (quality).
     void set_total_step(int total_step) { total_step_ = total_step; }
@@ -92,6 +94,7 @@ private:
     std::unique_ptr<SupertonicTokenizer>        tokenizer_;
     std::unordered_map<std::string, VoiceStyle> voices_;
     std::string                                 voice_id_ = "F1";
+    std::string                                 default_voice_id_;  // resolved in the ctor
 
     static constexpr int kTextT          = 128;       // fixed text length (relpos attention)
     static constexpr int kLatentChannels = 144;       // latent_dim(24) * chunk_compress(6)

--- a/include/speech_core/supertonic_c.h
+++ b/include/speech_core/supertonic_c.h
@@ -49,7 +49,8 @@ sc_supertonic_t sc_supertonic_create_from_paths(const char* duration_path,
 
 void sc_supertonic_destroy(sc_supertonic_t synth);
 
-/// Select the voice (e.g. "F1", "M3"). No-op + error string on unknown id.
+/// Select the voice (e.g. "F1", "M3"); "" restores the default. No-op + error
+/// string on unknown id.
 void sc_supertonic_set_voice(sc_supertonic_t synth, const char* voice_id);
 
 /// Flow-matching ODE steps: 5 (fast) · 8 (default) · 12 (quality).

--- a/src/models/kokoro/kokoro_tts.cpp
+++ b/src/models/kokoro/kokoro_tts.cpp
@@ -111,6 +111,12 @@ KokoroTts::Config KokoroTts::Config::short_turn_3p5s(bool hw_accel) {
     return config;
 }
 
+namespace {
+// Voice selected at construction and by set_voice(""); also the auto-switch
+// target for English.
+constexpr const char* kDefaultVoice = "af_heart";
+}  // namespace
+
 KokoroTts::KokoroTts(
     const std::string& model_path,
     const std::string& voices_dir,
@@ -150,9 +156,8 @@ KokoroTts::KokoroTts(
             data_dir + "/dict_" + lang + ".json");
     }
 
-    // Load default voice
-    set_voice("af_heart");
-    voice_overridden_ = false;
+    // Load the default voice with the language auto-switch armed.
+    set_voice("");
     current_lang_ = "en";
 }
 
@@ -161,7 +166,22 @@ KokoroTts::~KokoroTts() {
 }
 
 void KokoroTts::set_voice(const std::string& name) {
-    voice_embedding_ = load_voice_embedding(name);
+    if (name.empty()) {
+        // Back to the engine default. Clearing current_lang_ makes the next
+        // synthesize() re-run the language auto-switch, so a language other
+        // than English picks up its mapped voice again.
+        if (!load_voice_embedding(kDefaultVoice, voice_embedding_)) {
+            voice_embedding_.assign(256, 0.0f);
+        }
+        voice_overridden_ = false;
+        current_lang_.clear();
+        return;
+    }
+    std::vector<float> embedding;
+    if (!load_voice_embedding(name, embedding)) {
+        throw std::invalid_argument("Kokoro: unknown voice '" + name + "'");
+    }
+    voice_embedding_ = std::move(embedding);
     voice_overridden_ = true;
 }
 
@@ -172,17 +192,19 @@ void KokoroTts::set_speed(float speed) {
     speed_ = speed;
 }
 
-std::vector<float> KokoroTts::load_voice_embedding(const std::string& name) {
+bool KokoroTts::load_voice_embedding(const std::string& name,
+                                     std::vector<float>& out) {
     std::string path = voices_dir_ + "/" + name + ".bin";
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
         LOGE("Voice file not found: %s", path.c_str());
-        return std::vector<float>(256, 0.0f);
+        return false;
     }
 
     std::vector<float> embedding(256);
     file.read(reinterpret_cast<char*>(embedding.data()), 256 * sizeof(float));
-    return embedding;
+    out = std::move(embedding);
+    return true;
 }
 
 void KokoroTts::auto_switch_voice(const std::string& lang) {
@@ -206,8 +228,8 @@ void KokoroTts::auto_switch_voice(const std::string& lang) {
 
     for (auto& entry : map) {
         if (lang == entry.lang) {
-            auto emb = load_voice_embedding(entry.voice);
-            if (emb[0] != 0.0f || emb[1] != 0.0f) {  // check not zeroed (missing file)
+            std::vector<float> emb;
+            if (load_voice_embedding(entry.voice, emb)) {
                 voice_embedding_ = std::move(emb);
                 LOGI("TTS: auto-switched voice to %s for language %s", entry.voice, entry.lang);
             }

--- a/src/models/litert/litert_kokoro_tts.cpp
+++ b/src/models/litert/litert_kokoro_tts.cpp
@@ -326,7 +326,7 @@ void LiteRTKokoroTts::load_support_data(const std::string& data_dir) {
         phonemizer_.load_language_dict(
             lang, data_dir + "/dict_" + lang + ".json");
     }
-    set_voice("af_heart");
+    set_voice("");
     current_lang_ = "en";
 }
 
@@ -373,12 +373,25 @@ std::vector<float> LiteRTKokoroTts::load_voice_embedding(
 }
 
 void LiteRTKokoroTts::set_voice(const std::string& name) {
+    if (name.empty()) {
+        voice_embedding_ = load_voice_embedding("af_heart");
+        voice_overridden_ = false;
+        current_lang_.clear();  // re-run the auto-switch on the next synthesize()
+        return;
+    }
+    const std::filesystem::path path =
+        std::filesystem::path(voices_dir_) / (name + ".bin");
+    if (!std::filesystem::exists(path)) {
+        throw std::invalid_argument("Kokoro LiteRT: unknown voice '" + name + "'");
+    }
     voice_embedding_ = load_voice_embedding(name);
+    voice_overridden_ = true;
 }
 
 void LiteRTKokoroTts::auto_switch_voice(const std::string& language) {
     if (language == current_lang_) return;
     current_lang_ = language;
+    if (voice_overridden_) return;
 
     struct LangVoice {
         const char* language;

--- a/src/models/litert/litert_supertonic_tts.cpp
+++ b/src/models/litert/litert_supertonic_tts.cpp
@@ -125,6 +125,7 @@ LiteRTSupertonicTts::LiteRTSupertonicTts(const std::string& duration_path,
         if (voices_.empty())
             throw std::runtime_error("Supertonic: no voice styles in " + voice_styles_dir);
         if (!voices_.count(voice_id_)) voice_id_ = voices_.begin()->first;
+        default_voice_id_ = voice_id_;
     } catch (...) {
         destroy_graphs();  // release any LiteRt handles acquired before the failure, then rethrow
         throw;
@@ -149,6 +150,10 @@ void LiteRTSupertonicTts::destroy_graphs() noexcept {
 void LiteRTSupertonicTts::cancel() { cancelled_.store(true); }
 
 void LiteRTSupertonicTts::set_voice(const std::string& voice_id) {
+    if (voice_id.empty()) {
+        voice_id_ = default_voice_id_;
+        return;
+    }
     if (!voices_.count(voice_id))
         throw std::invalid_argument("Supertonic: unknown voice '" + voice_id + "'");
     voice_id_ = voice_id;

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -493,6 +493,70 @@ void test_kokoro_tts(const std::string& dir) {
     std::printf("ok (samples=%zu)\n", total_samples);
 }
 
+// set_voice(): unknown ids throw before touching state, an explicit voice
+// changes the audio and pins it across language changes, and "" restores the
+// default plus the language auto-switch.
+void test_kokoro_voice_selection(const std::string& dir) {
+    std::string model = dir + "/kokoro-e2e.onnx";
+    std::string voices = dir + "/voices";
+    if (!file_exists(model) || !file_exists(dir + "/vocab_index.json") ||
+        !file_exists(voices + "/af_heart.bin") || !file_exists(voices + "/ff_siwis.bin")) {
+        std::printf("  [skip] kokoro files (incl. voices/{af_heart,ff_siwis}.bin) not in %s\n",
+                    dir.c_str());
+        return;
+    }
+    std::printf("  test_kokoro_voice_selection ... ");
+
+    speech_core::KokoroTts tts(model, voices, dir, /*hw_accel=*/false);
+    // Kokoro draws its `random_phases` graph input from rand(); reseed before
+    // every render so two renders with the same voice are comparable.
+    auto render = [&](const char* text, const char* lang) {
+        std::srand(1234u);
+        std::vector<float> pcm;
+        tts.synthesize(text, lang, [&](const float* s, size_t n, bool) {
+            pcm.insert(pcm.end(), s, s + n);
+        });
+        return pcm;
+    };
+    auto mean_abs_diff = [](const std::vector<float>& a, const std::vector<float>& b) {
+        if (a.size() != b.size()) return 1.0;
+        double acc = 0.0;
+        for (size_t i = 0; i < a.size(); ++i) acc += std::fabs(a[i] - b[i]);
+        return a.empty() ? 0.0 : acc / static_cast<double>(a.size());
+    };
+
+    bool threw = false;
+    try {
+        tts.set_voice("no_such_voice");
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    REQUIRE(threw);
+
+    // Explicit voice vs. default, then "" restores the default output.
+    const auto base = render("Hello world.", "en");
+    REQUIRE(!base.empty());
+    tts.set_voice("ff_siwis");
+    const auto voiced = render("Hello world.", "en");
+    REQUIRE(mean_abs_diff(voiced, base) > 1e-3);
+    tts.set_voice("");
+    const auto restored = render("Hello world.", "en");
+    REQUIRE(mean_abs_diff(restored, base) < 1e-3);
+
+    // An explicit voice survives a language change; "" re-arms the
+    // language-driven switch (fr -> ff_siwis).
+    tts.set_voice("af_heart");
+    const auto pinned_fr = render("Bonjour le monde.", "fr");
+    tts.set_voice("");
+    const auto auto_fr = render("Bonjour le monde.", "fr");
+    tts.set_voice("ff_siwis");
+    const auto explicit_fr = render("Bonjour le monde.", "fr");
+    REQUIRE(mean_abs_diff(pinned_fr, auto_fr) > 1e-3);
+    REQUIRE(mean_abs_diff(auto_fr, explicit_fr) < 1e-3);
+
+    std::printf("ok (base=%zu voiced=%zu)\n", base.size(), voiced.size());
+}
+
 void test_kokoro_short_turn_profile(const std::string& dir) {
     const char* model_env = std::getenv("SPEECH_KOKORO_REALTIME_ONNX_PATH");
     if (!model_env || !file_exists(model_env) ||
@@ -1305,6 +1369,7 @@ int main() {
     RUN(test_onnx_canary_stt);
     RUN(test_nemotron_multilingual_stt);
     RUN(test_kokoro_tts);
+    RUN(test_kokoro_voice_selection);
     RUN(test_kokoro_short_turn_profile);
     RUN(test_deepfilter);
     RUN(test_sidon_restorer);

--- a/tests/test_tts_voice.cpp
+++ b/tests/test_tts_voice.cpp
@@ -1,0 +1,106 @@
+// TTSInterface::set_voice() contract: the base default is a no-op, an
+// override receives the id verbatim, and the empty id means "restore the
+// backend default". Pure interface test — no model runtime involved.
+
+// Force-enable asserts even under Release builds.
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "speech_core/interfaces.h"
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+// A fixed-voice backend: overrides nothing beyond the pure virtuals.
+class FixedVoiceTts : public TTSInterface {
+public:
+    void synthesize(const std::string& text,
+                    const std::string& /*language*/,
+                    TTSChunkCallback on_chunk) override {
+        std::vector<float> pcm(text.size(), 0.25f);
+        on_chunk(pcm.data(), pcm.size(), true);
+    }
+    int output_sample_rate() const override { return 24000; }
+};
+
+// A preset backend: records what the host asked for.
+class PresetTts : public TTSInterface {
+public:
+    std::string voice = "F1";
+    int set_calls = 0;
+
+    void set_voice(const std::string& voice_id) override {
+        ++set_calls;
+        voice = voice_id.empty() ? "F1" : voice_id;
+    }
+    void synthesize(const std::string& /*text*/,
+                    const std::string& /*language*/,
+                    TTSChunkCallback on_chunk) override {
+        const float sample = 0.0f;
+        on_chunk(&sample, 1, true);
+    }
+    int output_sample_rate() const override { return 44100; }
+};
+
+size_t render(TTSInterface& tts) {
+    size_t samples = 0;
+    tts.synthesize("hello", "en", [&](const float*, size_t n, bool) { samples += n; });
+    return samples;
+}
+
+}  // namespace
+
+void test_default_set_voice_is_a_noop() {
+    FixedVoiceTts tts;
+    TTSInterface& iface = tts;
+    iface.set_voice("M1");
+    iface.set_voice("");
+    assert(render(iface) == 5);
+    std::printf("  PASS: default_set_voice_is_a_noop\n");
+}
+
+void test_override_receives_id_and_empty_restores_default() {
+    PresetTts tts;
+    TTSInterface& iface = tts;
+
+    iface.set_voice("M3");
+    assert(tts.voice == "M3");
+    assert(render(iface) == 1);
+
+    iface.set_voice("");
+    assert(tts.voice == "F1");
+    assert(tts.set_calls == 2);
+    std::printf("  PASS: override_receives_id_and_empty_restores_default\n");
+}
+
+// The per-call pattern a host uses to offer a voice on one synthesize() call
+// without leaking it into later calls.
+void test_scoped_voice_round_trip() {
+    PresetTts tts;
+    TTSInterface& iface = tts;
+
+    const std::string requested = "F4";
+    if (!requested.empty()) iface.set_voice(requested);
+    render(iface);
+    if (!requested.empty()) iface.set_voice("");
+
+    assert(tts.voice == "F1");
+    assert(tts.set_calls == 2);
+    std::printf("  PASS: scoped_voice_round_trip\n");
+}
+
+int main() {
+    std::printf("test_tts_voice:\n");
+    test_default_set_voice_is_a_noop();
+    test_override_receives_id_and_empty_restores_default();
+    test_scoped_voice_round_trip();
+    std::printf("All TTS voice tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds `TTSInterface::set_voice(voice_id)` so hosts can select a backend voice preset through the abstract interface. Motivated by soniqo/speech-android#80, where the Android SDK wants `synthesize(text, language, voice)` on a shared TTS instance without a `dynamic_cast` in the JNI bridge.

## What changed

- `interfaces.h`: `virtual void set_voice(const std::string&)` with a no-op default. An empty id means "restore the backend default", unknown ids throw `std::invalid_argument`. Documented in `docs/interfaces.md`.
- `KokoroTts` / `LiteRTKokoroTts`: `set_voice` is now an override. `set_voice("")` restores `af_heart` and re-arms the language auto-switch (previously there was no way back once an explicit voice was set). An unknown voice now throws instead of silently loading a zeroed 256-float embedding. LiteRT Kokoro gains the `voice_overridden_` guard the ONNX build already had, so an explicit voice is no longer replaced on the next language change.
- `LiteRTSupertonicTts`: remembers the default resolved in the constructor (`F1`, or the first loaded style) and restores it on `""`. `sc_supertonic_set_voice` inherits the reset semantics.
- Docs: `docs/interfaces.md`, `docs/models.md` (Kokoro voice bullet), `supertonic_c.h` comment.

No C ABI changes; `CTTSAdapter` keeps the no-op default.

## Test plan

- [x] `cmake -B build && cmake --build build && ctest` (default config): 33/33, including the new `test_tts_voice`.
- [x] `SPEECH_CORE_WITH_ONNX=ON` config: 42/42. `test_models` ran `test_kokoro_voice_selection` against real Kokoro assets (unknown id throws, explicit voice changes output, `""` restores the baseline, explicit voice survives `fr`, `""` re-arms `fr → ff_siwis`).
- [x] LiteRT backends (Supertonic, LiteRT Kokoro) compiled via the speech-android NDK build (`SPEECH_CORE_WITH_LITERT=ON`, arm64-v8a + x86_64).
