### PR TITLE
Add Smart Turn v3.2 end-of-turn classifier to turn detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,8 @@ jobs:
               apt-get update -q
               apt-get install -yq /dist/speech_*_amd64.deb
               for exe in speech_transcribe speech_synthesize speech_phonemize \
-                         speech_voxcpm2_clone speech_demo speech-server; do
+                         speech_smart_turn speech_voxcpm2_clone speech_demo \
+                         speech-server; do
                 echo "--- ldd $exe"
                 test -x "/usr/bin/$exe" || { echo "MISSING $exe"; exit 1; }
                 if ldd /usr/bin/$exe | grep "not found"; then
@@ -167,6 +168,7 @@ jobs:
           for exe in package-root/usr/bin/speech_transcribe \
                      package-root/usr/bin/speech_synthesize \
                      package-root/usr/bin/speech_phonemize \
+                     package-root/usr/bin/speech_smart_turn \
                      package-root/usr/bin/speech-server; do
             file "$exe" | tee /dev/stderr | grep -q "aarch64"
             # shellcheck disable=SC2016 # Match the literal ELF $ORIGIN token.
@@ -270,6 +272,7 @@ jobs:
             "bin/speech_transcribe.exe",
             "bin/speech_synthesize.exe",
             "bin/speech_phonemize.exe",
+            "bin/speech_smart_turn.exe",
             "bin/speech.dll",
             "bin/onnxruntime.dll",
             "bin/onnxruntime_providers_shared.dll",
@@ -297,7 +300,7 @@ jobs:
               $help -notmatch "/v1/audio/transcriptions") {
             throw "speech-server.exe did not start and print endpoint help"
           }
-          foreach ($executable in @("speech_transcribe.exe", "speech_synthesize.exe", "speech_phonemize.exe")) {
+          foreach ($executable in @("speech_transcribe.exe", "speech_synthesize.exe", "speech_phonemize.exe", "speech_smart_turn.exe")) {
             $executablePath = Join-Path $root.FullName "bin/$executable"
             $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
             $startInfo.FileName = $executablePath

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 speech-core — voice agent pipeline engine in C++17. Provides:
 
 1. **Orchestration core** — state machine, turn detection, interruption handling, speech queue, conversation context, streaming VAD state machine, audio utilities. Zero ML dependencies, pure C++17.
-2. **Abstract interfaces** — `STTInterface`, `TTSInterface`, `VADInterface`, `EnhancerInterface`, `EchoCancellerInterface`, `LLMInterface`, plus the batch diarization interfaces `SegmentationInterface`, `EmbeddingInterface`, `DiarizerInterface` (with `SegmentationWindow` / `DiarizedSegment` / `DiarizerConfig` types) in `include/speech_core/interfaces.h`. Consumers (speech-swift, speech-android, speech-cloud, …) implement these with their own model backends.
-3. **Optional ONNX reference implementations** — `SileroVad`, `ParakeetStt`, `KokoroTts`, `DeepFilterEnhancer` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_ONNX=ON`.
+2. **Abstract interfaces** — `STTInterface`, `TTSInterface`, `VADInterface`, `TurnCompletionInterface`, `EnhancerInterface`, `EchoCancellerInterface`, `LLMInterface`, plus the batch diarization interfaces `SegmentationInterface`, `EmbeddingInterface`, `DiarizerInterface` (with `SegmentationWindow` / `DiarizedSegment` / `DiarizerConfig` types) in `include/speech_core/interfaces.h`. Consumers (speech-swift, speech-android, speech-cloud, …) implement these with their own model backends.
+3. **Optional ONNX reference implementations** — `SileroVad`, `ParakeetStt`, `KokoroTts`, `DeepFilterEnhancer`, `OnnxSmartTurn` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_ONNX=ON`.
 4. **Optional LiteRT reference implementations** — `LiteRTSileroVad`, `LiteRTParakeetStt`, `LiteRTKokoroTts`, `LiteRTVoxCPM2Tts`, `LiteRTChatterboxTts`, `LiteRTWeSpeakerEmbedding`, `LiteRTPyannoteSegmentation`, `LiteRTOmnilingualStt`, `LiteRTNemotronStreamingStt` in `include/speech_core/models/`. Compiled in only when `SPEECH_CORE_WITH_LITERT=ON`. Backed by `libLiteRt` from Google's `ai-edge-litert` package (extracted from the PyPI wheel by `scripts/fetch_litert.sh`). DeepFilter LiteRT does not exist yet. `LiteRTKokoroTts` ships the validated three-stage 60-frame FP32 bundle, enforces a 56-frame right-context guard, and is enabled on Windows and Android where the validated runtimes export the required TensorFlow Lite interpreter C API. `LiteRTChatterboxTts` (multilingual TTS, `soniqo/Chatterbox-LiteRT`, C ABI in `chatterbox_c.h`) defaults to greedy decoding; ship the fp16 T3 bundle for Arabic (int8 is English-quality only).
 5. **Diarization** — `DiarizationPipeline` (`DiarizerInterface`) in `include/speech_core/diarization/`. Pure C++17, no ML-runtime dependency, built into the **core** library; composes a `SegmentationInterface` + `EmbeddingInterface` with constrained agglomerative clustering.
 
@@ -83,7 +83,7 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + 
 | `include/speech_core/tts_synthesis_options.h` | Generic C++ TTS streaming/buffered delivery mode and offline post-process flag contract |
 | `include/speech_core/voxcpm2_c.h` | Standalone VoxCPM2 LiteRT C ABI, including synthesis delivery options and post-process flags |
 | `include/speech_core/models/voxcpm2_synthesis_options.h` | VoxCPM2 compatibility aliases for the generic TTS synthesis options |
-| `include/speech_core/interfaces.h` | Abstract STT / TTS / VAD / Enhancer / AEC / LLM + Segmentation / Embedding / Diarizer interfaces |
+| `include/speech_core/interfaces.h` | Abstract STT / TTS / VAD / Turn completion / Enhancer / AEC / LLM + Segmentation / Embedding / Diarizer interfaces |
 | `include/speech_core/pipeline/voice_pipeline.h` | Main orchestrator |
 | `include/speech_core/pipeline/turn_detector.h` | VAD-driven turn boundaries + interruption logic |
 | `include/speech_core/pipeline/speech_queue.h` | Priority queue with cancel/resume |
@@ -93,6 +93,7 @@ target_link_libraries(my_app PRIVATE speech_core speech_core_models_litert) # + 
 | `include/speech_core/models/parakeet_stt.h` | Parakeet TDT v3 (ORT) — implements `STTInterface` |
 | `include/speech_core/models/kokoro_tts.h` | Kokoro 82M (ORT) — implements `TTSInterface` |
 | `include/speech_core/models/deepfilter.h` | DeepFilterNet3 (ORT) — implements `EnhancerInterface` |
+| `include/speech_core/models/onnx_smart_turn.h` | Smart Turn v3.2 (ORT) — implements `TurnCompletionInterface` |
 | `include/speech_core/models/onnx_engine.h` | ORT singleton with NNAPI/QNN/CPU EP selection |
 | `include/speech_core/models/litert_silero_vad.h` | Silero VAD v5 (LiteRT) — implements `VADInterface` |
 | `include/speech_core/models/litert_parakeet_stt.h` | Parakeet TDT v3 (LiteRT, INT8 encoder) — implements `STTInterface` |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ if(SPEECH_CORE_WITH_ONNX)
         src/models/sortformer/onnx_sortformer_diarizer.cpp
         src/models/redimnet/onnx_redimnet_speaker_embedding.cpp
         src/models/wespeaker/onnx_wespeaker_embedding.cpp
+        src/models/smartturn/onnx_smart_turn.cpp
     )
     # VoxCPM2 tokenizer is pure C++17 and shared with the LiteRT target. To
     # avoid duplicate symbols when a downstream binary links both targets, we
@@ -257,6 +258,13 @@ if(SPEECH_CORE_WITH_ONNX)
         target_link_libraries(speech_sidon_restore PRIVATE speech_core_models)
         if(MSVC)
             target_compile_definitions(speech_sidon_restore PRIVATE _USE_MATH_DEFINES NOMINMAX)
+        endif()
+
+        # End-of-turn probability for one recorded utterance (Smart Turn v3.2).
+        add_executable(speech_smart_turn examples/onnx/smart_turn.cpp)
+        target_link_libraries(speech_smart_turn PRIVATE speech_core_models)
+        if(MSVC)
+            target_compile_definitions(speech_smart_turn PRIVATE _USE_MATH_DEFINES NOMINMAX)
         endif()
 
         # Diarization runtime gate: proves the C++ ONNX wrappers reproduce the
@@ -691,6 +699,7 @@ if(SPEECH_CORE_BUILD_TESTS)
            OR TEST_NAME STREQUAL "test_onnx_localvqe_model"
            OR TEST_NAME STREQUAL "test_onnx_redimnet_model"
            OR TEST_NAME STREQUAL "test_onnx_sortformer_model"
+           OR TEST_NAME STREQUAL "test_onnx_smart_turn_model"
            OR TEST_NAME STREQUAL "test_redimnet_audio_preparation"
            OR TEST_NAME STREQUAL "test_litert_functiongemma_llm"
            OR TEST_NAME STREQUAL "test_openai_tts_server"
@@ -858,6 +867,16 @@ if(SPEECH_CORE_BUILD_TESTS)
             PRIVATE speech_core_models)
         add_test(NAME test_onnx_sortformer_model
                  COMMAND test_onnx_sortformer_model)
+    endif()
+
+    if(SPEECH_CORE_WITH_ONNX AND
+       EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_onnx_smart_turn_model.cpp)
+        add_executable(test_onnx_smart_turn_model
+            tests/test_onnx_smart_turn_model.cpp)
+        target_link_libraries(test_onnx_smart_turn_model
+            PRIVATE speech_core_models)
+        add_test(NAME test_onnx_smart_turn_model
+                 COMMAND test_onnx_smart_turn_model)
     endif()
 
     if(SPEECH_CORE_WITH_ONNX AND
@@ -1194,7 +1213,7 @@ if(SPEECH_CORE_PACKAGE)
     # Collect whichever CLI targets this configuration actually built.
     set(_pkg_cli_targets "")
     foreach(_t speech_demo speech_transcribe speech_synthesize speech_phonemize
-               speech_server speech_voxcpm2_clone)
+               speech_smart_turn speech_server speech_voxcpm2_clone)
         if(TARGET ${_t})
             list(APPEND _pkg_cli_targets ${_t})
         endif()

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ speech-core separates a small, model-agnostic orchestration layer from optional 
 | Model | Task | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/guides/vad) | Voice activity detection | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | End-of-turn detection | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/guides/parakeet) | Speech-to-text | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/guides/whisper) | Multilingual speech-to-text | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Speech-to-text + translation (en/de/es/fr) | ✓ | — |
@@ -149,6 +150,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_ar.md
+++ b/README_ar.md
@@ -49,6 +49,7 @@
 | النموذج | المهمة | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/ar/guides/vad) | اكتشاف النشاط الصوتي | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | اكتشاف نهاية دور المتحدث | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/ar/guides/parakeet) | تحويل الكلام إلى نص | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ar/guides/whisper) | تعرف متعدد اللغات | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | تحويل الكلام إلى نص + ترجمة (en/de/es/fr) | ✓ | — |
@@ -154,6 +155,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_de.md
+++ b/README_de.md
@@ -43,6 +43,7 @@ speech-core trennt eine kleine, modellunabhängige Orchestrierungsschicht von op
 | Modell | Aufgabe | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/de/guides/vad) | Voice Activity Detection | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | End-of-Turn-Erkennung | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/de/guides/parakeet) | Speech-to-Text | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/de/guides/whisper) | Mehrsprachiges Speech-to-Text | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Speech-to-Text + Übersetzung (en/de/es/fr) | ✓ | — |
@@ -139,6 +140,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_es.md
+++ b/README_es.md
@@ -43,6 +43,7 @@ speech-core separa una pequeña capa de orquestación independiente del modelo d
 | Modelo | Tarea | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/es/guides/vad) | Detección de actividad de voz | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Detección de fin de turno | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/es/guides/parakeet) | Voz a texto | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/es/guides/whisper) | Voz a texto multilingüe | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Voz a texto + traducción (en/de/es/fr) | ✓ | — |
@@ -139,6 +140,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_fr.md
+++ b/README_fr.md
@@ -43,6 +43,7 @@ speech-core sépare une petite couche d'orchestration indépendante des modèles
 | Modèle | Tâche | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/fr/guides/vad) | Détection d'activité vocale | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Détection de fin de tour de parole | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/fr/guides/parakeet) | Parole vers texte | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/fr/guides/whisper) | Parole vers texte multilingue | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Parole vers texte + traduction (en/de/es/fr) | ✓ | — |
@@ -139,6 +140,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_hi.md
+++ b/README_hi.md
@@ -43,6 +43,7 @@ speech-core एक छोटे, model-agnostic orchestration layer को optio
 | Model | कार्य | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/hi/guides/vad) | Voice activity detection | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | टर्न समाप्ति का पता लगाना | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/hi/guides/parakeet) | Speech-to-text | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/hi/guides/whisper) | Multilingual speech-to-text | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Speech-to-text + translation (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_ja.md
+++ b/README_ja.md
@@ -47,6 +47,7 @@ speech-core は、小さくモデル非依存のオーケストレーション�
 | モデル | タスク | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/ja/guides/vad) | 音声区間検出 | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | ターン終了検出 | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/ja/guides/parakeet) | 音声認識 | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ja/guides/whisper) | 多言語音声認識 | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 音声認識 + 翻訳（en/de/es/fr） | ✓ | — |
@@ -149,6 +150,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_ko.md
+++ b/README_ko.md
@@ -47,6 +47,7 @@ speech-core는 작고 모델에 독립적인 오케스트레이션 계층과 선
 | 모델 | 작업 | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/ko/guides/vad) | 음성 활동 감지 | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | 턴 종료 감지 | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/ko/guides/parakeet) | 음성 인식 | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ko/guides/whisper) | 다국어 음성 인식 | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 음성 인식 + 번역 (en/de/es/fr) | ✓ | — |
@@ -149,6 +150,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_pt.md
+++ b/README_pt.md
@@ -43,6 +43,7 @@ speech-core separa uma pequena camada de orquestração independente de modelo d
 | Modelo | Tarefa | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/pt/guides/vad) | Detecção de atividade de voz | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Detecção de fim de turno | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/pt/guides/parakeet) | Voz para texto | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/pt/guides/whisper) | Voz para texto multilíngue | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Voz para texto + tradução (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_ru.md
+++ b/README_ru.md
@@ -43,6 +43,7 @@ speech-core отделяет компактный, независимый от �
 | Модель | Задача | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/ru/guides/vad) | Детекция речи | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Определение конца реплики | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/ru/guides/parakeet) | Распознавание речи | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/ru/guides/whisper) | Многоязычное распознавание | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Распознавание речи + перевод (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_th.md
+++ b/README_th.md
@@ -43,6 +43,7 @@ speech-core แยกชั้น orchestration ขนาดเล็กที�
 | โมเดล | งาน | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/th/guides/vad) | ตรวจจับกิจกรรมเสียง | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | ตรวจจับการจบเทิร์นการพูด | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/th/guides/parakeet) | เสียงเป็นข้อความ | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/th/guides/whisper) | เสียงเป็นข้อความหลายภาษา | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | เสียงเป็นข้อความ + การแปล (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_tr.md
+++ b/README_tr.md
@@ -43,6 +43,7 @@ speech-core küçük, modelden bağımsız bir orkestrasyon katmanını isteğe 
 | Model | Görev | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/tr/guides/vad) | Ses etkinliği algılama | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Söz sırası sonu algılama | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/tr/guides/parakeet) | Konuşmadan metne | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/tr/guides/whisper) | Çok dilli konuşmadan metne | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | Konuşmadan metne + çeviri (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_vi.md
+++ b/README_vi.md
@@ -43,6 +43,7 @@ speech-core tách lớp điều phối nhỏ, độc lập với mô hình khỏ
 | Mô hình | Tác vụ | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/vi/guides/vad) | Phát hiện hoạt động giọng nói | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | Phát hiện kết thúc lượt nói | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/vi/guides/parakeet) | Giọng nói thành văn bản | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/vi/guides/whisper) | STT đa ngôn ngữ | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | STT + dịch thuật (en/de/es/fr) | ✓ | — |
@@ -134,6 +135,7 @@ curl -fLO "https://github.com/soniqo/speech-core/releases/download/v${VERSION}/s
 sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/README_zh.md
+++ b/README_zh.md
@@ -47,6 +47,7 @@ speech-core 将小巧、与模型无关的编排层和可选推理后端分离�
 | 模型 | 任务 | ONNX | LiteRT |
 |---|---|:---:|:---:|
 | [Silero VAD v5](https://huggingface.co/soniqo/Silero-VAD-v5-LiteRT) · [soniqo.audio](https://soniqo.audio/zh/guides/vad) | 语音活动检测 | ✓ | ✓ |
+| [Smart Turn v3.2](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) · [Pipecat](https://github.com/pipecat-ai/smart-turn) | 话轮结束检测 | ✓ | — |
 | [Parakeet TDT v3 (0.6B)](https://huggingface.co/soniqo/Parakeet-TDT-0.6B-v3-LiteRT-INT8) · [soniqo.audio](https://soniqo.audio/zh/guides/parakeet) | 语音转文字 | ✓ | ✓ |
 | [Whisper v3 / turbo](https://huggingface.co/soniqo/Whisper-Large-v3-Turbo-ONNX) · [soniqo.audio](https://soniqo.audio/zh/guides/whisper) | 多语言语音转文字 | ✓ | — |
 | [Canary 180M Flash](https://huggingface.co/soniqo/Canary-180M-Flash-ONNX) | 语音转文字 + 翻译（en/de/es/fr） | ✓ | — |
@@ -149,6 +150,7 @@ sudo apt install "./speech_${VERSION}_${ARCH}.deb"
 
 speech download-models
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech serve

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -94,3 +94,10 @@ The optional Pocket TTS bundle is published separately at
 https://huggingface.co/soniqo/Pocket-TTS-100M-ONNX-INT8 under CC BY 4.0. Its
 fixed voice was performed by Alba MacKenna; retain that attribution when the
 bundle is redistributed or used in product notices.
+
+The optional Smart Turn v3.2 bundle is published separately at
+https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX under the BSD-2-Clause
+license, Copyright (c) 2024-2025 Daily (Pipecat). Binary redistributions of
+the model files must reproduce that copyright notice, the license conditions,
+and the disclaimer in the documentation or other materials provided with the
+distribution.

--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -82,6 +82,8 @@ Key fields:
 - `post_playback_guard` — suppress VAD after playback (AEC settle)
 - `eager_stt` — start STT before silence confirms (saves latency)
 - `eager_stt_delay` — seconds in PendingSilence before eager fires (filters mid-sentence pauses)
+- `turn_completion_threshold` — end-of-turn classifier threshold (default 0.5; only used once `sc_pipeline_set_turn_completion()` attached one)
+- `turn_completion_max_silence` — seconds of silence after which a turn the classifier vetoed ends anyway (default 2.0, measured from the pause start, 0 = never)
 - `warmup_stt` — dummy STT at pipeline start (Neural Engine cold start)
 - `max_history_messages` — max conversation messages to retain (default 50, 0 = unlimited)
 - `max_history_tokens` — max conversation tokens (default 0 = disabled, requires `count_tokens` on LLM vtable)
@@ -218,6 +220,21 @@ sc_pipeline_set_echo_canceller(pipeline, aec);
 ```
 
 Processing chain: `mic → AEC → enhance → VAD → STT`. Implementations can use SpeexDSP, WebRTC AEC, or platform-native echo cancellation.
+
+### End-of-turn classifier
+
+`sc_pipeline_set_turn_completion()` attaches an optional end-of-turn classifier such as Smart Turn. Once attached, a VAD pause only ends the user's turn when the classifier's completion probability reaches `turn_completion_threshold`; below it the pipeline keeps listening until the user speaks again (same turn) or `turn_completion_max_silence` elapses. Eager STT respects the veto. The callback runs synchronously inside `sc_pipeline_push_audio()` once per pause, so it should return within a few tens of milliseconds (Smart Turn: 20–50 ms on a laptop CPU). Call it before `sc_pipeline_start()`; a NULL `turn_complete_probability` detaches the classifier.
+
+```c
+sc_turn_completion_vtable_t turn = {
+    .context = my_smart_turn,
+    // audio of the turn so far (PCM Float32 at sample_rate); return P(turn complete) in [0, 1]
+    .turn_complete_probability = my_turn_complete_probability_fn
+};
+sc_pipeline_set_turn_completion(pipeline, turn);
+```
+
+Hosts that run the classifier natively (CoreML on Apple platforms, ONNX Runtime elsewhere) bridge it through this vtable exactly like `sc_vad_vtable_t`; speech-core's own ONNX implementation is `OnnxSmartTurn` (see [models.md](models.md#onnxsmartturn)).
 
 ## Standalone TTS C APIs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,7 @@ Set-ExecutionPolicy -Scope Process Bypass
 | Transcription | `speech transcribe` | `speech_transcribe.exe` | ✓ | ✓ | ✓ |
 | Kokoro synthesis | `speech speak` | `speech_synthesize.exe` | ✓ | ✓ | ✓ |
 | Kokoro phonemizer | `speech phonemize` | `speech_phonemize.exe` | ✓ | ✓ | ✓ |
+| Smart Turn end-of-turn probability | `speech turn` | `speech_smart_turn.exe` | ✓ | ✓ | ✓ |
 | OpenAI-compatible HTTP audio | `speech serve` | `speech-server.exe` | ✓ | ✓ | ✓ |
 | VoxCPM2 voice cloning | `speech clone` | — | ✓ | — | — |
 | ALSA microphone pipeline | `speech demo` | — | ✓ | — | — |
@@ -61,7 +62,7 @@ are ONNX-only; LiteRT voice cloning remains in the Linux amd64 package.
 ## Quick examples
 
 Download the ONNX models needed by transcription, Kokoro speech synthesis,
-phonemization, and the live demo:
+phonemization, the Smart Turn end-of-turn classifier, and the live demo:
 
 ```bash
 speech download-models
@@ -71,6 +72,7 @@ The default destination is `~/.cache/speech-core/models`. Then run:
 
 ```bash
 speech transcribe recording.wav
+speech turn recording.wav
 speech speak "Hello world" hello.wav
 speech phonemize "Bonjour le monde" fr
 speech demo --transcribe-only
@@ -81,6 +83,12 @@ The input to `transcribe` must be a WAV file. Mono and stereo PCM16, PCM24,
 and Float32 WAV inputs are accepted and resampled to 16 kHz mono internally.
 The `demo` command uses the default ALSA capture device unless `--device` is
 provided.
+
+`turn` prints the Smart Turn v3.2 probability that the speaker has finished
+their turn, judged from the last 8 s of a 16-bit PCM WAV (any sample rate;
+resampled to 16 kHz). `--threshold` (default 0.5) sets the complete /
+incomplete verdict and `--json` switches to machine-readable output. Use it
+to tune `turn_completion_threshold` on your own recordings.
 
 VoxCPM2 is an optional, much larger download (about 13 GB for the x86 bundle):
 
@@ -99,6 +107,7 @@ speech transcribe <input.wav>
 speech speak "<text>" [output.wav] [language]
 speech synthesize "<text>" [output.wav] [language]
 speech phonemize "<text>" [language]
+speech turn <utterance.wav> [--model path.onnx] [--threshold 0.5] [--json]
 speech serve [--host HOST] [--port PORT] [--model-dir PATH] [--api-key KEY]
 speech clone [bundle_dir] <ref.wav> "<text>" <out.wav> [instruction] [max_steps] [seed]
 speech demo [--model-dir <path>] [--qnn] [--transcribe-only] [--device <alsa_device>]
@@ -113,6 +122,7 @@ arguments for its complete positional syntax:
 speech_transcribe [model_dir] <input.wav>
 speech_synthesize [model_dir] <output.wav> "<text>" [language]
 speech_phonemize [model_dir] "<text>" [language]
+speech_smart_turn <in.wav> [--model path.onnx] [--threshold 0.5] [--json]
 speech-server [--host HOST] [--port PORT] [--model-dir PATH] [--api-key KEY]
 speech_voxcpm2_clone [bundle_dir] <ref.wav> "<text>" <out.wav> [instruction] [max_steps] [seed]
 ```
@@ -121,7 +131,7 @@ speech_voxcpm2_clone [bundle_dir] <ref.wav> "<text>" <out.wav> [instruction] [ma
 
 | Variable | Used by | Default |
 |---|---|---|
-| `SPEECH_MODEL_DIR` | ONNX transcribe, speak, phonemize, demo, server | `~/.cache/speech-core/models` or `%LOCALAPPDATA%\speech-core\models` |
+| `SPEECH_MODEL_DIR` | ONNX transcribe, speak, phonemize, turn, demo, server | `~/.cache/speech-core/models` or `%LOCALAPPDATA%\speech-core\models` |
 | `SPEECH_SERVER_API_KEY` | Optional bearer authentication for `speech-server` | unset; loopback-only access needs no key |
 | `SPEECH_LITERT_MODEL_DIR` | VoxCPM2 clone | architecture-specific VoxCPM2 cache directory |
 | `SPEECH_CORE_CACHE_DIR` | Overrides the speech-core cache root | `%LOCALAPPDATA%\speech-core`, `$XDG_CACHE_HOME/speech-core`, or `~/.cache/speech-core` |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -11,6 +11,7 @@ This file is the C++ counterpart to speech-swift's [`docs/shared-protocols.md`](
 │  VoicePipeline ─┬─► STTInterface            │
 │                 ├─► TTSInterface            │
 │                 ├─► VADInterface            │
+│                 ├─► TurnCompletionInterface │
 │                 ├─► EnhancerInterface       │
 │                 ├─► EchoCancellerInterface  │
 │                 └─► LLMInterface (optional) │
@@ -135,6 +136,24 @@ Returns a speech probability in `[0, 1]` per chunk. The probability stream is co
 **Reference implementation:** `SileroVad` (Silero VAD v5 via ONNX Runtime, 512 samples @ 16 kHz).
 
 **Swift counterpart:** `StreamingVADProvider`.
+
+## TurnCompletionInterface — End-of-turn classification (utterance-level)
+
+```cpp
+class TurnCompletionInterface {
+public:
+    virtual ~TurnCompletionInterface() = default;
+
+    virtual float turn_complete_probability(
+        const float* samples, size_t length, int sample_rate) = 0;
+};
+```
+
+Returns the probability in `[0, 1]` that the user has finished their turn, given the audio of the turn so far. A VAD only hears silence; a turn-completion model listens to the whole utterance, so a mid-sentence pause keeps the agent waiting while a finished sentence gets an immediate reply. `TurnDetector` calls it synchronously from the audio path once per VAD pause (Smart Turn looks at the last 8 s), so implementations must return within a few tens of milliseconds. Optional: attach one with `VoicePipeline::set_turn_completion()`; the decision threshold and the silence cap live in `AgentConfig::turn_completion_threshold` / `turn_completion_max_silence`.
+
+**Reference implementation:** `OnnxSmartTurn` (Pipecat Smart Turn v3.2 via ONNX Runtime, last 8 s @ 16 kHz).
+
+**Swift counterpart:** `SmartTurnModel` (`TurnCompletionProvider`) in speech-swift, bridged through `sc_turn_completion_vtable_t`.
 
 ## EnhancerInterface — Speech enhancement / denoising
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -7,6 +7,7 @@ speech-core ships two parallel sets of model wrappers under `include/speech_core
 | Model | Interface | Header | Status |
 |---|---|---|---|
 | `SileroVad` | `VADInterface` | `speech_core/models/silero_vad.h` | full |
+| `OnnxSmartTurn` | `TurnCompletionInterface` | `speech_core/models/onnx_smart_turn.h` | full |
 | `ParakeetStt` | `STTInterface` | `speech_core/models/parakeet_stt.h` | full |
 | `OnnxWhisperStt` | `STTInterface` | `speech_core/models/onnx_whisper_stt.h` | full |
 | `OnnxCanaryStt` | `STTInterface` | `speech_core/models/onnx_canary_stt.h` | full (offline, en/de/es/fr) |
@@ -313,6 +314,39 @@ float prob = vad.process_chunk(samples_512, 512);  // → [0, 1]
 - LSTM state carried across chunks; `reset()` clears it between sessions
 - Returns speech probability; feed to `StreamingVAD` for start/end events
 - Model files: [soniqo/Silero-VAD-v5-ONNX](https://huggingface.co/soniqo/Silero-VAD-v5-ONNX) — `silero-vad.onnx` (~2 MB)
+
+## OnnxSmartTurn
+
+Pipecat Smart Turn v3.2 — end-of-turn classifier. A VAD only hears silence;
+Smart Turn listens to the prosody of the whole utterance and scores whether
+the user has finished their turn, so a mid-sentence pause keeps the agent
+waiting while a finished sentence gets an immediate reply. Whisper-Tiny
+encoder + attention pooling + MLP head, 8.0 M parameters, 23 languages.
+
+```cpp
+#include <speech_core/models/onnx_smart_turn.h>
+
+speech_core::OnnxSmartTurn model("/models/smart-turn-v3.2-int8.onnx");
+
+// Audio of the turn so far at any rate (resampled to 16 kHz internally).
+float p = model.turn_complete_probability(turn.data(), turn.size(), rate);
+
+// Or let the pipeline ask it on every VAD pause (before start()).
+pipeline.set_turn_completion(&model);
+```
+
+- Graph contract: `audio [1, 128000] float32` (the last 8 s of 16 kHz audio) → `probability [1, 1] float32`. `kSampleRate = 16000`, `kWindowSamples = 128000`.
+- The Whisper log-mel front-end — including the zero-mean / unit-variance waveform normalisation the model was trained with — is embedded in the graph, so there is no C++ feature extraction.
+- Window: the last 8 s of the turn, zero-padded at the front when the turn is shorter (`OnnxSmartTurn::prepare_window()`); longer turns contribute only their final 8 s.
+- Pipeline: `VoicePipeline::set_turn_completion()` / `TurnDetector::set_turn_completion()`. Once attached, a VAD pause only ends the user's turn when the probability reaches `AgentConfig::turn_completion_threshold` (default 0.5). Below it the detector holds the turn — audio keeps accumulating, further speech continues the same turn, the next pause asks again on the whole turn — until `AgentConfig::turn_completion_max_silence` (default 2.0 s from the start of the pause, 0 = never) ends it anyway. Eager STT respects the veto; force-split and `flush()` bypass the classifier. Details in [pipeline.md](pipeline.md#end-of-turn-classifier-smart-turn).
+- Cost: one synchronous call per pause on the audio thread — about 35 ms on an Apple M5 Pro with ORT's default two threads (20 ms with four); the int8 graph is the same speed there and mainly saves download size. Expect more on phone-class CPUs.
+- Upstream accuracy on Pipecat's 31.5k-clip test set: 93.7 % (fp32), 92.6 % (int8).
+- **ONNX-only.** No LiteRT variant.
+- C API: `sc_turn_completion_vtable_t` + `sc_pipeline_set_turn_completion()`, with `sc_config_t.turn_completion_threshold` / `turn_completion_max_silence`; Swift/Kotlin hosts can bridge their own classifier (e.g. CoreML) the same way as `sc_vad_vtable_t`.
+- CLI: `speech_smart_turn <in.wav> [--model path.onnx] [--threshold 0.5] [--json]` (`examples/onnx/smart_turn.cpp`), or `speech turn <utterance.wav>` through the dispatcher — prints the completion probability for the last 8 s of a recording.
+- Tests: `test_turn_detector_smart_turn` (scripted classifier, no model) and `test_onnx_smart_turn_model`, gated on `SPEECH_SMART_TURN_ONNX=/path/to/smart-turn-v3.2-int8.onnx` (`SPEECH_CORE_TEST_AUDIO` optionally points at the finished-sentence fixture WAV).
+- License: BSD-2-Clause — weights by Daily / Pipecat ([pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn), [pipecat-ai/smart-turn-v3](https://huggingface.co/pipecat-ai/smart-turn-v3)).
+- Model files: [soniqo/Smart-Turn-v3.2-ONNX](https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX) — `smart-turn-v3.2.onnx` (float32, 33 MB) and `smart-turn-v3.2-int8.onnx` (int8, ~10 MB). `scripts/download_models.sh` / `.ps1` fetch the int8 graph.
 
 ## ParakeetStt
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -120,6 +120,17 @@ to prevent backends that ignore cancellation from emitting stale results.
 4. On confirmed speech start: begin buffering audio, emit `UserSpeechStarted`
 5. On confirmed speech end: emit `UserSpeechEnded` with the buffered audio
 
+### End-of-turn classifier (Smart Turn)
+
+Silence alone is a weak signal for the end of a turn: people pause mid-sentence to think, and a VAD-only detector cuts them off. `TurnDetector::set_turn_completion()` — exposed as `VoicePipeline::set_turn_completion()`, call before `start()`, `nullptr` disables — attaches an optional `TurnCompletionInterface` such as `OnnxSmartTurn` (Pipecat Smart Turn v3.2). With a classifier attached, a VAD pause becomes a question rather than a verdict:
+
+1. On a pause — silence confirmed, or the eager-STT moment — the detector calls `turn_complete_probability()` on the audio of the turn so far (Smart Turn looks at the last 8 s). The call is synchronous on the audio thread, once per pause, roughly 20–50 ms on a laptop CPU.
+2. If the probability reaches `turn_completion_threshold` (default 0.5), the turn ends as usual: `UserSpeechEnded` carries the audio, and `TurnEvent::turn_completion_probability` carries the score.
+3. Otherwise the detector **holds** the turn (`turn_held()` is true): audio keeps accumulating, and if the user speaks again it continues the *same* turn — no second `UserSpeechStarted`. The next pause asks the classifier again on the whole turn.
+4. If silence continues for `turn_completion_max_silence` (default 2.0 s, measured from the start of the pause; 0 = never), the turn ends anyway, so a user who trails off still gets a reply.
+
+Eager STT respects the veto: a mid-sentence pause no longer produces an early utterance, while a pause the classifier agrees is final still fires the eager utterance at `eager_stt_delay`. `flush()` settles a held turn at end of stream, and force-split (`max_utterance_duration`) bypasses the classifier. The classifier is never consulted while the agent is speaking, so the short-speech (AEC echo) discard path is unchanged. `turn_completion_probability` is -1 whenever no classifier ran — no model attached, force-split, flush, or the silence cap expired.
+
 ### Force-split
 
 If an utterance exceeds `max_utterance_duration` (default 15s), `TurnDetector` force-ends the current segment and resets the VAD. This prevents unbounded memory growth and triggers intermediate transcriptions.
@@ -215,6 +226,8 @@ config.post_playback_guard = 0.3f;         // seconds — suppress VAD after pla
 // Latency optimizations
 config.eager_stt = true;                   // start STT before silence confirms (saves ~0.3s)
 config.eager_stt_delay = 0.3f;             // seconds in silence before eager fires (filters pauses)
+config.turn_completion_threshold = 0.5f;   // end-of-turn classifier: probability that ends the turn
+config.turn_completion_max_silence = 2.0f; // seconds of silence that end a vetoed turn anyway (0 = never)
 config.warmup_stt = true;                  // dummy transcription at pipeline start (ANE cold start)
 
 // Conversation history
@@ -228,6 +241,8 @@ config.partial_transcription_interval = 1.0f; // seconds between chunk pushes
 
 config.language = "en";                    // STT/TTS language hint (empty = auto-detect)
 ```
+
+The two `turn_completion_*` fields only take effect once a classifier is attached with `VoicePipeline::set_turn_completion()` before `start()` (see [End-of-turn classifier](#end-of-turn-classifier-smart-turn)); without one, turns end on VAD silence as before.
 
 ### Eager STT
 

--- a/examples/linux/include/speech.h
+++ b/examples/linux/include/speech.h
@@ -39,6 +39,7 @@ typedef struct {
     bool enable_enhancer;
     bool transcribe_only;
     float min_silence_duration;
+    bool enable_smart_turn;  /* end-of-turn classifier, needs smart-turn-v3.2*.onnx in model_dir */
 } speech_config_t;
 
 typedef void (*speech_event_fn)(const speech_event_t* event, void* context);

--- a/examples/linux/src/speech.cpp
+++ b/examples/linux/src/speech.cpp
@@ -2,6 +2,7 @@
 
 #include <speech_core/models/deepfilter.h>
 #include <speech_core/models/kokoro_tts.h>
+#include <speech_core/models/onnx_smart_turn.h>
 #include <speech_core/models/parakeet_stt.h>
 #include <speech_core/models/silero_vad.h>
 #include <speech_core/pipeline/agent_config.h>
@@ -25,6 +26,7 @@ struct speech_pipeline_s {
     std::unique_ptr<speech_core::ParakeetStt> stt;
     std::unique_ptr<speech_core::KokoroTts> tts;
     std::unique_ptr<speech_core::DeepFilterEnhancer> enhancer;
+    std::unique_ptr<speech_core::OnnxSmartTurn> smart_turn;
     std::unique_ptr<speech_core::VoicePipeline> pipeline;
 
     speech_event_fn user_callback = nullptr;
@@ -84,6 +86,7 @@ extern "C" speech_config_t speech_config_default(void) {
     config.enable_enhancer = false;
     config.transcribe_only = false;
     config.min_silence_duration = 0.4f;
+    config.enable_smart_turn = false;
     return config;
 }
 
@@ -139,6 +142,24 @@ extern "C" speech_pipeline_t speech_create(speech_config_t config,
         h->pipeline = std::make_unique<speech_core::VoicePipeline>(
             *h->stt, *tts_ptr, nullptr, *h->vad, sc_cfg,
             [raw](const speech_core::PipelineEvent& e) { dispatch_event(raw, e); });
+
+        // Optional end-of-turn classifier: a VAD pause only ends the turn
+        // once Smart Turn agrees the sentence is finished.
+        if (config.enable_smart_turn) {
+            std::string st = dir + "/smart-turn-v3.2" + suffix + ".onnx";
+            if (FILE* f = std::fopen(st.c_str(), "r")) {
+                std::fclose(f);
+            } else {
+                st = dir + "/smart-turn-v3.2.onnx";
+            }
+            if (FILE* f = std::fopen(st.c_str(), "r")) {
+                std::fclose(f);
+                h->smart_turn = std::make_unique<speech_core::OnnxSmartTurn>(st, false);
+                h->pipeline->set_turn_completion(h->smart_turn.get());
+            } else {
+                std::fprintf(stderr, "[speech] smart turn requested but %s not found\n", st.c_str());
+            }
+        }
 
         // Optional enhancer
         if (config.enable_enhancer) {

--- a/examples/onnx/smart_turn.cpp
+++ b/examples/onnx/smart_turn.cpp
@@ -1,0 +1,158 @@
+// Smart Turn v3.2 end-of-turn probability for a recorded utterance (ONNX backend).
+//
+// Feeds the last 8 s of a WAV file to OnnxSmartTurn and prints the probability
+// that the speaker has finished their turn — the same call TurnDetector makes
+// when a VAD pause is detected. Useful for tuning
+// AgentConfig::turn_completion_threshold on your own recordings.
+//
+// Usage:
+//   speech_smart_turn <in.wav> [--model path.onnx] [--threshold 0.5] [--json]
+//
+//   in.wav   : 16-bit PCM WAV, any sample rate (resampled to 16 kHz)
+//   --model  : defaults to $SPEECH_MODEL_DIR/smart-turn-v3.2-int8.onnx, falling
+//              back to smart-turn-v3.2.onnx (see scripts/download_models.sh)
+
+#include <speech_core/models/onnx_smart_turn.h>
+
+#include "../common/default_model_dir.h"
+#include "../common/utf8_args.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Minimal mono-float loader for canonical PCM-16 RIFF/WAVE. Multi-channel input
+// is down-mixed by averaging. Mirrors examples/onnx/sidon_restore.cpp.
+bool load_wav_mono(const std::string& path, std::vector<float>& out, int& sample_rate) {
+    std::ifstream f(std::filesystem::u8path(path), std::ios::binary);
+    if (!f) { std::fprintf(stderr, "cannot open %s\n", path.c_str()); return false; }
+
+    char riff[4], wave[4];
+    uint32_t file_size = 0;
+    f.read(riff, 4);
+    f.read(reinterpret_cast<char*>(&file_size), 4);
+    f.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
+        std::fprintf(stderr, "%s is not a RIFF/WAVE file\n", path.c_str());
+        return false;
+    }
+
+    char chunk_id[4];
+    uint32_t chunk_size = 0;
+    uint16_t audio_format = 0, channels = 0, bits = 0;
+    uint32_t rate = 0;
+    bool have_fmt = false;
+
+    while (f.read(chunk_id, 4)) {
+        f.read(reinterpret_cast<char*>(&chunk_size), 4);
+        if (std::memcmp(chunk_id, "fmt ", 4) == 0) {
+            f.read(reinterpret_cast<char*>(&audio_format), 2);
+            f.read(reinterpret_cast<char*>(&channels), 2);
+            f.read(reinterpret_cast<char*>(&rate), 4);
+            f.seekg(6, std::ios::cur);
+            f.read(reinterpret_cast<char*>(&bits), 2);
+            if (chunk_size > 16) f.seekg(chunk_size - 16, std::ios::cur);
+            have_fmt = true;
+        } else if (std::memcmp(chunk_id, "data", 4) == 0) {
+            if (!have_fmt || audio_format != 1 || bits != 16 || channels == 0) {
+                std::fprintf(stderr, "%s: only 16-bit PCM WAV is supported\n", path.c_str());
+                return false;
+            }
+            const size_t n = chunk_size / 2;
+            std::vector<int16_t> pcm(n);
+            f.read(reinterpret_cast<char*>(pcm.data()), chunk_size);
+            const size_t frames = n / channels;
+            out.resize(frames);
+            for (size_t i = 0; i < frames; ++i) {
+                int acc = 0;
+                for (uint16_t c = 0; c < channels; ++c) acc += pcm[i * channels + c];
+                out[i] = static_cast<float>(acc) / (channels * 32768.0f);
+            }
+            sample_rate = static_cast<int>(rate);
+            return true;
+        } else {
+            f.seekg(chunk_size, std::ios::cur);
+        }
+    }
+    std::fprintf(stderr, "%s: no data chunk\n", path.c_str());
+    return false;
+}
+
+std::string default_model_path() {
+    const std::string dir = speech_example_model_dir();
+    const std::string int8 = dir + "/smart-turn-v3.2-int8.onnx";
+    if (std::filesystem::exists(std::filesystem::u8path(int8))) return int8;
+    return dir + "/smart-turn-v3.2.onnx";
+}
+
+void usage(const char* argv0) {
+    std::fprintf(stderr,
+        "usage: %s <in.wav> [--model path.onnx] [--threshold 0.5] [--json]\n"
+        "  Prints the Smart Turn v3.2 probability that the speaker finished\n"
+        "  their turn, judged from the last 8 s of the recording.\n",
+        argv0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::vector<std::string> args = speech_examples::utf8_args(argc, argv);
+    const char* argv0 = args.empty() ? "speech_smart_turn" : args[0].c_str();
+
+    std::string in_wav;
+    std::string model_path;
+    float threshold = 0.5f;
+    bool json = false;
+    for (size_t i = 1; i < args.size(); ++i) {
+        const std::string& a = args[i];
+        if (a == "--model" && i + 1 < args.size()) {
+            model_path = args[++i];
+        } else if (a == "--threshold" && i + 1 < args.size()) {
+            threshold = std::strtof(args[++i].c_str(), nullptr);
+        } else if (a == "--json") {
+            json = true;
+        } else if (a == "-h" || a == "--help") {
+            usage(argv0);
+            return 0;
+        } else if (in_wav.empty() && !a.empty() && a[0] != '-') {
+            in_wav = a;
+        } else {
+            usage(argv0);
+            return 2;
+        }
+    }
+    if (in_wav.empty()) {
+        usage(argv0);
+        return 2;
+    }
+    if (model_path.empty()) model_path = default_model_path();
+
+    std::vector<float> audio;
+    int rate = 0;
+    if (!load_wav_mono(in_wav, audio, rate)) return 1;
+
+    try {
+        speech_core::OnnxSmartTurn model(model_path, /*hardware_acceleration=*/false);
+        const float probability =
+            model.turn_complete_probability(audio.data(), audio.size(), rate);
+        const bool complete = probability >= threshold;
+        if (json) {
+            std::printf("{\"probability\": %.4f, \"threshold\": %.2f, \"complete\": %s}\n",
+                        probability, threshold, complete ? "true" : "false");
+        } else {
+            std::printf("turn complete probability: %.3f (%s, threshold %.2f)\n",
+                        probability, complete ? "complete" : "incomplete", threshold);
+        }
+        return 0;
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
+}

--- a/include/speech_core/interfaces.h
+++ b/include/speech_core/interfaces.h
@@ -260,6 +260,32 @@ public:
 };
 
 // ---------------------------------------------------------------------------
+// Turn completion — end-of-turn classification (utterance-level)
+// ---------------------------------------------------------------------------
+
+/// Decides whether the user has finished their turn once the VAD reports a
+/// pause. A VAD only hears silence; a turn-completion model listens to the
+/// prosody of the whole utterance so a mid-sentence pause keeps the agent
+/// waiting while a finished sentence gets an immediate reply.
+///
+/// Reference implementation: OnnxSmartTurn (Pipecat Smart Turn v3.2).
+class TurnCompletionInterface {
+public:
+    virtual ~TurnCompletionInterface() = default;
+
+    /// Probability [0, 1] that the user's turn is complete.
+    /// @param samples      PCM Float32 audio of the turn so far. Implementations
+    ///                     look at the most recent seconds (Smart Turn: 8 s).
+    /// @param length       Number of samples
+    /// @param sample_rate  Sample rate of `samples` in Hz
+    ///
+    /// Called synchronously from the audio path when the VAD reports a pause,
+    /// so it must return within a few tens of milliseconds.
+    virtual float turn_complete_probability(
+        const float* samples, size_t length, int sample_rate) = 0;
+};
+
+// ---------------------------------------------------------------------------
 // Speech Enhancement
 // ---------------------------------------------------------------------------
 

--- a/include/speech_core/models/onnx_smart_turn.h
+++ b/include/speech_core/models/onnx_smart_turn.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "speech_core/interfaces.h"
+
+#include <onnxruntime_c_api.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace speech_core {
+
+/// Pipecat Smart Turn v3.2 end-of-turn classifier (ONNX Runtime backend).
+///
+/// Whisper-Tiny encoder + attention pooling + MLP head, 8 M parameters. Our
+/// export embeds the Whisper log-mel front-end (including the zero-mean /
+/// unit-variance waveform normalisation the model was trained with), so the
+/// graph takes raw 16 kHz audio:
+///
+///     audio [1, 128000] float32  ->  probability [1, 1] float32
+///
+/// The window is the last 8 s of the user's turn, zero-padded at the front
+/// when shorter. Run it on the whole current turn after the VAD reports a
+/// pause. One call costs roughly 20-50 ms on a laptop CPU with ORT's default
+/// two threads (the encoder dominates; the embedded front-end is ~4 ms).
+///
+/// Model files: https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX
+class OnnxSmartTurn final : public TurnCompletionInterface {
+public:
+    static constexpr int kSampleRate = 16000;
+    static constexpr std::size_t kWindowSamples = 128000;  // 8 s
+
+    explicit OnnxSmartTurn(
+        const std::string& model_path, bool hardware_acceleration = false);
+    ~OnnxSmartTurn() override;
+
+    OnnxSmartTurn(const OnnxSmartTurn&) = delete;
+    OnnxSmartTurn& operator=(const OnnxSmartTurn&) = delete;
+
+    float turn_complete_probability(
+        const float* samples, std::size_t length, int sample_rate) override;
+
+    /// The last kWindowSamples of `samples` (already at kSampleRate), left-padded
+    /// with zeros when the turn is shorter than 8 s.
+    static std::vector<float> prepare_window(
+        const float* samples, std::size_t length);
+
+private:
+    void validate_contract();
+
+    const OrtApi* api_ = nullptr;
+    OrtSession* session_ = nullptr;
+    std::vector<float> window_;
+};
+
+}  // namespace speech_core

--- a/include/speech_core/pipeline/agent_config.h
+++ b/include/speech_core/pipeline/agent_config.h
@@ -47,6 +47,19 @@ struct AgentConfig {
     /// speech). 0 = fire on first silence frame (splits on every pause).
     float eager_stt_delay = 0.3f;
 
+    /// Threshold for an optional end-of-turn classifier (see
+    /// TurnDetector::set_turn_completion / TurnCompletionInterface). Once a
+    /// model is attached, a VAD pause only ends the user's turn when the
+    /// classifier's completion probability reaches this value. Below it the
+    /// detector keeps listening: the turn continues if the user speaks again,
+    /// and ends anyway after turn_completion_max_silence.
+    float turn_completion_threshold = 0.5f;
+
+    /// Seconds of continued silence after the classifier said "not finished"
+    /// before the turn ends regardless (protects against a user trailing off).
+    /// Measured from the start of the pause. 0 = never end on silence alone.
+    float turn_completion_max_silence = 2.0f;
+
     /// Run a dummy STT transcription at pipeline start to warm up the model.
     /// First inference on CoreML/Neural Engine is slow due to cold start;
     /// this brings subsequent latency from ~3s to <1s.

--- a/include/speech_core/pipeline/turn_detector.h
+++ b/include/speech_core/pipeline/turn_detector.h
@@ -36,6 +36,11 @@ struct TurnEvent {
 
     /// Accumulated user audio for this turn (populated on UserSpeechEnded).
     std::vector<float> audio;
+
+    /// Completion probability from the attached TurnCompletionInterface for
+    /// the pause that ended this turn, or -1 when no classifier ran (no model
+    /// attached, force-split, flush, or the silence cap expired).
+    float turn_completion_probability = -1.0f;
 };
 
 /// Wraps StreamingVAD with interruption handling and utterance accumulation.
@@ -69,6 +74,19 @@ public:
 
     /// Flush any pending turn at end of stream.
     void flush();
+
+    /// Attach an optional end-of-turn classifier. When set, a VAD pause only
+    /// ends the user's turn once the classifier's probability reaches
+    /// AgentConfig::turn_completion_threshold; otherwise the detector keeps
+    /// the turn open (audio keeps accumulating) until the user speaks again
+    /// or turn_completion_max_silence elapses. Pass nullptr to disable.
+    void set_turn_completion(TurnCompletionInterface* model) {
+        turn_completion_ = model;
+    }
+
+    /// True while the classifier has vetoed the last pause and the detector
+    /// is waiting for more speech or the silence cap.
+    bool turn_held() const { return turn_hold_; }
 
     /// Reset all state (clears any active post-playback guard).
     void reset();
@@ -113,7 +131,22 @@ private:
     /// Post-playback guard: remaining samples to suppress before resuming VAD.
     size_t guard_remaining_samples_ = 0;
 
+    /// Optional end-of-turn classifier (not owned).
+    TurnCompletionInterface* turn_completion_ = nullptr;
+    bool turn_hold_ = false;         // classifier vetoed the last pause
+    float turn_hold_since_ = 0.0f;   // start of the pause being held
+
     void force_end_utterance(float time);
+
+    /// Ask the classifier about the turn so far. Returns -1 (treated as
+    /// "complete") when no classifier is attached.
+    float classify_turn();
+
+    /// Emit UserSpeechEnded for the accumulated turn and clear turn state.
+    void end_turn(float time, bool eager, float probability);
+
+    /// Enter the hold state after the classifier vetoed a pause at `time`.
+    void hold_turn(float time);
 };
 
 }  // namespace speech_core

--- a/include/speech_core/pipeline/voice_pipeline.h
+++ b/include/speech_core/pipeline/voice_pipeline.h
@@ -115,6 +115,14 @@ public:
     /// Must be called before start(). Pass nullptr to disable.
     void set_echo_canceller(EchoCancellerInterface* aec) { echo_canceller_ = aec; }
 
+    /// Attach an optional end-of-turn classifier (e.g. OnnxSmartTurn). When set,
+    /// a VAD pause only ends the user's turn once the classifier agrees; see
+    /// AgentConfig::turn_completion_threshold / turn_completion_max_silence.
+    /// Must be called before start(). Pass nullptr to disable.
+    void set_turn_completion(TurnCompletionInterface* model) {
+        turn_detector_.set_turn_completion(model);
+    }
+
     /// Access the tool registry for adding tools.
     ToolRegistry& tool_registry() { return tool_registry_; }
 

--- a/include/speech_core/speech_core_c.h
+++ b/include/speech_core/speech_core_c.h
@@ -86,6 +86,8 @@ typedef struct {
     float post_playback_guard;
     bool eager_stt;
     float eager_stt_delay;
+    float turn_completion_threshold;   // End-of-turn classifier threshold (default 0.5)
+    float turn_completion_max_silence; // Seconds of silence that end a vetoed turn anyway (default 2.0)
     bool warmup_stt;
     int max_history_messages;     // Max conversation messages (default 50, 0 = unlimited)
     int max_history_tokens;       // Max conversation tokens (default 0 = disabled)
@@ -195,6 +197,18 @@ typedef struct {
     size_t (*chunk_size)(void* ctx);
 } sc_vad_vtable_t;
 
+/// End-of-turn classifier (e.g. Smart Turn). Returns the probability in
+/// [0, 1] that the user has finished their turn, given the audio of the turn
+/// so far (PCM Float32 at sample_rate). Implementations look at the most
+/// recent seconds (Smart Turn: 8 s). Called synchronously from
+/// sc_pipeline_push_audio when the VAD reports a pause, so it must return
+/// within a few tens of milliseconds.
+typedef struct {
+    void* context;
+    float (*turn_complete_probability)(void* ctx, const float* samples,
+                                       size_t length, int sample_rate);
+} sc_turn_completion_vtable_t;
+
 typedef struct {
     void* context;
     void (*chat)(void* ctx, const sc_message_t* messages, size_t count,
@@ -270,6 +284,14 @@ void sc_pipeline_set_enhancer(sc_pipeline_t pipeline,
 /// Must be called before sc_pipeline_start().
 void sc_pipeline_set_echo_canceller(sc_pipeline_t pipeline,
                                      sc_echo_canceller_vtable_t aec);
+
+/// Attach an optional end-of-turn classifier. When set, a VAD pause only ends
+/// the user's turn once the classifier's probability reaches
+/// sc_config_t.turn_completion_threshold; below it the pipeline keeps
+/// listening until the user speaks again or turn_completion_max_silence
+/// elapses. Must be called before sc_pipeline_start().
+void sc_pipeline_set_turn_completion(sc_pipeline_t pipeline,
+                                     sc_turn_completion_vtable_t model);
 
 /// Register a tool with platform callback handler.
 /// Must be called before sc_pipeline_start().

--- a/scripts/download_models.ps1
+++ b/scripts/download_models.ps1
@@ -69,7 +69,8 @@ $defaultFiles = @(
     "Kokoro-82M-ONNX/voices/am_michael.bin",
     "Kokoro-82M-ONNX/voices/bf_emma.bin",
     "Kokoro-82M-ONNX/voices/bm_george.bin",
-    "DeepFilterNet3-ONNX/deepfilter.onnx"
+    "DeepFilterNet3-ONNX/deepfilter.onnx",
+    "Smart-Turn-v3.2-ONNX/smart-turn-v3.2-int8.onnx"
 )
 
 $stenografFiles = @(

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -54,6 +54,9 @@ FILES=(
     # DeepFilterNet3's libdf DSP tables are generated in-process, so the legacy
     # auxiliary binary is no longer a runtime dependency.
     "DeepFilterNet3-ONNX/deepfilter.onnx"
+    # Smart Turn v3.2 end-of-turn classifier (optional, ~10 MB); the fp32
+    # graph smart-turn-v3.2.onnx lives in the same repo if you prefer it.
+    "Smart-Turn-v3.2-ONNX/smart-turn-v3.2-int8.onnx"
 )
 
 for entry in "${FILES[@]}"; do

--- a/scripts/speech-dispatch.sh
+++ b/scripts/speech-dispatch.sh
@@ -32,6 +32,7 @@ case "$cmd" in
         fi
         run_tool speech_synthesize ;;
     phonemize)         run_tool speech_phonemize "$@" ;;
+    turn)              run_tool speech_smart_turn "$@" ;;
     serve|server)      run_tool speech-server "$@" ;;
     clone)             run_tool speech_voxcpm2_clone "$@" ;;
     demo)              run_tool speech_demo "$@" ;;
@@ -51,6 +52,7 @@ commands:
   serve [--host HOST] [--port PORT]  OpenAI-compatible local audio server
   clone <ref.wav> "<text>" <out.wav> voice cloning (VoxCPM2)
   phonemize "<text>" [language]      text -> phonemes (Kokoro phonemizer)
+  turn <utterance.wav>               end-of-turn probability (Smart Turn)
   demo [--transcribe-only]           live ALSA mic loop
   download-models [litert|voxcpm2]   fetch models to ~/.cache/speech-core
 

--- a/src/models/smartturn/onnx_smart_turn.cpp
+++ b/src/models/smartturn/onnx_smart_turn.cpp
@@ -1,0 +1,188 @@
+#include "speech_core/models/onnx_smart_turn.h"
+
+#include "speech_core/audio/resampler.h"
+#include "speech_core/models/onnx_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace speech_core {
+namespace {
+
+struct OrtValueHandle {
+    const OrtApi* api = nullptr;
+    OrtValue* value = nullptr;
+    ~OrtValueHandle() {
+        if (api && value) api->ReleaseValue(value);
+    }
+};
+
+std::vector<std::string> io_names(
+    const OrtApi* api, OrtSession* session, bool inputs) {
+    OrtAllocator* allocator = nullptr;
+    ort_check(api, api->GetAllocatorWithDefaultOptions(&allocator));
+    std::size_t count = 0;
+    if (inputs) {
+        ort_check(api, api->SessionGetInputCount(session, &count));
+    } else {
+        ort_check(api, api->SessionGetOutputCount(session, &count));
+    }
+    std::vector<std::string> result;
+    for (std::size_t index = 0; index < count; ++index) {
+        char* name = nullptr;
+        if (inputs) {
+            ort_check(api, api->SessionGetInputName(
+                session, index, allocator, &name));
+        } else {
+            ort_check(api, api->SessionGetOutputName(
+                session, index, allocator, &name));
+        }
+        result.emplace_back(name);
+        OrtStatus* status = api->AllocatorFree(allocator, name);
+        if (status) api->ReleaseStatus(status);
+    }
+    return result;
+}
+
+std::pair<std::vector<int64_t>, ONNXTensorElementDataType> tensor_contract(
+    const OrtApi* api, OrtSession* session, std::size_t index, bool input) {
+    OrtTypeInfo* type_info = nullptr;
+    if (input) {
+        ort_check(api, api->SessionGetInputTypeInfo(
+            session, index, &type_info));
+    } else {
+        ort_check(api, api->SessionGetOutputTypeInfo(
+            session, index, &type_info));
+    }
+    const OrtTensorTypeAndShapeInfo* tensor_info = nullptr;
+    OrtStatus* cast = api->CastTypeInfoToTensorInfo(type_info, &tensor_info);
+    if (cast || !tensor_info) {
+        if (cast) api->ReleaseStatus(cast);
+        api->ReleaseTypeInfo(type_info);
+        throw std::runtime_error("Smart Turn graph I/O must be tensors");
+    }
+    ONNXTensorElementDataType type = ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
+    std::size_t rank = 0;
+    ort_check(api, api->GetTensorElementType(tensor_info, &type));
+    ort_check(api, api->GetDimensionsCount(tensor_info, &rank));
+    std::vector<int64_t> shape(rank);
+    ort_check(api, api->GetDimensions(tensor_info, shape.data(), rank));
+    api->ReleaseTypeInfo(type_info);
+    return {std::move(shape), type};
+}
+
+}  // namespace
+
+OnnxSmartTurn::OnnxSmartTurn(
+    const std::string& model_path, bool hardware_acceleration) {
+    auto& engine = OnnxEngine::get();
+    api_ = engine.api();
+    session_ = engine.load(model_path, hardware_acceleration);
+    try {
+        validate_contract();
+    } catch (...) {
+        api_->ReleaseSession(session_);
+        session_ = nullptr;
+        throw;
+    }
+    window_.assign(kWindowSamples, 0.0f);
+}
+
+OnnxSmartTurn::~OnnxSmartTurn() {
+    if (session_) api_->ReleaseSession(session_);
+}
+
+void OnnxSmartTurn::validate_contract() {
+    if (io_names(api_, session_, true) != std::vector<std::string>{"audio"}
+        || io_names(api_, session_, false)
+            != std::vector<std::string>{"probability"}) {
+        throw std::runtime_error(
+            "Smart Turn ONNX graph has incompatible I/O names "
+            "(expected audio -> probability; use the soniqo audio-input export)");
+    }
+    const auto input = tensor_contract(api_, session_, 0, true);
+    const auto output = tensor_contract(api_, session_, 0, false);
+    if (input.first != std::vector<int64_t>{1, static_cast<int64_t>(kWindowSamples)}
+        || output.first != std::vector<int64_t>{1, 1}
+        || input.second != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT
+        || output.second != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+        throw std::runtime_error(
+            "Smart Turn ONNX graph has incompatible tensor shapes or types");
+    }
+}
+
+std::vector<float> OnnxSmartTurn::prepare_window(
+    const float* samples, std::size_t length) {
+    if (!samples && length > 0) {
+        throw std::invalid_argument("Smart Turn audio buffer is null");
+    }
+    std::vector<float> window(kWindowSamples, 0.0f);
+    if (length >= kWindowSamples) {
+        std::copy_n(samples + (length - kWindowSamples), kWindowSamples,
+                    window.begin());
+    } else if (length > 0) {
+        std::copy_n(samples, length, window.begin() + (kWindowSamples - length));
+    }
+    return window;
+}
+
+float OnnxSmartTurn::turn_complete_probability(
+    const float* samples, std::size_t length, int sample_rate) {
+    if (sample_rate <= 0) {
+        throw std::invalid_argument("Smart Turn sample rate must be positive");
+    }
+    if (!samples && length > 0) {
+        throw std::invalid_argument("Smart Turn audio buffer is null");
+    }
+    std::vector<float> resampled;
+    if (sample_rate != kSampleRate) {
+        resampled = Resampler::resample(samples, length, sample_rate, kSampleRate);
+        samples = resampled.data();
+        length = resampled.size();
+    }
+    // Only the last 8 s matter, so resampling a long turn first is wasteful but
+    // rare (the pipeline caps utterances well below that on 16 kHz input).
+    std::fill(window_.begin(), window_.end(), 0.0f);
+    if (length >= kWindowSamples) {
+        std::copy_n(samples + (length - kWindowSamples), kWindowSamples,
+                    window_.begin());
+    } else if (length > 0) {
+        std::copy_n(samples, length, window_.begin() + (kWindowSamples - length));
+    }
+    for (const float value : window_) {
+        if (!std::isfinite(value)) {
+            throw std::invalid_argument(
+                "Smart Turn audio contains a non-finite sample");
+        }
+    }
+
+    const int64_t input_shape[] = {1, static_cast<int64_t>(kWindowSamples)};
+    OrtValue* input = nullptr;
+    ort_check(api_, api_->CreateTensorWithDataAsOrtValue(
+        OnnxEngine::get().cpu_memory(),
+        window_.data(), window_.size() * sizeof(float),
+        input_shape, 2, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &input));
+    OrtValueHandle input_handle{api_, input};
+    const char* input_names[] = {"audio"};
+    const char* output_names[] = {"probability"};
+    OrtValue* inputs[] = {input};
+    OrtValue* outputs[] = {nullptr};
+    ort_check(api_, api_->Run(
+        session_, nullptr, input_names, inputs, 1, output_names, 1, outputs));
+    OrtValueHandle output_handle{api_, outputs[0]};
+
+    float* values = nullptr;
+    ort_check(api_, api_->GetTensorMutableData(
+        outputs[0], reinterpret_cast<void**>(&values)));
+    const float probability = values[0];
+    if (!std::isfinite(probability)) {
+        throw std::runtime_error("Smart Turn returned a non-finite probability");
+    }
+    return std::min(1.0f, std::max(0.0f, probability));
+}
+
+}  // namespace speech_core

--- a/src/pipeline/turn_detector.cpp
+++ b/src/pipeline/turn_detector.cpp
@@ -20,6 +20,38 @@ TurnDetector::TurnDetector(
     }
 }
 
+float TurnDetector::classify_turn() {
+    if (!turn_completion_) return -1.0f;
+    return turn_completion_->turn_complete_probability(
+        utterance_buffer_.data(), utterance_buffer_.size(),
+        vad_.input_sample_rate());
+}
+
+void TurnDetector::end_turn(float time, bool eager, float probability) {
+    in_speech_ = false;
+    turn_hold_ = false;
+    interruption_time_ = -1.0f;
+
+    TurnEvent ended;
+    ended.type = TurnEvent::UserSpeechEnded;
+    ended.time = time;
+    ended.eager = eager;
+    ended.turn_completion_probability = probability;
+    ended.audio = utterance_buffer_;
+    on_event_(ended);
+    utterance_buffer_.clear();
+}
+
+void TurnDetector::hold_turn(float time) {
+    // The classifier says the user is not done: keep the turn open. Audio
+    // keeps accumulating into utterance_buffer_ (in_speech_ stays true), a
+    // later SpeechStarted continues the same turn, and the silence cap in
+    // push_audio ends it if nothing more is said.
+    turn_hold_ = true;
+    turn_hold_since_ = time;
+    eager_pending_ = false;
+}
+
 void TurnDetector::push_audio(const float* samples, size_t count) {
     size_t chunk_size = vad_.chunk_size();
     size_t offset = 0;
@@ -44,11 +76,19 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
 
         for (const auto& vad_event : events) {
             if (vad_event.type == VADEvent::SpeechStarted) {
-                // Prepend pre-speech audio to capture onset
-                utterance_buffer_ = pre_speech_ring_;
-                pre_speech_ring_.clear();
-                utterance_start_ = vad_event.start_time;
-                in_speech_ = true;
+                // The user resuming after a pause the classifier vetoed is
+                // the same turn: keep the buffer and start time, and don't
+                // re-announce the turn to the pipeline.
+                const bool continuing_held_turn = turn_hold_;
+                if (continuing_held_turn) {
+                    turn_hold_ = false;
+                } else {
+                    // Prepend pre-speech audio to capture onset
+                    utterance_buffer_ = pre_speech_ring_;
+                    pre_speech_ring_.clear();
+                    utterance_start_ = vad_event.start_time;
+                    in_speech_ = true;
+                }
                 interruption_confirmed_ = false;
 
                 // If agent is speaking, defer interruption until min duration met
@@ -64,29 +104,28 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
                     }
                 }
 
-                TurnEvent started;
-                started.type = TurnEvent::UserSpeechStarted;
-                started.time = vad_event.start_time;
-                on_event_(started);
+                if (!continuing_held_turn) {
+                    TurnEvent started;
+                    started.type = TurnEvent::UserSpeechStarted;
+                    started.time = vad_event.start_time;
+                    on_event_(started);
+                }
 
             } else if (vad_event.type == VADEvent::SpeechPaused) {
                 // Eager STT: start timer when silence begins. After
                 // eager_stt_delay elapses, fire UserSpeechEnded early.
                 if (config_.eager_stt && in_speech_ && !agent_speaking_
-                    && !eager_utterance_sent_) {
+                    && !eager_utterance_sent_ && !turn_hold_) {
                     if (config_.eager_stt_delay <= 0.0f) {
-                        // No delay — fire immediately (original behavior)
-                        eager_utterance_sent_ = true;
-                        in_speech_ = false;
-                        interruption_time_ = -1.0f;
-
-                        TurnEvent ended;
-                        ended.type = TurnEvent::UserSpeechEnded;
-                        ended.time = vad_event.end_time;
-                        ended.eager = true;
-                        ended.audio = utterance_buffer_;
-                        on_event_(ended);
-                        utterance_buffer_.clear();
+                        // No delay — fire immediately (original behavior),
+                        // unless the classifier says the user is mid-sentence.
+                        const float p = classify_turn();
+                        if (p >= 0.0f && p < config_.turn_completion_threshold) {
+                            hold_turn(vad_event.end_time);
+                        } else {
+                            eager_utterance_sent_ = true;
+                            end_turn(vad_event.end_time, /*eager=*/true, p);
+                        }
                     } else {
                         // Start deferred eager timer
                         eager_pending_ = true;
@@ -97,6 +136,8 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
             } else if (vad_event.type == VADEvent::SpeechResumed) {
                 // Cancel deferred eager — speech resumed before delay elapsed
                 eager_pending_ = false;
+                // A classifier hold ends the same way: the turn continues.
+                turn_hold_ = false;
 
                 // Speech resumed after a pause — if we sent an eager utterance,
                 // that's already being processed. Treat resumed speech as a
@@ -116,11 +157,11 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
                 }
 
             } else if (vad_event.type == VADEvent::SpeechEnded) {
-                in_speech_ = false;
                 eager_pending_ = false;  // silence confirmed — normal path handles it
 
                 // If eager STT already fired, silence just confirmed it — skip
                 if (eager_utterance_sent_) {
+                    in_speech_ = false;
                     eager_utterance_sent_ = false;
                     utterance_buffer_.clear();
                     interruption_time_ = -1.0f;
@@ -128,6 +169,7 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
                 // During agent speaking: discard speech that was too short
                 // to confirm interruption (AEC residual echo)
                 else if (agent_speaking_ && !interruption_confirmed_) {
+                    in_speech_ = false;
                     // False trigger (AEC residual echo) — restore audio to
                     // pre-speech ring so onset context is preserved for the
                     // next real utterance.
@@ -145,6 +187,7 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
                     config_.interruption_recovery_timeout > 0.0f &&
                     (vad_event.end_time - interruption_time_) <
                         config_.interruption_recovery_timeout) {
+                    in_speech_ = false;
                     // Brief interruption — recover
                     TurnEvent recovered;
                     recovered.type = TurnEvent::InterruptionRecovered;
@@ -152,15 +195,20 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
                     on_event_(recovered);
                     interruption_time_ = -1.0f;
                     utterance_buffer_.clear();
-                } else {
-                    // Normal speech ended
-                    interruption_time_ = -1.0f;
-                    TurnEvent ended;
-                    ended.type = TurnEvent::UserSpeechEnded;
-                    ended.time = vad_event.end_time;
-                    ended.audio = utterance_buffer_;
-                    on_event_(ended);
-                    utterance_buffer_.clear();
+                }
+                // The classifier already vetoed this pause (at the eager
+                // moment); silence confirming it changes nothing.
+                else if (turn_hold_) {
+                    // keep holding
+                }
+                // Normal speech ended — ask the classifier, if any
+                else {
+                    const float p = classify_turn();
+                    if (p >= 0.0f && p < config_.turn_completion_threshold) {
+                        hold_turn(vad_event.end_time);
+                    } else {
+                        end_turn(vad_event.end_time, /*eager=*/false, p);
+                    }
                 }
             }
         }
@@ -170,17 +218,21 @@ void TurnDetector::push_audio(const float* samples, size_t count) {
             float elapsed = streaming_vad_.current_time() - eager_pending_time_;
             if (elapsed >= config_.eager_stt_delay) {
                 eager_pending_ = false;
-                eager_utterance_sent_ = true;
-                in_speech_ = false;
-                interruption_time_ = -1.0f;
+                const float p = classify_turn();
+                if (p >= 0.0f && p < config_.turn_completion_threshold) {
+                    hold_turn(eager_pending_time_);
+                } else {
+                    eager_utterance_sent_ = true;
+                    end_turn(eager_pending_time_, /*eager=*/true, p);
+                }
+            }
+        }
 
-                TurnEvent ended;
-                ended.type = TurnEvent::UserSpeechEnded;
-                ended.time = eager_pending_time_;
-                ended.eager = true;
-                ended.audio = utterance_buffer_;
-                on_event_(ended);
-                utterance_buffer_.clear();
+        // Classifier hold: the user never resumed — end the turn on the cap.
+        if (turn_hold_ && config_.turn_completion_max_silence > 0.0f) {
+            float held = streaming_vad_.current_time() - turn_hold_since_;
+            if (held >= config_.turn_completion_max_silence) {
+                end_turn(turn_hold_since_, /*eager=*/false, -1.0f);
             }
         }
 
@@ -229,14 +281,7 @@ void TurnDetector::buffer_pre_speech(const float* samples, size_t count) {
 }
 
 void TurnDetector::force_end_utterance(float time) {
-    in_speech_ = false;
-
-    TurnEvent ended;
-    ended.type = TurnEvent::UserSpeechEnded;
-    ended.time = time;
-    ended.audio = utterance_buffer_;
-    on_event_(ended);
-    utterance_buffer_.clear();
+    end_turn(time, /*eager=*/false, -1.0f);
 
     // Reset VAD state so it can detect new speech
     streaming_vad_.reset();
@@ -268,6 +313,13 @@ void TurnDetector::set_post_playback_guard(float seconds) {
 }
 
 void TurnDetector::flush() {
+    if (turn_hold_) {
+        // The VAD is idle; the classifier was still waiting for more speech.
+        // End of stream settles it, with whatever was buffered meanwhile.
+        end_turn(turn_hold_since_, /*eager=*/false, -1.0f);
+        streaming_vad_.flush();
+        return;
+    }
     auto events = streaming_vad_.flush();
     for (const auto& vad_event : events) {
         if (vad_event.type == VADEvent::SpeechEnded) {
@@ -298,6 +350,8 @@ void TurnDetector::reset() {
     eager_utterance_sent_ = false;
     eager_pending_ = false;
     guard_remaining_samples_ = 0;
+    turn_hold_ = false;
+    turn_hold_since_ = 0.0f;
 }
 
 void TurnDetector::reset_for_new_stream() {

--- a/src/speech_core_c.cpp
+++ b/src/speech_core_c.cpp
@@ -187,6 +187,19 @@ public:
     }
 };
 
+class CTurnCompletionAdapter : public TurnCompletionInterface {
+public:
+    explicit CTurnCompletionAdapter(sc_turn_completion_vtable_t vt) : vt_(vt) {}
+    float turn_complete_probability(
+        const float* samples, size_t length, int sample_rate) override {
+        if (!vt_.turn_complete_probability) return 1.0f;
+        return vt_.turn_complete_probability(
+            vt_.context, samples, length, sample_rate);
+    }
+private:
+    sc_turn_completion_vtable_t vt_;
+};
+
 // ---------------------------------------------------------------------------
 // Pipeline handle
 // ---------------------------------------------------------------------------
@@ -198,6 +211,7 @@ struct sc_pipeline_s {
     std::unique_ptr<CVADAdapter> vad;
     std::unique_ptr<CEnhancerAdapter> enhancer;
     std::unique_ptr<CEchoCancellerAdapter> echo_canceller;
+    std::unique_ptr<CTurnCompletionAdapter> turn_completion;
     std::unique_ptr<VoicePipeline> pipeline;
     sc_event_fn event_fn;
     void* event_context;
@@ -246,6 +260,8 @@ sc_config_t sc_config_default(void) {
     c.post_playback_guard = 0.3f;
     c.eager_stt = true;
     c.eager_stt_delay = 0.3f;
+    c.turn_completion_threshold = 0.5f;
+    c.turn_completion_max_silence = 2.0f;
     c.warmup_stt = true;
     c.max_history_messages = 50;
     c.max_history_tokens = 0;
@@ -293,6 +309,8 @@ sc_pipeline_t sc_pipeline_create(
     agent_config.post_playback_guard = config.post_playback_guard;
     agent_config.eager_stt = config.eager_stt;
     agent_config.eager_stt_delay = config.eager_stt_delay;
+    agent_config.turn_completion_threshold = config.turn_completion_threshold;
+    agent_config.turn_completion_max_silence = config.turn_completion_max_silence;
     agent_config.warmup_stt = config.warmup_stt;
     agent_config.max_history_messages = config.max_history_messages;
     agent_config.max_history_tokens = config.max_history_tokens;
@@ -386,6 +404,18 @@ void sc_pipeline_set_echo_canceller(sc_pipeline_t pipeline,
     if (!pipeline) return;
     pipeline->echo_canceller = std::make_unique<CEchoCancellerAdapter>(aec);
     pipeline->pipeline->set_echo_canceller(pipeline->echo_canceller.get());
+}
+
+void sc_pipeline_set_turn_completion(sc_pipeline_t pipeline,
+                                     sc_turn_completion_vtable_t model) {
+    if (!pipeline) return;
+    if (!model.turn_complete_probability) {
+        pipeline->pipeline->set_turn_completion(nullptr);
+        pipeline->turn_completion.reset();
+        return;
+    }
+    pipeline->turn_completion = std::make_unique<CTurnCompletionAdapter>(model);
+    pipeline->pipeline->set_turn_completion(pipeline->turn_completion.get());
 }
 
 void sc_pipeline_add_tool(sc_pipeline_t pipeline, sc_tool_definition_t tool) {

--- a/tests/test_onnx_smart_turn_model.cpp
+++ b/tests/test_onnx_smart_turn_model.cpp
@@ -1,0 +1,145 @@
+// Smart Turn v3.2 ONNX wrapper against the published graph.
+//
+// Gated on SPEECH_SMART_TURN_ONNX (path to smart-turn-v3.2-int8.onnx or the
+// fp32 graph) so CI without models skips cleanly. Checks the I/O contract, the
+// 8 s window preparation, determinism, and that the finished sentence in
+// tests/data/test_audio.wav (speech from 5 s to 9 s, silence elsewhere) is
+// scored as complete: the Python reference on its first 12 s is 0.97 for the
+// fp32 graph and 0.97 for the dynamic int8 graph.
+
+#include "speech_core/models/onnx_smart_turn.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int fail(const char* message) {
+    std::cerr << "FAIL: " << message << "\n";
+    return 1;
+}
+
+bool load_wav_mono(const std::string& path, std::vector<float>& out, int& rate) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    char riff[4], wave[4];
+    uint32_t size = 0;
+    f.read(riff, 4);
+    f.read(reinterpret_cast<char*>(&size), 4);
+    f.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) return false;
+    char id[4];
+    uint32_t chunk = 0;
+    uint16_t format = 0, channels = 0, bits = 0;
+    uint32_t sr = 0;
+    while (f.read(id, 4)) {
+        f.read(reinterpret_cast<char*>(&chunk), 4);
+        if (std::memcmp(id, "fmt ", 4) == 0) {
+            f.read(reinterpret_cast<char*>(&format), 2);
+            f.read(reinterpret_cast<char*>(&channels), 2);
+            f.read(reinterpret_cast<char*>(&sr), 4);
+            f.seekg(6, std::ios::cur);
+            f.read(reinterpret_cast<char*>(&bits), 2);
+            if (chunk > 16) f.seekg(chunk - 16, std::ios::cur);
+        } else if (std::memcmp(id, "data", 4) == 0) {
+            if (format != 1 || bits != 16 || channels == 0) return false;
+            std::vector<int16_t> pcm(chunk / 2);
+            f.read(reinterpret_cast<char*>(pcm.data()), chunk);
+            const size_t frames = pcm.size() / channels;
+            out.resize(frames);
+            for (size_t i = 0; i < frames; ++i) {
+                int acc = 0;
+                for (uint16_t c = 0; c < channels; ++c) acc += pcm[i * channels + c];
+                out[i] = static_cast<float>(acc) / (channels * 32768.0f);
+            }
+            rate = static_cast<int>(sr);
+            return true;
+        } else {
+            f.seekg(chunk, std::ios::cur);
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main() {
+    const char* configured = std::getenv("SPEECH_SMART_TURN_ONNX");
+    if (!configured || !*configured) {
+        std::cout << "SPEECH_SMART_TURN_ONNX not set — skipping Smart Turn model test\n";
+        return 0;
+    }
+
+    // Window preparation is pure and cheap; pin it before touching ORT.
+    {
+        std::vector<float> ramp(1000);
+        for (size_t i = 0; i < ramp.size(); ++i) ramp[i] = static_cast<float>(i);
+        const auto window = speech_core::OnnxSmartTurn::prepare_window(ramp.data(), ramp.size());
+        if (window.size() != speech_core::OnnxSmartTurn::kWindowSamples) return fail("window size");
+        if (window[0] != 0.0f || window[window.size() - 1001] != 0.0f) return fail("front padding");
+        if (window[window.size() - 1000] != 0.0f || window.back() != 999.0f) return fail("tail placement");
+
+        std::vector<float> longer(speech_core::OnnxSmartTurn::kWindowSamples + 5000);
+        for (size_t i = 0; i < longer.size(); ++i) longer[i] = static_cast<float>(i);
+        const auto tail = speech_core::OnnxSmartTurn::prepare_window(longer.data(), longer.size());
+        if (tail.front() != 5000.0f || tail.back() != static_cast<float>(longer.size() - 1)) {
+            return fail("long turns keep the last 8 s");
+        }
+    }
+
+    speech_core::OnnxSmartTurn model(configured, /*hardware_acceleration=*/false);
+
+    // Synthetic harmonic burst: finite, in range, deterministic.
+    std::vector<float> tone(48000);
+    for (size_t i = 0; i < tone.size(); ++i) {
+        const float t = static_cast<float>(i) / 16000.0f;
+        tone[i] = 0.2f * std::sin(2.0f * 3.14159265f * 140.0f * t)
+                + 0.1f * std::sin(2.0f * 3.14159265f * 280.0f * t);
+    }
+    const float p1 = model.turn_complete_probability(tone.data(), tone.size(), 16000);
+    const float p2 = model.turn_complete_probability(tone.data(), tone.size(), 16000);
+    if (!std::isfinite(p1) || p1 < 0.0f || p1 > 1.0f) return fail("probability out of range");
+    if (std::fabs(p1 - p2) > 1e-5f) return fail("not deterministic");
+
+    // Resampling path: the same tone at 48 kHz must land close to 16 kHz.
+    std::vector<float> tone48(tone.size() * 3);
+    for (size_t i = 0; i < tone48.size(); ++i) {
+        const float t = static_cast<float>(i) / 48000.0f;
+        tone48[i] = 0.2f * std::sin(2.0f * 3.14159265f * 140.0f * t)
+                  + 0.1f * std::sin(2.0f * 3.14159265f * 280.0f * t);
+    }
+    const float p48 = model.turn_complete_probability(tone48.data(), tone48.size(), 48000);
+    if (std::fabs(p48 - p1) > 0.1f) return fail("48 kHz input diverges from 16 kHz");
+
+    // Digital silence must not produce NaN (the front-end normalisation guards var=0).
+    std::vector<float> silence(16000, 0.0f);
+    const float ps = model.turn_complete_probability(silence.data(), silence.size(), 16000);
+    if (!std::isfinite(ps)) return fail("silence produced a non-finite probability");
+
+    // Real utterance: a finished sentence from the shared fixture.
+    const char* fixture = std::getenv("SPEECH_CORE_TEST_AUDIO");
+    std::string wav = fixture && *fixture ? fixture : "tests/data/test_audio.wav";
+    std::vector<float> audio;
+    int rate = 0;
+    if (load_wav_mono(wav, audio, rate)) {
+        // The fixture trails off into 11 s of silence; keep the sentence plus
+        // three seconds of pause, which is what a VAD hand-off looks like.
+        audio.resize(std::min(audio.size(), static_cast<size_t>(12) * static_cast<size_t>(rate)));
+        const float p = model.turn_complete_probability(audio.data(), audio.size(), rate);
+        std::cout << "  " << wav << ": p(complete) = " << p << "\n";
+        if (p < 0.85f) return fail("finished fixture sentence scored as incomplete");
+    } else {
+        std::cout << "  (fixture " << wav << " not found; skipping the reference check)\n";
+    }
+
+    std::cout << "Smart Turn ONNX model test passed (p_tone=" << p1 << ")\n";
+    return 0;
+}

--- a/tests/test_speech_dispatch.sh
+++ b/tests/test_speech_dispatch.sh
@@ -9,7 +9,7 @@ cp "$dispatcher" "$tmp/speech"
 chmod +x "$tmp/speech"
 
 for tool in \
-    speech_transcribe speech_synthesize speech_phonemize speech-server \
+    speech_transcribe speech_synthesize speech_phonemize speech_smart_turn speech-server \
     speech_voxcpm2_clone speech_demo speech_download_models \
     speech_download_models_litert speech_download_voxcpm2
 do
@@ -47,6 +47,10 @@ fr' synthesize Bonjour hello.wav fr
 assert_output 'speech_phonemize
 bonjour
 fr' phonemize bonjour fr
+
+assert_output 'speech_smart_turn
+utterance.wav
+--json' turn utterance.wav --json
 
 assert_output 'speech-server
 --host

--- a/tests/test_turn_detector_smart_turn.cpp
+++ b/tests/test_turn_detector_smart_turn.cpp
@@ -22,9 +22,11 @@
 #include "speech_core/pipeline/agent_config.h"
 #include "speech_core/pipeline/turn_detector.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <memory>
 #include <vector>
 
 using namespace speech_core;

--- a/tests/test_turn_detector_smart_turn.cpp
+++ b/tests/test_turn_detector_smart_turn.cpp
@@ -1,0 +1,295 @@
+// TurnDetector with an end-of-turn classifier attached (Smart Turn semantics).
+//
+// The classifier is scripted so the test is pure orchestration: no ORT, no
+// model file. It pins down the contract that TurnCompletionInterface adds on
+// top of the VAD hysteresis:
+//
+//   * a pause the classifier accepts ends the turn exactly as before;
+//   * a pause it vetoes keeps the turn open — audio keeps accumulating, the
+//     user resuming continues the same turn (no second UserSpeechStarted),
+//     and the next pause asks the classifier again on the whole turn;
+//   * a vetoed pause that stays silent ends on turn_completion_max_silence;
+//   * eager STT respects the veto too (no early utterance on a mid-sentence
+//     pause) and still fires when the classifier agrees;
+//   * flush() settles a held turn; the agent-speaking discard path never
+//     consults the classifier.
+
+#ifdef NDEBUG
+#  undef NDEBUG
+#endif
+
+#include "speech_core/interfaces.h"
+#include "speech_core/pipeline/agent_config.h"
+#include "speech_core/pipeline/turn_detector.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace speech_core;
+
+namespace {
+
+constexpr size_t kChunk = 512;
+constexpr float kChunkSeconds = 512.0f / 16000.0f;
+
+class ScriptedVAD : public VADInterface {
+public:
+    std::vector<float> probs;
+    size_t idx = 0;
+    float process_chunk(const float*, size_t) override {
+        size_t i = idx++;
+        return (i < probs.size()) ? probs[i] : 0.0f;
+    }
+    void reset() override { idx = 0; }
+    int input_sample_rate() const override { return 16000; }
+    size_t chunk_size() const override { return kChunk; }
+};
+
+class ScriptedTurnModel : public TurnCompletionInterface {
+public:
+    std::vector<float> answers;   // consumed in order; last one repeats
+    std::vector<size_t> lengths;  // audio length seen per call
+    std::vector<int> rates;
+    float turn_complete_probability(
+        const float* samples, size_t length, int sample_rate) override {
+        assert(samples != nullptr || length == 0);
+        lengths.push_back(length);
+        rates.push_back(sample_rate);
+        if (answers.empty()) return 1.0f;
+        const size_t i = std::min(lengths.size() - 1, answers.size() - 1);
+        return answers[i];
+    }
+};
+
+struct Harness {
+    ScriptedVAD vad;
+    ScriptedTurnModel model;
+    AgentConfig config;
+    std::vector<TurnEvent> events;
+    std::unique_ptr<TurnDetector> detector;
+
+    Harness() {
+        config.vad.min_speech_duration = 0.25f;
+        config.vad.min_silence_duration = 0.1f;
+        config.vad.pre_speech_buffer_duration = 0.0f;
+        config.eager_stt = false;
+        config.turn_completion_threshold = 0.5f;
+        config.turn_completion_max_silence = 1.0f;
+        config.max_utterance_duration = 0.0f;
+    }
+
+    void build(bool attach_model) {
+        detector = std::make_unique<TurnDetector>(
+            vad, config, [this](const TurnEvent& e) { events.push_back(e); });
+        if (attach_model) detector->set_turn_completion(&model);
+    }
+
+    /// Append `seconds` of chunks with the given VAD probability.
+    void script(float prob, float seconds) {
+        const size_t n = static_cast<size_t>(std::lround(seconds / kChunkSeconds));
+        for (size_t i = 0; i < n; ++i) vad.probs.push_back(prob);
+    }
+
+    void run_all() {
+        std::vector<float> audio(vad.probs.size() * kChunk, 0.01f);
+        detector->push_audio(audio.data(), audio.size());
+    }
+
+    size_t count(TurnEvent::Type type) const {
+        size_t n = 0;
+        for (const auto& e : events) if (e.type == type) ++n;
+        return n;
+    }
+
+    const TurnEvent& last(TurnEvent::Type type) const {
+        for (auto it = events.rbegin(); it != events.rend(); ++it) {
+            if (it->type == type) return *it;
+        }
+        assert(false && "event not found");
+        return events.front();
+    }
+};
+
+void test_without_model_unchanged() {
+    Harness h;
+    h.build(false);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.5f);
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechStarted) == 1);
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(h.last(TurnEvent::UserSpeechEnded).turn_completion_probability < 0.0f);
+    assert(h.model.lengths.empty());
+    std::printf("  no model: unchanged\n");
+}
+
+void test_complete_pause_ends_turn() {
+    Harness h;
+    h.model.answers = {0.93f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.5f);
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechStarted) == 1);
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(h.model.lengths.size() == 1);
+    assert(h.model.rates[0] == 16000);
+    const auto& ended = h.last(TurnEvent::UserSpeechEnded);
+    assert(std::fabs(ended.turn_completion_probability - 0.93f) < 1e-6f);
+    assert(!ended.eager);
+    // The classifier saw the same audio the event carries: the speech after
+    // onset confirmation (no pre-speech ring in this harness) plus the
+    // pending-silence chunks before confirmation — about 0.85 s.
+    assert(ended.audio.size() == h.model.lengths[0]);
+    assert(ended.audio.size() >= 12000);
+    std::printf("  complete pause: ended on silence confirmation\n");
+}
+
+void test_incomplete_then_resume_is_one_turn() {
+    Harness h;
+    h.model.answers = {0.2f, 0.9f};
+    h.build(true);
+    h.script(0.9f, 1.0f);   // "I'd like to ..."
+    h.script(0.0f, 0.4f);   // mid-sentence pause (vetoed)
+    h.script(0.9f, 1.0f);   // "... book a table"
+    h.script(0.0f, 0.5f);   // real end (accepted)
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechStarted) == 1);
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(h.model.lengths.size() == 2);
+    assert(h.model.lengths[1] > h.model.lengths[0]);
+    const auto& ended = h.last(TurnEvent::UserSpeechEnded);
+    // Whole turn: both speech segments plus the pause in between (~2.25 s).
+    assert(ended.audio.size() >= static_cast<size_t>(2.0f * 16000));
+    assert(std::fabs(ended.turn_completion_probability - 0.9f) < 1e-6f);
+    assert(!h.detector->turn_held());
+    std::printf("  vetoed pause + resume: one turn, two classifier calls\n");
+}
+
+void test_incomplete_then_silence_cap() {
+    Harness h;
+    h.model.answers = {0.1f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.3f);   // pause vetoed at ~1.1 s (silence start ~1.0 s)
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 0);
+    assert(h.detector->turn_held());
+    assert(h.detector->in_speech());
+    h.vad.probs.clear();
+    h.vad.idx = 0;
+    h.script(0.0f, 1.0f);   // silence continues past the 1 s cap
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(h.model.lengths.size() == 1);   // no re-run on the cap
+    const auto& ended = h.last(TurnEvent::UserSpeechEnded);
+    assert(ended.turn_completion_probability < 0.0f);
+    assert(std::fabs(ended.time - 1.0f) < 2 * kChunkSeconds);  // pause start, not cap time
+    assert(!h.detector->turn_held());
+    assert(!h.detector->in_speech());
+    std::printf("  vetoed pause + silence: ended on the cap\n");
+}
+
+void test_eager_respects_veto() {
+    Harness h;
+    h.config.eager_stt = true;
+    h.config.eager_stt_delay = 0.2f;
+    h.config.vad.min_silence_duration = 0.6f;
+    h.config.turn_completion_max_silence = 1.5f;
+    h.model.answers = {0.2f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.8f);   // eager would fire at 0.2 s, silence confirms at 0.6 s
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 0);
+    assert(h.model.lengths.size() == 1);   // asked once, at the eager moment
+    assert(h.detector->turn_held());
+    h.vad.probs.clear();
+    h.vad.idx = 0;
+    h.script(0.0f, 1.0f);
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(!h.last(TurnEvent::UserSpeechEnded).eager);
+    std::printf("  eager STT: veto suppresses the early utterance\n");
+}
+
+void test_eager_fires_when_complete() {
+    Harness h;
+    h.config.eager_stt = true;
+    h.config.eager_stt_delay = 0.2f;
+    h.config.vad.min_silence_duration = 0.6f;
+    h.model.answers = {0.8f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.8f);
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    const auto& ended = h.last(TurnEvent::UserSpeechEnded);
+    assert(ended.eager);
+    assert(std::fabs(ended.turn_completion_probability - 0.8f) < 1e-6f);
+    assert(h.model.lengths.size() == 1);
+    std::printf("  eager STT: fires when the classifier agrees\n");
+}
+
+void test_flush_settles_held_turn() {
+    Harness h;
+    h.model.answers = {0.1f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.3f);
+    h.run_all();
+    assert(h.detector->turn_held());
+    h.detector->flush();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 1);
+    assert(!h.detector->turn_held());
+    assert(h.last(TurnEvent::UserSpeechEnded).audio.size() >= 12000);
+    std::printf("  flush: settles a held turn\n");
+}
+
+void test_agent_speaking_discard_skips_model() {
+    Harness h;
+    h.config.min_interruption_duration = 1.0f;
+    h.model.answers = {0.9f};
+    h.build(true);
+    h.detector->set_agent_speaking(true);
+    h.script(0.9f, 0.4f);   // too short to confirm an interruption
+    h.script(0.0f, 0.5f);
+    h.run_all();
+    assert(h.count(TurnEvent::UserSpeechEnded) == 0);
+    assert(h.count(TurnEvent::Interruption) == 0);
+    assert(h.model.lengths.empty());
+    std::printf("  agent speaking: echo discard never asks the classifier\n");
+}
+
+void test_reset_clears_hold() {
+    Harness h;
+    h.model.answers = {0.1f};
+    h.build(true);
+    h.script(0.9f, 1.0f);
+    h.script(0.0f, 0.3f);
+    h.run_all();
+    assert(h.detector->turn_held());
+    h.detector->reset();
+    assert(!h.detector->turn_held());
+    assert(!h.detector->in_speech());
+    std::printf("  reset: clears the hold\n");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("TurnDetector + turn completion classifier\n");
+    test_without_model_unchanged();
+    test_complete_pause_ends_turn();
+    test_incomplete_then_resume_is_one_turn();
+    test_incomplete_then_silence_cap();
+    test_eager_respects_veto();
+    test_eager_fires_when_complete();
+    test_flush_settles_held_turn();
+    test_agent_speaking_discard_skips_model();
+    test_reset_clears_hold();
+    std::printf("all turn completion tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #145.

## What

- `TurnCompletionInterface` and `OnnxSmartTurn`: an ONNX Runtime wrapper for Pipecat Smart Turn v3.2. The published graph takes the last 8 s of 16 kHz audio (`audio [1, 128000]`) and returns `probability [1, 1]`; the Whisper log-mel front-end, including the zero-mean/unit-variance waveform normalisation the model was trained with, is embedded in the graph, so there is no C++ feature extraction.
- `TurnDetector` can hold a turn. Once a classifier is attached, a VAD pause only ends the user's turn when the classifier agrees; resumed speech continues the same turn (no second `UserSpeechStarted`), the next pause asks again on the whole turn, and `turn_completion_max_silence` (2.0 s) ends it anyway. Eager STT respects the veto and still fires when the classifier agrees; flush and force-split settle held turns.
- `VoicePipeline::set_turn_completion()` and the C API (`sc_turn_completion_vtable_t`, `sc_pipeline_set_turn_completion`, `sc_config_t.turn_completion_threshold` / `turn_completion_max_silence`) so Swift and Kotlin hosts can plug in their own classifier, the same way as `sc_vad_vtable_t`.
- `speech turn <utterance.wav>` (`speech_smart_turn`), download-script entries for `soniqo/Smart-Turn-v3.2-ONNX`, packaging and release checks, docs, README mirrors, and third-party notice (BSD-2-Clause).

## Model

Re-exported from `pipecat-ai/smart-turn-v3` into https://huggingface.co/soniqo/Smart-Turn-v3.2-ONNX (fp32 33 MB, int8 11 MB). On 1,000 upstream test clips the fp32 graph matches upstream exactly (92.9 %) and the int8 graph scores 93.0 %. One call costs about 35 ms on an Apple M5 Pro with ORT's default two threads (20 ms with four); the classifier runs once per pause.

## Tests

- `test_turn_detector_smart_turn` (scripted VAD and classifier): unchanged behaviour without a model, accepted pause, vetoed pause + resume as one turn, silence cap, eager veto / eager fire, flush, agent-speaking discard, reset.
- `test_onnx_smart_turn_model` (gated on `SPEECH_SMART_TURN_ONNX`): contract validation, window preparation, determinism, resampling, silence, and the finished fixture sentence scoring 0.97.
- Full `ctest`: 43/43 on macOS with ONNX enabled.

## Follow-up

speech-swift already has the CoreML model and the pure-Swift `StreamingVADProcessor` hook; wiring it into `VoicePipeline` needs the next SpeechCore.xcframework release with this C API.