### PR TITLE
Drop the Korean voice from Kokoro's language auto-switch map

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -1235,7 +1235,6 @@ Voice embeddings are 256-float `.bin` files in `voices_dir`. Default voice is `a
 | `hi` | hf_alpha |
 | `ja` | jf_alpha |
 | `zh` | zf_xiaobei |
-| `ko` | kf_somi |
 
 ### Data directory
 

--- a/src/models/kokoro/kokoro_tts.cpp
+++ b/src/models/kokoro/kokoro_tts.cpp
@@ -223,7 +223,6 @@ void KokoroTts::auto_switch_voice(const std::string& lang) {
         {"hi", "hf_alpha"},
         {"ja", "jf_alpha"},
         {"zh", "zf_xiaobei"},
-        {"ko", "kf_somi"},
     };
 
     for (auto& entry : map) {

--- a/src/models/litert/litert_kokoro_tts.cpp
+++ b/src/models/litert/litert_kokoro_tts.cpp
@@ -400,7 +400,7 @@ void LiteRTKokoroTts::auto_switch_voice(const std::string& language) {
     static const LangVoice voices[] = {
         {"en", "af_heart"}, {"fr", "ff_siwis"}, {"es", "ef_dora"},
         {"it", "if_sara"}, {"pt", "pf_dora"},  {"hi", "hf_alpha"},
-        {"ja", "jf_alpha"}, {"zh", "zf_xiaobei"}, {"ko", "kf_somi"},
+        {"ja", "jf_alpha"}, {"zh", "zf_xiaobei"},
     };
 
     for (const auto& entry : voices) {


### PR DESCRIPTION
## Summary

Kokoro's language→voice auto-switch table maps `ko` to `kf_somi`, but that voice does not exist: `hexgrad/Kokoro-82M` ships 54 voices with no Korean one, the published `soniqo/Kokoro-82M-ONNX` bundle has none, and the phonemizer has no Korean G2P. The entry could only ever fail the file lookup (logging `Voice file not found`) and keep whichever voice was already loaded.

Noticed while wiring per-call voices for soniqo/speech-android#80; the Android `ModelManager` download list was suspected of missing `kf_somi.bin`, but the gap is in this table, not the downloader.

## What changed

- `KokoroTts` and `LiteRTKokoroTts`: drop the `{"ko", "kf_somi"}` row from the auto-switch map.
- `docs/models.md`: drop the `ko` row from the Kokoro language table.

Behavioral no-op for every supported language; Korean input still synthesizes with the current voice as before, minus the misleading error log.

## Test plan

- [x] Default config: `ctest` 33/33.
- [x] `SPEECH_CORE_WITH_ONNX=ON`: `ctest` 42/42, with `test_models` running the Kokoro tests (`test_kokoro_tts`, `test_kokoro_voice_selection`) against real assets.
